### PR TITLE
Add auth-db

### DIFF
--- a/.github/workflows/unit-tests.yaml
+++ b/.github/workflows/unit-tests.yaml
@@ -1,0 +1,26 @@
+name: Run Unit Tests for PRs
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+      - name: Install dependencies
+        run: npm install
+
+      # Tests fail to run if this one package isn't installed
+      - name: Install rollup for linux
+        run: npm install @rollup/rollup-linux-x64-gnu
+
+      - name: Run Unit Tests
+        run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/node_modules
-coverage
+**/coverage
+**/data/*.sqlite
 
 # Editor directories and files
 .vscode/*

--- a/auth-db/README.md
+++ b/auth-db/README.md
@@ -1,0 +1,40 @@
+# @saflib/auth-db
+
+Shared authentication database library for SAF services. This package provides a unified interface for managing user authentication data across different SAF services.
+
+## Features
+
+- User management
+- Session handling
+- SQLite-based storage using Drizzle ORM
+
+## Usage
+
+```typescript
+import { AuthDB } from "@saflib/auth-db";
+
+const db = new AuthDB({
+  // configuration options
+});
+
+// Use the database
+```
+
+## Development
+
+```bash
+# Run tests
+npm test
+
+# Run tests with coverage
+npm run test:coverage
+
+# Generate database migrations
+npm run db:generate
+```
+
+## Dependencies
+
+- Node.js v18+
+- SQLite3
+- Drizzle ORM

--- a/auth-db/README.md
+++ b/auth-db/README.md
@@ -5,7 +5,7 @@ Shared authentication database library for SAF services. This package provides a
 ## Features
 
 - User management
-- Session handling
+- Email authentication
 - SQLite-based storage using Drizzle ORM
 
 ## Usage
@@ -18,6 +18,12 @@ const db = new AuthDB({
 });
 
 // Use the database
+await db.users.create({ email: "user@example.com", createdAt: new Date() });
+await db.emailAuth.create({
+  userId: 1,
+  email: "user@example.com",
+  passwordHash: new Uint8Array(),
+});
 ```
 
 ## Development
@@ -38,3 +44,9 @@ npm run db:generate
 - Node.js v18+
 - SQLite3
 - Drizzle ORM
+
+## Notes
+
+- Session management is handled by the auth service using `better-sqlite3-session-store`
+- This package focuses on core user identity and authentication data
+- Different services can implement their own session management strategies

--- a/auth-db/drizzle.config.ts
+++ b/auth-db/drizzle.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "drizzle-kit";
+import path from "path";
+import { fileURLToPath } from "url";
+
+const getDirname = () => {
+  const __filename = fileURLToPath(import.meta.url);
+  return path.dirname(__filename);
+};
+
+const usersDbName = `users-${process.env.NODE_ENV}.sqlite`;
+
+export const getDbPath = () => {
+  return path.join(getDirname(), `data/${usersDbName}`);
+};
+
+export const getMigrationsPath = () => {
+  return path.join(getDirname(), "./migrations");
+};
+
+export default defineConfig({
+  out: "./migrations",
+  schema: "./src/schema.ts",
+  dialect: "sqlite",
+  dbCredentials: {
+    url: `./data/${usersDbName}`,
+  },
+});

--- a/auth-db/migrations/0000_parallel_bishop.sql
+++ b/auth-db/migrations/0000_parallel_bishop.sql
@@ -1,0 +1,7 @@
+CREATE TABLE `users` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`name` text NOT NULL,
+	`email` text NOT NULL
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `users_email_unique` ON `users` (`email`);

--- a/auth-db/migrations/0001_lush_black_queen.sql
+++ b/auth-db/migrations/0001_lush_black_queen.sql
@@ -1,0 +1,16 @@
+CREATE TABLE `email_auth` (
+	`user_id` integer NOT NULL,
+	`email` text NOT NULL,
+	`password_hash` blob NOT NULL,
+	`verified_at` integer,
+	`verification_token` text,
+	`verification_token_expires_at` integer,
+	`forgot_password_token` text,
+	`forgot_password_token_expires_at` integer,
+	FOREIGN KEY (`user_id`) REFERENCES `users`(`id`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX `email_auth_user_id_unique` ON `email_auth` (`user_id`);--> statement-breakpoint
+CREATE UNIQUE INDEX `email_auth_email_unique` ON `email_auth` (`email`);--> statement-breakpoint
+ALTER TABLE `users` ADD `created_at` integer NOT NULL;--> statement-breakpoint
+ALTER TABLE `users` ADD `last_login_at` integer;

--- a/auth-db/migrations/0002_skinny_stephen_strange.sql
+++ b/auth-db/migrations/0002_skinny_stephen_strange.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `users` DROP COLUMN `name`;

--- a/auth-db/migrations/meta/0000_snapshot.json
+++ b/auth-db/migrations/meta/0000_snapshot.json
@@ -1,0 +1,55 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "77b544ff-a897-41dc-9a3f-681eda45b4cc",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "tables": {
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/auth-db/migrations/meta/0001_snapshot.json
+++ b/auth-db/migrations/meta/0001_snapshot.json
@@ -1,0 +1,156 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5f2052a9-66be-490b-b9ea-84bd09276bd7",
+  "prevId": "77b544ff-a897-41dc-9a3f-681eda45b4cc",
+  "tables": {
+    "email_auth": {
+      "name": "email_auth",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_token_expires_at": {
+          "name": "verification_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forgot_password_token": {
+          "name": "forgot_password_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forgot_password_token_expires_at": {
+          "name": "forgot_password_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "email_auth_user_id_unique": {
+          "name": "email_auth_user_id_unique",
+          "columns": ["user_id"],
+          "isUnique": true
+        },
+        "email_auth_email_unique": {
+          "name": "email_auth_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "email_auth_user_id_users_id_fk": {
+          "name": "email_auth_user_id_users_id_fk",
+          "tableFrom": "email_auth",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/auth-db/migrations/meta/0002_snapshot.json
+++ b/auth-db/migrations/meta/0002_snapshot.json
@@ -1,0 +1,149 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9224520f-540a-438d-997a-78f6660c9431",
+  "prevId": "5f2052a9-66be-490b-b9ea-84bd09276bd7",
+  "tables": {
+    "email_auth": {
+      "name": "email_auth",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "blob",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "verified_at": {
+          "name": "verified_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_token": {
+          "name": "verification_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "verification_token_expires_at": {
+          "name": "verification_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forgot_password_token": {
+          "name": "forgot_password_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "forgot_password_token_expires_at": {
+          "name": "forgot_password_token_expires_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "email_auth_user_id_unique": {
+          "name": "email_auth_user_id_unique",
+          "columns": ["user_id"],
+          "isUnique": true
+        },
+        "email_auth_email_unique": {
+          "name": "email_auth_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "email_auth_user_id_users_id_fk": {
+          "name": "email_auth_user_id_users_id_fk",
+          "tableFrom": "email_auth",
+          "tableTo": "users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "users": {
+      "name": "users",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_login_at": {
+          "name": "last_login_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "users_email_unique": {
+          "name": "users_email_unique",
+          "columns": ["email"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/auth-db/migrations/meta/_journal.json
+++ b/auth-db/migrations/meta/_journal.json
@@ -1,0 +1,27 @@
+{
+  "version": "7",
+  "dialect": "sqlite",
+  "entries": [
+    {
+      "idx": 0,
+      "version": "6",
+      "when": 1736724211965,
+      "tag": "0000_parallel_bishop",
+      "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "6",
+      "when": 1738706444835,
+      "tag": "0001_lush_black_queen",
+      "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "6",
+      "when": 1738873621731,
+      "tag": "0002_skinny_stephen_strange",
+      "breakpoints": true
+    }
+  ]
+}

--- a/auth-db/package.json
+++ b/auth-db/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@saflib/auth-db",
+  "description": "Shared authentication database library for SAF services",
+  "private": true,
+  "type": "module",
+  "main": "src/index.ts",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "db:generate": "drizzle-kit generate"
+  },
+  "dependencies": {
+    "@saflib/drizzle-sqlite3": "*",
+    "better-sqlite3-session-store": "^0.1.0"
+  },
+  "devDependencies": {
+    "@saflib/drizzle-sqlite3-dev": "*",
+    "@saflib/vitest": "*"
+  }
+} 

--- a/auth-db/package.json
+++ b/auth-db/package.json
@@ -17,4 +17,4 @@
     "@saflib/drizzle-sqlite3-dev": "*",
     "@saflib/vitest": "*"
   }
-} 
+}

--- a/auth-db/package.json
+++ b/auth-db/package.json
@@ -11,8 +11,7 @@
     "db:generate": "drizzle-kit generate"
   },
   "dependencies": {
-    "@saflib/drizzle-sqlite3": "*",
-    "better-sqlite3-session-store": "^0.1.0"
+    "@saflib/drizzle-sqlite3": "*"
   },
   "devDependencies": {
     "@saflib/drizzle-sqlite3-dev": "*",

--- a/auth-db/package.json
+++ b/auth-db/package.json
@@ -8,7 +8,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "db:generate": "drizzle-kit generate"
+    "generate": "drizzle-kit generate"
   },
   "dependencies": {
     "@saflib/drizzle-sqlite3": "*"

--- a/auth-db/src/errors.ts
+++ b/auth-db/src/errors.ts
@@ -1,0 +1,8 @@
+import { HandledDatabaseError } from "@saflib/drizzle-sqlite3";
+
+export class AuthDatabaseError extends HandledDatabaseError {
+  constructor(message: string) {
+    super(message);
+    this.name = "AuthDatabaseError";
+  }
+}

--- a/auth-db/src/index.ts
+++ b/auth-db/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./schema.ts";
+export * from "./errors.ts";
+export * from "./instance.ts";

--- a/auth-db/src/instance.test.ts
+++ b/auth-db/src/instance.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { AuthDB } from "./instance.ts";
+import { join } from "path";
+import { unlink } from "fs/promises";
+
+describe("AuthDB multi-instance access", () => {
+  const testDbPath = join(process.cwd(), "test.db");
+
+  beforeEach(async () => {
+    // Clean up any existing test database
+    try {
+      await unlink(testDbPath);
+    } catch (error) {
+      // Ignore if file doesn't exist
+    }
+  });
+
+  afterEach(async () => {
+    // Clean up test database after each test
+    try {
+      await unlink(testDbPath);
+    } catch (error) {
+      // Ignore if file doesn't exist
+    }
+  });
+
+  it("should allow multiple instances to read and write to the same database file", async () => {
+    // Create two instances pointing to the same database file
+    const db1 = new AuthDB({ dbPath: testDbPath });
+    const db2 = new AuthDB({ dbPath: testDbPath });
+
+    // Create a user using the first instance
+    const newUser = {
+      email: "test@example.com",
+      createdAt: new Date(),
+    };
+    const createdUser = await db1.users.create(newUser);
+
+    // Verify the second instance can read the user
+    const userFromDb2 = await db2.users.getByEmail(newUser.email);
+    expect(userFromDb2).toEqual(createdUser);
+
+    // Update the user using the second instance
+    const updatedUser = await db2.users.updateLastLogin(createdUser.id);
+    expect(updatedUser?.lastLoginAt).toBeDefined();
+
+    // Verify the first instance sees the changes
+    const userFromDb1 = await db1.users.getById(createdUser.id);
+    expect(userFromDb1?.lastLoginAt).toBeDefined();
+    expect(userFromDb1?.lastLoginAt).toEqual(updatedUser?.lastLoginAt);
+  });
+});

--- a/auth-db/src/instance.ts
+++ b/auth-db/src/instance.ts
@@ -14,6 +14,9 @@ export interface AuthDBConfig {
 }
 
 export class AuthDB {
+  users: ReturnType<typeof createUserQueries>;
+  emailAuth: ReturnType<typeof createEmailAuthQueries>;
+
   constructor(config: AuthDBConfig = {}) {
     try {
       const sqlite =
@@ -28,10 +31,9 @@ export class AuthDB {
         migrationsFolder: config.migrationsPath || getMigrationsPath(),
       });
 
-      // Add query methods to this instance
-      Object.assign(this, db);
-      Object.assign(this, createUserQueries(db));
-      Object.assign(this, createEmailAuthQueries(db));
+      // Initialize query methods
+      this.users = createUserQueries(db);
+      this.emailAuth = createEmailAuthQueries(db);
     } catch (error) {
       throw new AuthDatabaseError(
         `Failed to initialize database: ${error instanceof Error ? error.message : String(error)}`

--- a/auth-db/src/instance.ts
+++ b/auth-db/src/instance.ts
@@ -3,34 +3,35 @@ import Database from "better-sqlite3";
 import * as schema from "./schema.ts";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import { AuthDatabaseError } from "./errors.ts";
+import { getDbPath, getMigrationsPath } from "../drizzle.config.ts";
 
 export interface AuthDBConfig {
   dbPath?: string;
-  migrationsPath: string;
+  migrationsPath?: string;
   inMemory?: boolean;
 }
 
 export class AuthDB {
-  private db: ReturnType<typeof drizzle>;
-
-  constructor(config: AuthDBConfig) {
+  constructor(config: AuthDBConfig = {}) {
     try {
-      const sqlite = config.inMemory
-        ? new Database(":memory:")
-        : new Database(config.dbPath || ":memory:");
+      const sqlite =
+        config.inMemory || process.env.NODE_ENV === "test"
+          ? new Database(":memory:")
+          : new Database(config.dbPath || getDbPath());
 
-      this.db = drizzle(sqlite, { schema });
+      const db = drizzle(sqlite, { schema });
 
       // Run migrations
-      migrate(this.db, { migrationsFolder: config.migrationsPath });
+      migrate(db, {
+        migrationsFolder: config.migrationsPath || getMigrationsPath(),
+      });
+
+      // Add query methods to this instance
+      Object.assign(this, db);
     } catch (error) {
       throw new AuthDatabaseError(
         `Failed to initialize database: ${error instanceof Error ? error.message : String(error)}`
       );
     }
-  }
-
-  get instance() {
-    return this.db;
   }
 }

--- a/auth-db/src/instance.ts
+++ b/auth-db/src/instance.ts
@@ -4,6 +4,8 @@ import * as schema from "./schema.ts";
 import { migrate } from "drizzle-orm/better-sqlite3/migrator";
 import { AuthDatabaseError } from "./errors.ts";
 import { getDbPath, getMigrationsPath } from "../drizzle.config.ts";
+import { createUserQueries } from "./queries/users.ts";
+import { createEmailAuthQueries } from "./queries/email-auth.ts";
 
 export interface AuthDBConfig {
   dbPath?: string;
@@ -28,6 +30,8 @@ export class AuthDB {
 
       // Add query methods to this instance
       Object.assign(this, db);
+      Object.assign(this, createUserQueries(db));
+      Object.assign(this, createEmailAuthQueries(db));
     } catch (error) {
       throw new AuthDatabaseError(
         `Failed to initialize database: ${error instanceof Error ? error.message : String(error)}`

--- a/auth-db/src/instance.ts
+++ b/auth-db/src/instance.ts
@@ -42,7 +42,7 @@ export class AuthDB {
       this.emailAuth = createEmailAuthQueries(db);
     } catch (error) {
       throw new AuthDatabaseError(
-        `Failed to initialize database: ${error instanceof Error ? error.message : String(error)}`
+        `Failed to initialize database: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
   }

--- a/auth-db/src/instance.ts
+++ b/auth-db/src/instance.ts
@@ -1,0 +1,36 @@
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import Database from "better-sqlite3";
+import * as schema from "./schema.ts";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { AuthDatabaseError } from "./errors.ts";
+
+export interface AuthDBConfig {
+  dbPath?: string;
+  migrationsPath: string;
+  inMemory?: boolean;
+}
+
+export class AuthDB {
+  private db: ReturnType<typeof drizzle>;
+
+  constructor(config: AuthDBConfig) {
+    try {
+      const sqlite = config.inMemory
+        ? new Database(":memory:")
+        : new Database(config.dbPath || ":memory:");
+
+      this.db = drizzle(sqlite, { schema });
+
+      // Run migrations
+      migrate(this.db, { migrationsFolder: config.migrationsPath });
+    } catch (error) {
+      throw new AuthDatabaseError(
+        `Failed to initialize database: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+
+  get instance() {
+    return this.db;
+  }
+}

--- a/auth-db/src/instance.ts
+++ b/auth-db/src/instance.ts
@@ -19,10 +19,16 @@ export class AuthDB {
 
   constructor(config: AuthDBConfig = {}) {
     try {
-      const sqlite =
-        config.inMemory || process.env.NODE_ENV === "test"
-          ? new Database(":memory:")
-          : new Database(config.dbPath || getDbPath());
+      // Unless overridden by config, use an in-memory database for testing and file-based storage otherwise
+      let dbStorage = ":memory:";
+      if (config.dbPath) {
+        dbStorage = config.dbPath;
+      } else if (config.inMemory || process.env.NODE_ENV === "test") {
+        dbStorage = ":memory:";
+      } else {
+        dbStorage = getDbPath();
+      }
+      const sqlite = new Database(dbStorage);
 
       const db = drizzle(sqlite, { schema });
 

--- a/auth-db/src/queries/email-auth.test.ts
+++ b/auth-db/src/queries/email-auth.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { AuthDB } from "../instance.ts";
+import { EmailAuthNotFoundError } from "./email-auth.ts";
+
+describe("email-auth queries", () => {
+  let db: AuthDB;
+
+  // Create a new database instance before each test
+  beforeEach(async () => {
+    db = new AuthDB({ inMemory: true });
+    await db.emailAuth.deleteAll();
+    await db.users.deleteAll();
+  });
+
+  describe("create", () => {
+    it("should create email auth for a user", async () => {
+      const user = await db.users.create({
+        email: "test@example.com",
+        createdAt: new Date(),
+      });
+
+      const passwordHash = Buffer.from([1, 2, 3]);
+      const auth = await db.emailAuth.create({
+        userId: user.id,
+        email: user.email,
+        passwordHash,
+      });
+
+      expect(auth).toMatchObject({
+        userId: user.id,
+        email: user.email,
+        passwordHash,
+      });
+    });
+  });
+
+  describe("getByEmail", () => {
+    it("should get email auth by email", async () => {
+      const user = await db.users.create({
+        email: "test@example.com",
+        createdAt: new Date(),
+      });
+
+      const passwordHash = Buffer.from([1, 2, 3]);
+      const created = await db.emailAuth.create({
+        userId: user.id,
+        email: user.email,
+        passwordHash,
+      });
+
+      const auth = await db.emailAuth.getByEmail(user.email);
+      expect(auth).toEqual(created);
+    });
+
+    it("should throw EmailAuthNotFoundError when email not found", async () => {
+      await expect(
+        db.emailAuth.getByEmail("nonexistent@example.com")
+      ).rejects.toThrow(EmailAuthNotFoundError);
+    });
+  });
+
+  describe("updateVerification", () => {
+    it("should update verification details", async () => {
+      const user = await db.users.create({
+        email: "test@example.com",
+        createdAt: new Date(),
+      });
+
+      const passwordHash = Buffer.from([1, 2, 3]);
+      await db.emailAuth.create({
+        userId: user.id,
+        email: user.email,
+        passwordHash,
+      });
+
+      const now = new Date();
+      const token = "verification-token";
+      const expiresAt = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+      expiresAt.setMilliseconds(0);
+
+      const updated = await db.emailAuth.updateVerification(
+        user.id,
+        token,
+        expiresAt,
+        null
+      );
+      expect(updated).toMatchObject({
+        verificationToken: token,
+        verificationTokenExpiresAt: expiresAt,
+        verifiedAt: null,
+      });
+    });
+
+    it("should throw EmailAuthNotFoundError when user not found", async () => {
+      await expect(
+        db.emailAuth.updateVerification(999, "token", new Date(), null)
+      ).rejects.toThrow(EmailAuthNotFoundError);
+    });
+  });
+
+  describe("updateForgotPasswordToken", () => {
+    it("should update forgot password token", async () => {
+      const user = await db.users.create({
+        email: "test@example.com",
+        createdAt: new Date(),
+      });
+
+      const passwordHash = Buffer.from([1, 2, 3]);
+      await db.emailAuth.create({
+        userId: user.id,
+        email: user.email,
+        passwordHash,
+      });
+
+      const now = new Date();
+      const token = "forgot-password-token";
+      const expiresAt = new Date(now.getTime() + 24 * 60 * 60 * 1000);
+      expiresAt.setMilliseconds(0);
+
+      const updated = await db.emailAuth.updateForgotPasswordToken(
+        user.id,
+        token,
+        expiresAt
+      );
+      expect(updated).toMatchObject({
+        forgotPasswordToken: token,
+        forgotPasswordTokenExpiresAt: expiresAt,
+      });
+    });
+
+    it("should throw EmailAuthNotFoundError when user not found", async () => {
+      await expect(
+        db.emailAuth.updateForgotPasswordToken(999, "token", new Date())
+      ).rejects.toThrow(EmailAuthNotFoundError);
+    });
+  });
+
+  describe("updatePasswordHash", () => {
+    it("should update password hash", async () => {
+      const user = await db.users.create({
+        email: "test@example.com",
+        createdAt: new Date(),
+      });
+
+      const passwordHash = Buffer.from([1, 2, 3]);
+      await db.emailAuth.create({
+        userId: user.id,
+        email: user.email,
+        passwordHash,
+      });
+
+      const newPasswordHash = Buffer.from([4, 5, 6]);
+      const updated = await db.emailAuth.updatePasswordHash(
+        user.id,
+        newPasswordHash
+      );
+      expect(updated).toMatchObject({
+        passwordHash: newPasswordHash,
+      });
+    });
+
+    it("should throw EmailAuthNotFoundError when user not found", async () => {
+      await expect(
+        db.emailAuth.updatePasswordHash(999, Buffer.from([4, 5, 6]))
+      ).rejects.toThrow(EmailAuthNotFoundError);
+    });
+  });
+});

--- a/auth-db/src/queries/email-auth.test.ts
+++ b/auth-db/src/queries/email-auth.test.ts
@@ -54,7 +54,7 @@ describe("email-auth queries", () => {
 
     it("should throw EmailAuthNotFoundError when email not found", async () => {
       await expect(
-        db.emailAuth.getByEmail("nonexistent@example.com")
+        db.emailAuth.getByEmail("nonexistent@example.com"),
       ).rejects.toThrow(EmailAuthNotFoundError);
     });
   });
@@ -82,7 +82,7 @@ describe("email-auth queries", () => {
         user.id,
         token,
         expiresAt,
-        null
+        null,
       );
       expect(updated).toMatchObject({
         verificationToken: token,
@@ -93,7 +93,7 @@ describe("email-auth queries", () => {
 
     it("should throw EmailAuthNotFoundError when user not found", async () => {
       await expect(
-        db.emailAuth.updateVerification(999, "token", new Date(), null)
+        db.emailAuth.updateVerification(999, "token", new Date(), null),
       ).rejects.toThrow(EmailAuthNotFoundError);
     });
   });
@@ -120,7 +120,7 @@ describe("email-auth queries", () => {
       const updated = await db.emailAuth.updateForgotPasswordToken(
         user.id,
         token,
-        expiresAt
+        expiresAt,
       );
       expect(updated).toMatchObject({
         forgotPasswordToken: token,
@@ -130,7 +130,7 @@ describe("email-auth queries", () => {
 
     it("should throw EmailAuthNotFoundError when user not found", async () => {
       await expect(
-        db.emailAuth.updateForgotPasswordToken(999, "token", new Date())
+        db.emailAuth.updateForgotPasswordToken(999, "token", new Date()),
       ).rejects.toThrow(EmailAuthNotFoundError);
     });
   });
@@ -152,7 +152,7 @@ describe("email-auth queries", () => {
       const newPasswordHash = Buffer.from([4, 5, 6]);
       const updated = await db.emailAuth.updatePasswordHash(
         user.id,
-        newPasswordHash
+        newPasswordHash,
       );
       expect(updated).toMatchObject({
         passwordHash: newPasswordHash,
@@ -161,7 +161,7 @@ describe("email-auth queries", () => {
 
     it("should throw EmailAuthNotFoundError when user not found", async () => {
       await expect(
-        db.emailAuth.updatePasswordHash(999, Buffer.from([4, 5, 6]))
+        db.emailAuth.updatePasswordHash(999, Buffer.from([4, 5, 6])),
       ).rejects.toThrow(EmailAuthNotFoundError);
     });
   });

--- a/auth-db/src/queries/email-auth.ts
+++ b/auth-db/src/queries/email-auth.ts
@@ -1,4 +1,4 @@
-import { emailAuth, users } from "../schema.ts";
+import { emailAuth } from "../schema.ts";
 import { AuthDatabaseError } from "../errors.ts";
 import { queryWrapper } from "@saflib/drizzle-sqlite3";
 import { eq } from "drizzle-orm";
@@ -23,7 +23,7 @@ export function createEmailAuthQueries(db: any) {
     ),
 
     getByEmail: queryWrapper(
-      async (email: string): Promise<SelectEmailAuth | undefined> => {
+      async (email: string): Promise<SelectEmailAuth> => {
         const result = await db.query.emailAuth.findFirst({
           where: eq(emailAuth.email, email),
         });

--- a/auth-db/src/queries/email-auth.ts
+++ b/auth-db/src/queries/email-auth.ts
@@ -1,0 +1,105 @@
+import { emailAuth, users } from "../schema.ts";
+import { AuthDatabaseError } from "../errors.ts";
+import { queryWrapper } from "@saflib/drizzle-sqlite3";
+import { eq } from "drizzle-orm";
+
+type NewEmailAuth = typeof emailAuth.$inferInsert;
+type SelectEmailAuth = typeof emailAuth.$inferSelect;
+
+export class EmailAuthNotFoundError extends AuthDatabaseError {
+  constructor() {
+    super("Email authentication not found.");
+    this.name = "EmailAuthNotFoundError";
+  }
+}
+
+export function createEmailAuthQueries(db: any) {
+  return {
+    create: queryWrapper(
+      async (auth: NewEmailAuth): Promise<SelectEmailAuth> => {
+        const result = await db.insert(emailAuth).values(auth).returning();
+        return result[0];
+      }
+    ),
+
+    getByEmail: queryWrapper(
+      async (email: string): Promise<SelectEmailAuth | undefined> => {
+        const result = await db.query.emailAuth.findFirst({
+          where: eq(emailAuth.email, email),
+        });
+        if (!result) {
+          throw new EmailAuthNotFoundError();
+        }
+        return result;
+      }
+    ),
+
+    updateVerification: queryWrapper(
+      async (
+        userId: number,
+        verificationToken: string | null,
+        verificationTokenExpiresAt: Date | null,
+        verifiedAt: Date | null
+      ): Promise<SelectEmailAuth> => {
+        const result = await db
+          .update(emailAuth)
+          .set({
+            verificationToken,
+            verificationTokenExpiresAt,
+            verifiedAt,
+          })
+          .where(eq(emailAuth.userId, userId))
+          .returning();
+
+        if (!result.length) {
+          throw new EmailAuthNotFoundError();
+        }
+        return result[0];
+      }
+    ),
+
+    updateForgotPasswordToken: queryWrapper(
+      async (
+        userId: number,
+        forgotPasswordToken: string | null,
+        forgotPasswordTokenExpiresAt: Date | null
+      ): Promise<SelectEmailAuth> => {
+        const result = await db
+          .update(emailAuth)
+          .set({
+            forgotPasswordToken,
+            forgotPasswordTokenExpiresAt,
+          })
+          .where(eq(emailAuth.userId, userId))
+          .returning();
+
+        if (!result.length) {
+          throw new EmailAuthNotFoundError();
+        }
+        return result[0];
+      }
+    ),
+
+    updatePasswordHash: queryWrapper(
+      async (
+        userId: number,
+        passwordHash: Uint8Array
+      ): Promise<SelectEmailAuth> => {
+        const result = await db
+          .update(emailAuth)
+          .set({ passwordHash })
+          .where(eq(emailAuth.userId, userId))
+          .returning();
+
+        if (!result.length) {
+          throw new EmailAuthNotFoundError();
+        }
+        return result[0];
+      }
+    ),
+
+    deleteAll: queryWrapper(async (): Promise<void> => {
+      await db.delete(emailAuth).execute();
+    }),
+  };
+}

--- a/auth-db/src/queries/email-auth.ts
+++ b/auth-db/src/queries/email-auth.ts
@@ -20,7 +20,7 @@ export function createEmailAuthQueries(db: any) {
       async (auth: NewEmailAuth): Promise<SelectEmailAuth> => {
         const result = await db.insert(emailAuth).values(auth).returning();
         return result[0];
-      }
+      },
     ),
 
     getByEmail: queryWrapper(
@@ -32,7 +32,7 @@ export function createEmailAuthQueries(db: any) {
           throw new EmailAuthNotFoundError();
         }
         return result;
-      }
+      },
     ),
 
     updateVerification: queryWrapper(
@@ -40,7 +40,7 @@ export function createEmailAuthQueries(db: any) {
         userId: number,
         verificationToken: string | null,
         verificationTokenExpiresAt: Date | null,
-        verifiedAt: Date | null
+        verifiedAt: Date | null,
       ): Promise<SelectEmailAuth> => {
         const result = await db
           .update(emailAuth)
@@ -56,14 +56,14 @@ export function createEmailAuthQueries(db: any) {
           throw new EmailAuthNotFoundError();
         }
         return result[0];
-      }
+      },
     ),
 
     updateForgotPasswordToken: queryWrapper(
       async (
         userId: number,
         forgotPasswordToken: string | null,
-        forgotPasswordTokenExpiresAt: Date | null
+        forgotPasswordTokenExpiresAt: Date | null,
       ): Promise<SelectEmailAuth> => {
         const result = await db
           .update(emailAuth)
@@ -78,13 +78,13 @@ export function createEmailAuthQueries(db: any) {
           throw new EmailAuthNotFoundError();
         }
         return result[0];
-      }
+      },
     ),
 
     updatePasswordHash: queryWrapper(
       async (
         userId: number,
-        passwordHash: Uint8Array
+        passwordHash: Uint8Array,
       ): Promise<SelectEmailAuth> => {
         const result = await db
           .update(emailAuth)
@@ -96,7 +96,7 @@ export function createEmailAuthQueries(db: any) {
           throw new EmailAuthNotFoundError();
         }
         return result[0];
-      }
+      },
     ),
 
     deleteAll: queryWrapper(async (): Promise<void> => {

--- a/auth-db/src/queries/email-auth.ts
+++ b/auth-db/src/queries/email-auth.ts
@@ -15,6 +15,7 @@ export class EmailAuthNotFoundError extends AuthDatabaseError {
 
 export function createEmailAuthQueries(db: any) {
   return {
+    EmailAuthNotFoundError,
     create: queryWrapper(
       async (auth: NewEmailAuth): Promise<SelectEmailAuth> => {
         const result = await db.insert(emailAuth).values(auth).returning();

--- a/auth-db/src/queries/users.test.ts
+++ b/auth-db/src/queries/users.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { AuthDB } from "../instance.ts";
+import { EmailConflictError, UserNotFoundError } from "./users.ts";
+
+describe("users queries", () => {
+  let db: AuthDB;
+
+  // Create a new database instance before each test
+  beforeEach(async () => {
+    db = new AuthDB({ inMemory: true });
+  });
+
+  describe("create", () => {
+    it("should create a new user", async () => {
+      const newUser = {
+        email: "test@example.com",
+        createdAt: new Date(),
+      };
+
+      const result = await db.users.create(newUser);
+
+      expect(result).toMatchObject({
+        ...newUser,
+        id: expect.any(Number),
+        createdAt: expect.any(Date),
+      });
+      expect(result.lastLoginAt).toBeNull();
+    });
+
+    it("should throw EmailConflictError for duplicate email", async () => {
+      const user = {
+        email: "test@example.com",
+        createdAt: new Date(),
+      };
+
+      await db.users.create(user);
+
+      await expect(db.users.create(user)).rejects.toThrow(EmailConflictError);
+    });
+  });
+
+  describe("getAll", () => {
+    it("should return all users", async () => {
+      const testUsers = [
+        {
+          name: "Test User 1",
+          email: "test1@example.com",
+          createdAt: new Date(),
+        },
+        {
+          name: "Test User 2",
+          email: "test2@example.com",
+          createdAt: new Date(),
+        },
+      ];
+
+      await Promise.all(testUsers.map((user) => db.users.create(user)));
+
+      const result = await db.users.getAll();
+      expect(result).toHaveLength(2);
+      expect(result.map((u) => u.email)).toEqual(
+        expect.arrayContaining(testUsers.map((u) => u.email))
+      );
+    });
+
+    it("should return empty array when no users exist", async () => {
+      const result = await db.users.getAll();
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("getByEmail", () => {
+    it("should return user by email", async () => {
+      const user = {
+        name: "Test User",
+        email: "test@example.com",
+        createdAt: new Date(),
+      };
+
+      const created = await db.users.create(user);
+      const result = await db.users.getByEmail(user.email);
+
+      expect(result).toEqual(created);
+    });
+
+    it("should throw UserNotFoundError when email not found", async () => {
+      await expect(
+        db.users.getByEmail("nonexistent@example.com")
+      ).rejects.toThrow(UserNotFoundError);
+    });
+  });
+
+  describe("getById", () => {
+    it("should return user by id", async () => {
+      const user = {
+        name: "Test User",
+        email: "test@example.com",
+        createdAt: new Date(),
+      };
+
+      const created = await db.users.create(user);
+      const result = await db.users.getById(created.id);
+
+      expect(result).toEqual(created);
+    });
+
+    it("should throw UserNotFoundError when id not found", async () => {
+      await expect(db.users.getById(999)).rejects.toThrow(UserNotFoundError);
+    });
+  });
+
+  describe("updateLastLogin", () => {
+    it("should update last login timestamp", async () => {
+      vi.useFakeTimers();
+      const user = {
+        name: "Test User",
+        email: "test@example.com",
+        createdAt: new Date(),
+      };
+
+      const created = await db.users.create(user);
+      const now = new Date();
+      vi.setSystemTime(now.setDate(now.getDate() + 1));
+      const result = await db.users.updateLastLogin(created.id);
+      expect(result).toBeDefined();
+      expect(result?.lastLoginAt).toBeInstanceOf(Date);
+      expect(result?.lastLoginAt?.getTime()).toBeGreaterThan(
+        created.createdAt.getTime()
+      );
+      vi.useRealTimers();
+    });
+
+    it("should throw UserNotFoundError when id not found", async () => {
+      await expect(db.users.updateLastLogin(999)).rejects.toThrow(
+        UserNotFoundError
+      );
+    });
+  });
+});

--- a/auth-db/src/queries/users.test.ts
+++ b/auth-db/src/queries/users.test.ts
@@ -59,7 +59,7 @@ describe("users queries", () => {
       const result = await db.users.getAll();
       expect(result).toHaveLength(2);
       expect(result.map((u) => u.email)).toEqual(
-        expect.arrayContaining(testUsers.map((u) => u.email))
+        expect.arrayContaining(testUsers.map((u) => u.email)),
       );
     });
 
@@ -85,7 +85,7 @@ describe("users queries", () => {
 
     it("should throw UserNotFoundError when email not found", async () => {
       await expect(
-        db.users.getByEmail("nonexistent@example.com")
+        db.users.getByEmail("nonexistent@example.com"),
       ).rejects.toThrow(UserNotFoundError);
     });
   });
@@ -125,14 +125,14 @@ describe("users queries", () => {
       expect(result).toBeDefined();
       expect(result?.lastLoginAt).toBeInstanceOf(Date);
       expect(result?.lastLoginAt?.getTime()).toBeGreaterThan(
-        created.createdAt.getTime()
+        created.createdAt.getTime(),
       );
       vi.useRealTimers();
     });
 
     it("should throw UserNotFoundError when id not found", async () => {
       await expect(db.users.updateLastLogin(999)).rejects.toThrow(
-        UserNotFoundError
+        UserNotFoundError,
       );
     });
   });

--- a/auth-db/src/queries/users.ts
+++ b/auth-db/src/queries/users.ts
@@ -57,17 +57,15 @@ export function createUserQueries(db: any) {
       }
     ),
 
-    getById: queryWrapper(
-      async (id: number): Promise<SelectUser | undefined> => {
-        const result = await db.query.users.findFirst({
-          where: eq(users.id, id),
-        });
-        if (!result) {
-          throw new UserNotFoundError();
-        }
-        return result;
+    getById: queryWrapper(async (id: number): Promise<SelectUser> => {
+      const result = await db.query.users.findFirst({
+        where: eq(users.id, id),
+      });
+      if (!result) {
+        throw new UserNotFoundError();
       }
-    ),
+      return result;
+    }),
 
     updateLastLogin: queryWrapper(async (id: number): Promise<SelectUser> => {
       const now = new Date();

--- a/auth-db/src/queries/users.ts
+++ b/auth-db/src/queries/users.ts
@@ -22,6 +22,8 @@ export class UserNotFoundError extends AuthDatabaseError {
 
 export function createUserQueries(db: any) {
   return {
+    UserNotFoundError,
+    EmailConflictError,
     create: queryWrapper(async (user: NewUser): Promise<SelectUser> => {
       try {
         const now = new Date();

--- a/auth-db/src/queries/users.ts
+++ b/auth-db/src/queries/users.ts
@@ -56,7 +56,7 @@ export function createUserQueries(db: any) {
           throw new UserNotFoundError();
         }
         return result;
-      }
+      },
     ),
 
     getById: queryWrapper(async (id: number): Promise<SelectUser> => {

--- a/auth-db/src/queries/users.ts
+++ b/auth-db/src/queries/users.ts
@@ -1,0 +1,90 @@
+import { users } from "../schema.ts";
+import { AuthDatabaseError } from "../errors.ts";
+import { queryWrapper } from "@saflib/drizzle-sqlite3";
+import { eq } from "drizzle-orm";
+
+type NewUser = typeof users.$inferInsert;
+type SelectUser = typeof users.$inferSelect;
+
+export class EmailConflictError extends AuthDatabaseError {
+  constructor() {
+    super("That email is taken.");
+    this.name = "EmailConflictError";
+  }
+}
+
+export class UserNotFoundError extends AuthDatabaseError {
+  constructor() {
+    super("User not found.");
+    this.name = "UserNotFoundError";
+  }
+}
+
+export function createUserQueries(db: any) {
+  return {
+    create: queryWrapper(async (user: NewUser): Promise<SelectUser> => {
+      try {
+        const now = new Date();
+        const result = await db
+          .insert(users)
+          .values({ ...user, createdAt: now })
+          .returning();
+        return result[0];
+      } catch (e: unknown) {
+        if (
+          e instanceof Error &&
+          e.message.includes("UNIQUE constraint failed: users.email")
+        ) {
+          throw new EmailConflictError();
+        }
+        throw e;
+      }
+    }),
+
+    getAll: queryWrapper(async (): Promise<SelectUser[]> => {
+      return db.query.users.findMany().execute();
+    }),
+
+    getByEmail: queryWrapper(
+      async (email: string): Promise<SelectUser | undefined> => {
+        const result = await db.query.users.findFirst({
+          where: eq(users.email, email),
+        });
+        if (!result) {
+          throw new UserNotFoundError();
+        }
+        return result;
+      }
+    ),
+
+    getById: queryWrapper(
+      async (id: number): Promise<SelectUser | undefined> => {
+        const result = await db.query.users.findFirst({
+          where: eq(users.id, id),
+        });
+        if (!result) {
+          throw new UserNotFoundError();
+        }
+        return result;
+      }
+    ),
+
+    updateLastLogin: queryWrapper(async (id: number): Promise<SelectUser> => {
+      const now = new Date();
+      const result = await db
+        .update(users)
+        .set({ lastLoginAt: now })
+        .where(eq(users.id, id))
+        .returning();
+
+      if (!result.length) {
+        throw new UserNotFoundError();
+      }
+      return result[0];
+    }),
+
+    deleteAll: queryWrapper(async (): Promise<void> => {
+      await db.delete(users).execute();
+    }),
+  };
+}

--- a/auth-db/src/schema.ts
+++ b/auth-db/src/schema.ts
@@ -1,0 +1,33 @@
+import { int, sqliteTable, text, blob } from "drizzle-orm/sqlite-core";
+
+// As a general rule, this table should contain members listed in OIDC Standard Claims.
+// See: https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims
+export const users = sqliteTable("users", {
+  id: int().primaryKey({ autoIncrement: true }),
+  createdAt: int("created_at", { mode: "timestamp" }).notNull(),
+  lastLoginAt: int("last_login_at", { mode: "timestamp" }),
+  email: text().notNull().unique(),
+});
+
+// Email authentication
+export const emailAuth = sqliteTable("email_auth", {
+  userId: int("user_id")
+    .notNull()
+    .references(() => users.id)
+    .unique(),
+  email: text("email").notNull().unique(),
+  passwordHash: blob("password_hash").notNull(),
+
+  // Verification
+  verifiedAt: int("verified_at", { mode: "timestamp" }),
+  verificationToken: text("verification_token"),
+  verificationTokenExpiresAt: int("verification_token_expires_at", {
+    mode: "timestamp",
+  }),
+
+  // Forgot password
+  forgotPasswordToken: text("forgot_password_token"),
+  forgotPasswordTokenExpiresAt: int("forgot_password_token_expires_at", {
+    mode: "timestamp",
+  }),
+});

--- a/drizzle-sqlite3/docs/setup.md
+++ b/drizzle-sqlite3/docs/setup.md
@@ -1,0 +1,251 @@
+# Setting Up a Drizzle SQLite3 Library
+
+This guide outlines the standard structure and setup for creating a Drizzle SQLite3 library in the monorepo.
+
+## Package Structure
+
+```
+package-name/
+├── package.json
+├── drizzle.config.ts
+├── data/              # SQLite database files
+├── migrations/        # Generated migrations
+└── src/              # Private implementation
+    ├── schema.ts     # Database schema
+    ├── instance.ts   # Database instance management
+    ├── errors.ts     # Error handling
+    └── queries/      # Database queries
+        └── <table-name>.ts  # Table-specific queries
+        └── <table-name>.test.ts  # Table-specific tests
+```
+
+## Required Files
+
+### package.json
+
+```json
+{
+  "name": "@saflib/your-package",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./src/instance.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "generate": "drizzle-kit generate:sqlite"
+  },
+  "dependencies": {
+    "@saflib/drizzle-sqlite3": "*"
+  },
+  "devDependencies": {
+    "@saflib/drizzle-sqlite3-dev": "*",
+    "@saflib/vitest": "*"
+  }
+}
+```
+
+### drizzle.config.ts
+
+```typescript
+import { fileURLToPath } from "node:url";
+import { dirname } from "node:path";
+
+// Handle both ESM and CommonJS contexts
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export function getDbPath() {
+  return "./data/database.sqlite";
+}
+
+export function getMigrationsPath() {
+  return "./migrations";
+}
+
+export default {
+  schema: "./src/schema.ts",
+  out: getMigrationsPath(),
+  driver: "better-sqlite",
+  dbCredentials: {
+    url: getDbPath(),
+  },
+};
+```
+
+### src/errors.ts
+
+```typescript
+import { HandledDatabaseError } from "@saflib/drizzle-sqlite3";
+
+export class DatabaseError extends HandledDatabaseError {
+  constructor(message: string, cause?: unknown) {
+    super(message, cause);
+    this.name = "DatabaseError";
+  }
+}
+```
+
+### src/instance.ts
+
+```typescript
+import { drizzle } from "@saflib/drizzle-sqlite3";
+import { Database } from "better-sqlite3";
+import * as schema from "./schema.ts";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+import { DatabaseError } from "./errors.ts";
+import { getDbPath, getMigrationsPath } from "../drizzle.config.ts";
+import { createUserQueries } from "./queries/users.ts";
+
+export interface DatabaseConfig {
+  dbPath?: string;
+  migrationsPath?: string;
+  inMemory?: boolean;
+}
+
+export class DatabaseInstance {
+  users: ReturnType<typeof createUserQueries>;
+
+  constructor(config: DatabaseConfig = {}) {
+    try {
+      // Unless overridden by config, use an in-memory database for testing and file-based storage otherwise
+      let dbStorage = ":memory:";
+      if (config.dbPath) {
+        dbStorage = config.dbPath;
+      } else if (config.inMemory || process.env.NODE_ENV === "test") {
+        dbStorage = ":memory:";
+      } else {
+        dbStorage = getDbPath();
+      }
+      const sqlite = new Database(dbStorage);
+
+      const db = drizzle(sqlite, { schema });
+
+      // Run migrations
+      migrate(db, {
+        migrationsFolder: config.migrationsPath || getMigrationsPath(),
+      });
+
+      // Initialize query methods
+      this.users = createUserQueries(db);
+    } catch (error) {
+      throw new DatabaseError(
+        `Failed to initialize database: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+  }
+}
+```
+
+### src/schema.ts
+
+```typescript
+import { sqliteTable, text, integer } from "drizzle-orm/sqlite-core";
+
+export const users = sqliteTable("users", {
+  id: integer("id", { mode: "number" }).primaryKey({ autoIncrement: true }),
+  email: text("email").notNull().unique(),
+  name: text("name").notNull(),
+  createdAt: integer("created_at", { mode: "timestamp" }).notNull(),
+  updatedAt: integer("updated_at", { mode: "timestamp" }).notNull(),
+});
+
+// Export types for consumers
+export type User = typeof users.$inferSelect;
+export type NewUser = typeof users.$inferInsert;
+```
+
+### src/queries/users.ts
+
+```typescript
+import { users } from "../schema.ts";
+import { DatabaseError } from "../errors.ts";
+import { queryWrapper } from "@saflib/drizzle-sqlite3";
+import { eq } from "drizzle-orm";
+
+type NewUser = typeof users.$inferInsert;
+type SelectUser = typeof users.$inferSelect;
+
+export class UserNotFoundError extends DatabaseError {
+  constructor() {
+    super("User not found");
+    this.name = "UserNotFoundError";
+  }
+}
+
+export class EmailConflictError extends DatabaseError {
+  constructor() {
+    super("Email already exists");
+    this.name = "EmailConflictError";
+  }
+}
+
+export function createUserQueries(db: any) {
+  return {
+    UserNotFoundError,
+    EmailConflictError,
+    create: queryWrapper(async (user: NewUser): Promise<SelectUser> => {
+      try {
+        const now = new Date();
+        const result = await db
+          .insert(users)
+          .values({ ...user, createdAt: now, updatedAt: now })
+          .returning();
+        return result[0];
+      } catch (e: unknown) {
+        if (
+          e instanceof Error &&
+          e.message.includes("UNIQUE constraint failed: users.email")
+        ) {
+          throw new EmailConflictError();
+        }
+        throw e;
+      }
+    }),
+
+    getById: queryWrapper(async (id: number): Promise<SelectUser> => {
+      const result = await db.query.users.findFirst({
+        where: eq(users.id, id),
+      });
+      if (!result) {
+        throw new UserNotFoundError();
+      }
+      return result;
+    }),
+  };
+}
+```
+
+## Setup Steps
+
+1. Create the package structure as shown above
+2. Write your schema in `src/schema.ts` following the schema guidelines
+3. Run `npm run generate` to create migrations
+4. Implement your queries in `src/queries/` following the query guidelines and add them to your `instance.ts`
+5. Write tests for your queries, adjacent to the query files
+
+## Testing
+
+When testing, the database will automatically use in-memory storage when `NODE_ENV=TEST`. This ensures each test starts with a fresh state.
+
+Example test:
+
+```typescript
+import { describe, it, expect } from "vitest";
+import { DatabaseInstance } from "./index.ts";
+
+describe("User Queries", () => {
+  it("creates and retrieves a user", async () => {
+    const db = new DatabaseInstance();
+    const user = await db.users.create({
+      email: "test@example.com",
+      name: "Test User",
+    });
+
+    const retrieved = await db.users.getById(user.id);
+    expect(retrieved).toEqual(user);
+  });
+});
+```

--- a/drizzle-sqlite3/tsconfig.json
+++ b/drizzle-sqlite3/tsconfig.json
@@ -1,5 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
-}

--- a/monorepo/docs/db-packages.md
+++ b/monorepo/docs/db-packages.md
@@ -7,7 +7,7 @@ This guide outlines best practices for creating packages that manage data storag
 Packages that manage data (such as SQLite databases, session storage, etc.) should:
 
 1. Store their data in a `data/` directory within the package
-2. Handle the data path internally rather than requiring it to be passed in
+2. Handle the data path internally by default rather than requiring it to be passed in
 3. Create the `data/` directory if it doesn't exist
 4. Add `data/` to `.gitignore` to prevent committing data files
 

--- a/monorepo/docs/db-packages.md
+++ b/monorepo/docs/db-packages.md
@@ -1,0 +1,54 @@
+# Database Packages
+
+This guide outlines best practices for creating packages that manage data storage in the monorepo.
+
+## Data Storage Location
+
+Packages that manage data (such as SQLite databases, session storage, etc.) should:
+
+1. Store their data in a `data/` directory within the package
+2. Handle the data path internally rather than requiring it to be passed in
+3. Create the `data/` directory if it doesn't exist
+4. Add `data/` to `.gitignore` to prevent committing data files
+
+Example structure:
+
+```
+package-name/
+├── package.json
+├── src/
+│   └── index.ts
+└── data/           # Data storage directory
+    └── .gitkeep    # To ensure directory exists in git
+```
+
+## Testing Behavior
+
+When `NODE_ENV` is set to "TEST":
+
+1. Use in-memory storage by default
+2. Each test should start with a fresh state
+3. No data should be persisted to disk
+
+Example implementation:
+
+```typescript
+export class Database {
+  private db: DatabaseImpl;
+
+  constructor() {
+    if (process.env.NODE_ENV === "TEST") {
+      this.db = new InMemoryDatabase();
+    } else {
+      this.db = new SQLiteDatabase("./data/database.sqlite");
+    }
+  }
+}
+```
+
+## Database Access
+
+1. Always use transactions for operations that modify data
+2. Implement proper error handling and rollback mechanisms
+3. Consider implementing connection pooling for high-concurrency scenarios
+4. Document any performance considerations or limitations

--- a/monorepo/docs/library-packages.md
+++ b/monorepo/docs/library-packages.md
@@ -1,0 +1,118 @@
+# Library Packages
+
+This guide outlines best practices for creating reusable library packages in the monorepo.
+
+## Interface Design
+
+1. **Type Management**
+
+   - It's acceptable to propagate types from dependencies when they represent core domain concepts
+   - Example: Database ORM types can be re-exported if they match your domain model
+
+   ```typescript
+   // ✅ Good: Propagating ORM types that match your domain
+   import { users } from "./schema.ts";
+   export type User = typeof users.$inferSelect;
+   export type NewUser = typeof users.$inferInsert;
+   ```
+
+2. **Error Handling**
+
+   - Never propagate dependency errors directly to consumers
+   - Catch and transform errors into library-specific error types
+   - Example:
+
+   ```typescript
+   // ❌ Bad: Propagating SQLite errors
+   async createUser(data: NewUser) {
+     return await db.insert(users).values(data);
+   }
+
+   // ✅ Good: Transforming to library-specific errors
+   class DatabaseError extends Error {
+     constructor(message: string, cause?: unknown) {
+       super(message);
+       this.name = "DatabaseError";
+       this.cause = cause;
+     }
+   }
+
+   async createUser(data: NewUser) {
+     try {
+       return await db.insert(users).values(data);
+     } catch (error) {
+       throw new DatabaseError("Failed to create user", error);
+     }
+   }
+   ```
+
+3. **Query Abstraction**
+   - Instead of exposing raw database queries, provide specific methods for common operations
+   - Encapsulate complex queries within the library
+   - Make the interface domain-focused rather than data-access focused
+
+## Package Structure
+
+1. **Public API Organization**
+
+   - Keep all public exports in the root directory
+   - Use `package.json` exports field to explicitly define public API
+   - Example:
+
+   ```json
+   {
+     "exports": {
+       ".": "./src/index.ts",
+       "./types": "./types.ts",
+       "./errors": "./errors.ts"
+     }
+   }
+   ```
+
+2. **Directory Structure**
+   ```
+   package-name/
+   ├── package.json
+   ├── types.ts           # Public types
+   ├── errors.ts         # Public error types
+   ├── index.ts          # Main entry point
+   └── src/              # Private implementation
+       ├── db.ts         # Database operations
+       ├── schema.ts     # Database schema
+       └── utils.ts      # Internal utilities
+   ```
+
+## Testing
+
+1. **Interface Testing**
+
+   - Test the public interface thoroughly
+   - Mock internal dependencies
+   - Focus on behavior, not implementation
+
+2. **Example Test**
+
+   ```typescript
+   describe("AuthDb", () => {
+     it("creates a user", async () => {
+       const db = new AuthDb();
+       const user = await db.createUser({
+         email: "test@example.com",
+         name: "Test User",
+       });
+       expect(user).toMatchObject({
+         email: "test@example.com",
+         name: "Test User",
+       });
+     });
+
+     it("handles database errors appropriately", async () => {
+       const db = new AuthDb();
+       await expect(
+         db.createUser({
+           /* invalid data */
+         })
+       ).rejects.toThrow(DatabaseError);
+     });
+   });
+   ```

--- a/monorepo/docs/ts-packages.md
+++ b/monorepo/docs/ts-packages.md
@@ -1,6 +1,6 @@
-# Creating TypeScript Packages
+# TypeScript Packages
 
-This guide outlines the best practices for creating TypeScript packages in your monorepo.
+This guide outlines the basic best practices for creating TypeScript packages in your monorepo.
 
 ## Package Structure
 
@@ -115,6 +115,13 @@ import { Something } from "./something.js";
 // Bad - using relative path to another package
 import { OtherThing } from "../../other-package/src/thing.ts";
 ```
