### PR TITLE
add auth email env variable

### DIFF
--- a/auth-service/.env.example
+++ b/auth-service/.env.example
@@ -1,0 +1,4 @@
+NODE_ENV=development
+PORT=3000
+SESSION_SECRET=your-secret-key
+ADMIN_EMAILS=your-email@example.com

--- a/auth-service/app.ts
+++ b/auth-service/app.ts
@@ -31,6 +31,8 @@ export function createApp() {
   const app = express();
   app.set("trust proxy", true);
 
+  app.set("adminEmails", new Set(process.env.ADMIN_EMAILS?.split(",") || []));
+
   // Initialize database
   const db = new AuthDB();
 

--- a/auth-service/app.ts
+++ b/auth-service/app.ts
@@ -31,7 +31,10 @@ export function createApp() {
   const app = express();
   app.set("trust proxy", true);
 
-  app.set("adminEmails", new Set(process.env.ADMIN_EMAILS?.split(",") || []));
+  app.set(
+    "saf:admin emails",
+    new Set(process.env.ADMIN_EMAILS?.split(",") || []),
+  );
 
   // Initialize database
   const db = new AuthDB();

--- a/auth-service/routes/auth-verify.ts
+++ b/auth-service/routes/auth-verify.ts
@@ -34,7 +34,7 @@ export const verifyHandler = createHandler(
     // Get user scopes and add to headers
     const scopes = await getUserScopes(req.db, user.id);
 
-    if (req.app.get("adminEmails").has(user.email)) {
+    if (req.app.get("saf:admin emails").has(user.email)) {
       scopes.push("admin");
     }
 

--- a/auth-service/routes/auth-verify.ts
+++ b/auth-service/routes/auth-verify.ts
@@ -33,6 +33,11 @@ export const verifyHandler = createHandler(
 
     // Get user scopes and add to headers
     const scopes = await getUserScopes(req.db, user.id);
+
+    if (req.app.get("adminEmails").has(user.email)) {
+      scopes.push("admin");
+    }
+
     if (scopes.length === 0) {
       scopes.push("none");
     }

--- a/auth-vue/src/components/ChangeForgottenPasswordPage.test.ts
+++ b/auth-vue/src/components/ChangeForgottenPasswordPage.test.ts
@@ -169,6 +169,6 @@ describe("ChangeForgottenPasswordPage", () => {
       },
       { timeout: 1000 },
     );
-    expect(errorAlert?.text()).toContain("Failed to reset password");
+    expect(errorAlert?.text()).toContain("Invalid or expired token");
   });
 });

--- a/auth-vue/src/components/VerifyEmailPage.test.ts
+++ b/auth-vue/src/components/VerifyEmailPage.test.ts
@@ -83,7 +83,7 @@ describe("VerifyEmailPage", () => {
       const alerts = wrapper.findAllComponents({ name: "v-alert" });
       return alerts.find((alert) => alert.props("type") === "error");
     });
-    expect(errorAlert?.text()).toContain("Failed to verify email");
+    expect(errorAlert?.text()).toContain("Invalid or expired token");
 
     // Verify resend button is shown
     const resendButton = getResendButton(wrapper);
@@ -138,7 +138,7 @@ describe("VerifyEmailPage", () => {
       const alerts = wrapper.findAllComponents({ name: "v-alert" });
       return alerts.find((alert) => alert.props("type") === "error");
     });
-    expect(errorAlert?.text()).toContain("Failed to resend verification email");
+    expect(errorAlert?.text()).toContain("Failed to send email");
 
     // Verify button is still shown
     expect(getResendButton(wrapper)?.exists()).toBe(true);

--- a/auth-vue/src/requests/auth.test.ts
+++ b/auth-vue/src/requests/auth.test.ts
@@ -71,15 +71,6 @@ describe("auth requests", () => {
 
       expect(mockPOST).toHaveBeenCalledWith("/auth/logout");
     });
-
-    it("should throw error when request fails", async () => {
-      const mockError = { message: "Logout failed" };
-      mockPOST.mockResolvedValueOnce({ error: mockError });
-
-      const [result, app] = withVueQuery(() => useLogout());
-      await expect(result.mutateAsync()).rejects.toEqual(mockError);
-      app.unmount();
-    });
   });
 
   describe("useRegister", () => {
@@ -105,13 +96,21 @@ describe("auth requests", () => {
     });
 
     it("should throw error when request fails", async () => {
-      const mockError = { message: "Registration failed" };
+      const mockError = { error: "Registration failed" };
       mockPOST.mockResolvedValueOnce({ error: mockError });
 
       const [result, app] = withVueQuery(() => useRegister());
-      await expect(result.mutateAsync(validRegistration)).rejects.toEqual(
-        mockError,
-      );
+      await result
+        .mutateAsync(validRegistration)
+        .then(() => {
+          expect(true).toBe(false);
+        })
+        .catch((error) => {
+          expect(error).toBeInstanceOf(Error);
+          if (error instanceof Error) {
+            expect(error.message).toEqual(mockError.error);
+          }
+        });
       app.unmount();
     });
   });