+
+## Additional Guidelines
+
+For more specific guidance, see:
+
+- [Database Packages](./db-packages.md) - For packages that manage data storage
+- [Library Packages](./library-packages.md) - For reusable library packages
 
 ## Generated Code
 

--- a/monorepo/docs/ts-packages.md
+++ b/monorepo/docs/ts-packages.md
@@ -9,8 +9,10 @@ A typical TypeScript package should have the following structure:
 ```
 package-name/
 ├── package.json
-└── src/           # Source files
-    └── index.ts   # Main entry point
+├── index.ts        # Main entry point
+├── types.ts        # Public types
+└── src/           # Private implementation
+    └── internal/  # Internal code
 ```
 
 ## Package.json
@@ -23,7 +25,10 @@ The `package.json` should be minimal and focused:
   "description": "Brief description of the package",
   "private": true,
   "type": "module",
-  "main": "src/index.ts",
+  "exports": {
+    ".": "./index.ts",
+    "./types": "./types.ts"
+  },
   "scripts": {
     "test": "vitest run",
     "test:watch": "vitest",
@@ -42,7 +47,7 @@ The `package.json` should be minimal and focused:
 Key points:
 
 - No version field needed (we're not publishing)
-- `main` points to the TypeScript file (we strip types at runtime)
+- Use `exports` field to explicitly define public API
 - `type` is `module` - we're using ESM
 - No separate types field needed
 - Use vitest for testing
@@ -107,7 +112,7 @@ Example:
 import { Something } from "./something.ts";
 
 // Good - importing from another package
-import { OtherThing } from "@your-org/other-package/src/thing.ts";
+import { OtherThing } from "@your-org/other-package/thing.ts";
 
 // Bad - using .js extension
 import { Something } from "./something.js";

--- a/monorepo/tsconfig.json
+++ b/monorepo/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "allowImportingTsExtensions": true,
+    "resolveJsonModule": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  }
+}