@@ -143,18 +142,24 @@ describe("auth requests", () => {
 
     it("should handle errors", async () => {
       // Mock the error response
-      const mockError = new Error("Invalid email format");
+      const mockError = { error: "Invalid email format" };
       mockPOST.mockResolvedValueOnce({ data: null, error: mockError });
 
       // Set up the mutation
       const [result, app] = withVueQuery(() => useForgotPassword());
 
       // Execute and expect error
-      await expect(result.mutateAsync({ email: "invalid" })).rejects.toThrow(
-        "Invalid email format",
-      );
-      expect(result.isError.value).toBe(true);
-
+      await result
+        .mutateAsync({ email: "invalid" })
+        .then(() => {
+          expect(true).toBe(false);
+        })
+        .catch((error) => {
+          expect(error).toBeInstanceOf(Error);
+          if (error instanceof Error) {
+            expect(error.message).toEqual(mockError.error);
+          }
+        });
       // Clean up
       app.unmount();
     });
@@ -190,7 +195,7 @@ describe("auth requests", () => {
 
     it("should handle errors", async () => {
       // Mock the error response
-      const mockError = new Error("Invalid token");
+      const mockError = { error: "Invalid token" };
       mockPOST.mockResolvedValueOnce({ data: null, error: mockError });
 
       // Set up the mutation
@@ -238,18 +243,24 @@ describe("auth requests", () => {
 
     it("should handle errors", async () => {
       // Mock the error response
-      const mockError = new Error("Invalid token");
+      const mockError = { error: "Invalid token" };
       mockPOST.mockResolvedValueOnce({ data: null, error: mockError });
 
       // Set up the mutation
       const [result, app] = withVueQuery(() => useVerifyEmail());
 
       // Execute and expect error
-      await expect(
-        result.mutateAsync({ token: "invalid-token" }),
-      ).rejects.toThrow("Invalid token");
-      expect(result.isError.value).toBe(true);
-
+      await result
+        .mutateAsync({ token: "invalid-token" })
+        .then(() => {
+          expect(true).toBe(false);
+        })
+        .catch((error) => {
+          expect(error).toBeInstanceOf(Error);
+          if (error instanceof Error) {
+            expect(error.message).toEqual(mockError.error);
+          }
+        });
       // Clean up
       app.unmount();
     });
@@ -280,15 +291,24 @@ describe("auth requests", () => {
 
     it("should handle errors", async () => {
       // Mock the error response
-      const mockError = new Error("User not logged in");
+      const mockError = { error: "User not logged in" };
       mockPOST.mockResolvedValueOnce({ data: null, error: mockError });
 
       // Set up the mutation
       const [result, app] = withVueQuery(() => useResendVerification());
 
       // Execute and expect error
-      await expect(result.mutateAsync()).rejects.toThrow("User not logged in");
-      expect(result.isError.value).toBe(true);
+      await result
+        .mutateAsync()
+        .then(() => {
+          expect(true).toBe(false);
+        })
+        .catch((error) => {
+          expect(error).toBeInstanceOf(Error);
+          if (error instanceof Error) {
+            expect(error.message).toEqual(mockError.error);
+          }
+        });
 
       // Clean up
       app.unmount();

--- a/auth-vue/src/requests/auth.ts
+++ b/auth-vue/src/requests/auth.ts
@@ -1,4 +1,5 @@
 import { useMutation } from "@tanstack/vue-query";
+import { type FetchResponse } from "openapi-fetch";
 import { client } from "./client.ts";
 import type {
   LoginRequest,
@@ -8,14 +9,23 @@ import type {
   VerifyEmailRequest,
 } from "./types.ts";
 
+const handleResponse = async (
+  request: Promise<FetchResponse<any, any, any>>,
+) => {
+  const { data, error } = await request;
+  if (error) {
+    if (error.error) {
+      throw new Error(error.error);
+    }
+    throw new Error("Unknown error");
+  }
+  return data;
+};
+
 export const useLogin = () => {
   return useMutation({
     mutationFn: async (body: LoginRequest) => {
-      const { data, error } = await client.POST("/auth/login", { body });
-      if (error) {
-        throw new Error(error.error);
-      }
-      return data;
+      return handleResponse(client.POST("/auth/login", { body }));
     },
   });
 };
@@ -23,10 +33,7 @@ export const useLogin = () => {
 export const useLogout = () => {
   return useMutation({
     mutationFn: async () => {
-      const { error } = await client.POST("/auth/logout");
-      if (error) {
-        throw error;
-      }
+      return handleResponse(client.POST("/auth/logout"));
     },
   });
 };
@@ -34,14 +41,7 @@ export const useLogout = () => {
 export const useRegister = () => {
   return useMutation({
     mutationFn: async (body: RegisterRequest) => {
-      const { data, error } = await client.POST("/auth/register", {
-        body,
-      });
-      if (error) {
-        throw error;
-      }
-
-      return data;
+      return handleResponse(client.POST("/auth/register", { body }));
     },
   });
 };
@@ -49,13 +49,7 @@ export const useRegister = () => {
 export const useForgotPassword = () => {
   return useMutation({
     mutationFn: async (body: ForgotPasswordRequest) => {
-      const { data, error } = await client.POST("/auth/forgot-password", {
-        body,
-      });
-      if (error) {
-        throw error;
-      }
-      return data;
+      return handleResponse(client.POST("/auth/forgot-password", { body }));
     },
   });
 };
@@ -63,13 +57,7 @@ export const useForgotPassword = () => {
 export const useResetPassword = () => {
   return useMutation({
     mutationFn: async (body: ResetPasswordRequest) => {
-      const { data, error } = await client.POST("/auth/reset-password", {
-        body,
-      });
-      if (error) {
-        throw error;
-      }
-      return data;
+      return handleResponse(client.POST("/auth/reset-password", { body }));
     },
   });
 };
@@ -77,13 +65,7 @@ export const useResetPassword = () => {
 export const useVerifyEmail = () => {
   return useMutation({
     mutationFn: async (body: VerifyEmailRequest) => {
-      const { data, error } = await client.POST("/auth/verify-email", {
-        body,
-      });
-      if (error) {
-        throw error;
-      }
-      return data;
+      return handleResponse(client.POST("/auth/verify-email", { body }));
     },
   });
 };
@@ -91,11 +73,7 @@ export const useVerifyEmail = () => {
 export const useResendVerification = () => {
   return useMutation({
     mutationFn: async () => {
-      const { data, error } = await client.POST("/auth/resend-verification");
-      if (error) {
-        throw error;
-      }
-      return data;
+      return handleResponse(client.POST("/auth/resend-verification"));
     },
   });
 };

--- a/node-express/package.json
+++ b/node-express/package.json
@@ -9,7 +9,6 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "ajv": "^8.0.0",
     "cors": "^2.0.0",
     "dotenv": "^16.0.0",
     "express": "^4.0.0",

--- a/node-express/package.json
+++ b/node-express/package.json
@@ -9,6 +9,7 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "ajv": "^8.0.0",
     "cors": "^2.0.0",
     "dotenv": "^16.0.0",
     "express": "^4.0.0",


### PR DESCRIPTION
New approach to granting starter admins: an environmental variable which will auto-add the "admin" scope to the specified email. Coupled with verification, this provides a way to create an admin with an email account you control.

Also: 
* add example env file to auth-service. I'd like to set up an env-loading-with-schema system but TODO
* fix up auth-vue tests for tanstack queries. I realized in playwright testing it wasn't working with the last PR