--- a/node-express-dev/tsconfig.json
+++ b/node-express-dev/tsconfig.json
@@ -1,3 +1,0 @@
-{
-  "extends": "../../tsconfig.json"
-}

--- a/node-express/tsconfig.json
+++ b/node-express/tsconfig.json
@@ -1,5 +1,0 @@
-{
-  "extends": "../../tsconfig.json",
-  "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
-}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,16 @@
         "node": ">=22"
       }
     },
+    "auth-db": {
+      "name": "@saflib/auth-db",
+      "dependencies": {
+        "@saflib/drizzle-sqlite3": "*"
+      },
+      "devDependencies": {
+        "@saflib/drizzle-sqlite3-dev": "*",
+        "@saflib/vitest": "*"
+      }
+    },
     "auth-spec": {
       "name": "@saflib/auth-spec",
       "devDependencies": {
@@ -2833,6 +2843,10 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@saflib/auth-db": {
+      "resolved": "auth-db",
+      "link": true
     },
     "node_modules/@saflib/auth-spec": {
       "resolved": "auth-spec",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,18 +1,3 @@
 {
-  "compilerOptions": {
-    "target": "es2020",
-    "module": "nodenext",
-    "moduleResolution": "nodenext",
-    "allowImportingTsExtensions": true,
-    "resolveJsonModule": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noEmit": true,
-    "esModuleInterop": true,
-    "forceConsistentCasingInFileNames": true,
-    "strict": true,
-    "skipLibCheck": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
-  }
+  "extends": "@saflib/monorepo/tsconfig.json"
 }


### PR DESCRIPTION
Continuing the gradual migration of auth logic into saflib, this moves the db portion. I moved the logic that was in https://github.com/sderickson/saf-2025 over. Cursor agent did a bit of refactoring to make the db not a singleton which I approved of, but otherwise this is pretty much the same old implementation. I did take the opportunity to add a test where, with the new instance implementation, I spun up two clients on the same file and tested they work.

## Documentation updates
My theory is documentation is the key to consistent output by agents. As such, I'm filling out docs as I go based on what I needed to guide the agent on for this PR. 
* The agent tried to have the db library defer responsibility of data to the consumer and change how the db behaved in testing. I'd rather packages that manage state to store that state in `/data` when not testing. Added `db-packages.md` with info like where to store `data` and when.
* The agent at first would have exposed drizzle interfaces by this library. Added `library-packages.md` with info like what functions to expose, and how to expose types.
* Generally I had to nudge the agent a bunch on how to properly set up the drizzle-sqlite3 setup. So I added a `setup.md` doc which hopefully will work well when an agent creates a new such db package from scratch. Will iterate of course...

### Unhandled agent misfires
What did the agent do wrong which I wasn't able to fix with documentation? And how might I address them in the future?
* **Not exporting types**. This is a subtle issue, but if you export functions and such for your library, but *don't* export their types or return types or such, it's not a great dev experience. I might in the future auto-generate library docs with `typedoc` which warns when that happens.
* **Not fixing a mock**. This is probably the number one thing I see the agent spin on, and I don't blame it. It needed to mock `argon2` in a certain way to fix a test and it didn't know how to do it. Maybe should add a doc on debugging mocking?

## Other work part of this PR:
* added unit test github action
* Updated gitignore
* Cleaned up tsconfigs, made the monorepo package the source of truth