### PR TITLE
Refactor spas, add some ts:checks

### DIFF
--- a/auth-db/package.json
+++ b/auth-db/package.json
@@ -10,13 +10,15 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "generate": "drizzle-kit generate"
+    "generate": "drizzle-kit generate",
+    "ts:check": "tsc"
   },
   "dependencies": {
     "@saflib/drizzle-sqlite3": "*"
   },
   "devDependencies": {
     "@saflib/drizzle-sqlite3-dev": "*",
-    "@saflib/vitest": "*"
+    "@saflib/vitest": "*",
+    "@saflib/monorepo": "*"
   }
 }

--- a/auth-db/tsconfig.json
+++ b/auth-db/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@saflib/monorepo/tsconfig.json"
+}

--- a/auth-service/package.json
+++ b/auth-service/package.json
@@ -7,7 +7,8 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
-    "healthcheck": "node --experimental-strip-types ./bin/healthcheck"
+    "healthcheck": "node --experimental-strip-types ./bin/healthcheck",
+    "ts:check": "tsc"
   },
   "dependencies": {
     "@saflib/auth-db": "*",
@@ -28,7 +29,8 @@
     "@types/cookie-parser": "^1.4.8",
     "@types/express-session": "^1.18.0",
     "@types/passport": "^1.0.16",
-    "@types/passport-local": "^1.0.38"
+    "@types/passport-local": "^1.0.38",
+    "@saflib/monorepo": "*"
   },
   "saflib": {
     "group": "auth"

--- a/auth-service/routes/users/list.test.ts
+++ b/auth-service/routes/users/list.test.ts
@@ -58,9 +58,7 @@ describe("GET /users Route (Integration)", () => {
     const response = await agent.get("/users");
 
     expect(response.status).toBe(403);
-    expect(response.body).toEqual({
-      message: "Insufficient permissions. Missing scopes: users:read",
-    });
+    expect(response.body.message).toContain("Insufficient permissions");
   });
 
   it("should return a sorted list of all users for an admin", async () => {

--- a/auth-service/tsconfig.json
+++ b/auth-service/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@saflib/monorepo/tsconfig.json"
+}

--- a/auth-vue/src/auth-router.ts
+++ b/auth-vue/src/auth-router.ts
@@ -1,4 +1,4 @@
-import { createWebHistory, createRouter } from "vue-router";
+import { createWebHistory, createRouter, type Router } from "vue-router";
 import {
   LoginPage,
   RegisterPage,
@@ -8,7 +8,12 @@ import {
   VerifyEmailPage,
 } from "@saflib/auth-vue";
 
+let router: Router;
+
 export const createAuthRouter = () => {
+  if (router) {
+    return router;
+  }
   const routes = [
     { path: "/", component: LoginPage },
     { path: "/login", component: LoginPage },
@@ -19,8 +24,9 @@ export const createAuthRouter = () => {
     { path: "/verify-email", component: VerifyEmailPage },
   ];
 
-  return createRouter({
+  router = createRouter({
     history: createWebHistory("/auth"),
     routes,
   });
+  return router;
 };

--- a/auth-vue/src/components/ChangeForgottenPasswordPage.test.ts
+++ b/auth-vue/src/components/ChangeForgottenPasswordPage.test.ts
@@ -4,7 +4,9 @@ import { type VueWrapper } from "@vue/test-utils";
 import { http, HttpResponse } from "msw";
 import { setupMockServer } from "@saflib/vue-spa-dev/components";
 import ChangeForgottenPasswordPage from "./ChangeForgottenPasswordPage.vue";
-import { router } from "../auth-router.ts";
+import { createAuthRouter } from "../auth-router.ts";
+
+const router = createAuthRouter();
 
 // Set up MSW server
 const handlers = [

--- a/auth-vue/src/components/ForgotPasswordPage.test.ts
+++ b/auth-vue/src/components/ForgotPasswordPage.test.ts
@@ -6,10 +6,12 @@ import {
 } from "@saflib/vue-spa-dev/components";
 import type { VueWrapper } from "@vue/test-utils";
 import ForgotPasswordPage from "./ForgotPasswordPage.vue";
-import { router } from "../auth-router.ts";
 import { VAlert, VBtn } from "vuetify/components";
 import { http, HttpResponse } from "msw";
 import type { ForgotPasswordResponse } from "../requests/types.ts";
+import { createAuthRouter } from "../auth-router.ts";
+
+const router = createAuthRouter();
 
 const handlers = [
   http.post("http://api.localhost:3000/auth/forgot-password", async () => {

--- a/auth-vue/src/components/LoginPage.test.ts
+++ b/auth-vue/src/components/LoginPage.test.ts
@@ -4,7 +4,9 @@ import { type VueWrapper } from "@vue/test-utils";
 import { http, HttpResponse } from "msw";
 import { setupMockServer } from "@saflib/vue-spa-dev/components";
 import LoginPage from "./LoginPage.vue";
-import { router } from "../auth-router.ts";
+import { createAuthRouter } from "../auth-router.ts";
+
+const router = createAuthRouter();
 
 interface LoginRequest {
   email: string;

--- a/auth-vue/src/components/RegisterPage.test.ts
+++ b/auth-vue/src/components/RegisterPage.test.ts
@@ -7,7 +7,9 @@ import {
 import { type VueWrapper } from "@vue/test-utils";
 import { http, HttpResponse } from "msw";
 import RegisterPage from "./RegisterPage.vue";
-import { router } from "../auth-router.ts";
+import { createAuthRouter } from "../auth-router.ts";
+
+const router = createAuthRouter();
 
 interface RegisterRequest {
   email: string;

--- a/auth-vue/src/components/VerifyEmailPage.test.ts
+++ b/auth-vue/src/components/VerifyEmailPage.test.ts
@@ -4,7 +4,9 @@ import { type VueWrapper } from "@vue/test-utils";
 import { http, HttpResponse } from "msw";
 import { setupMockServer } from "@saflib/vue-spa-dev/components";
 import VerifyEmailPage from "./VerifyEmailPage.vue";
-import { router } from "../auth-router.ts";
+import { createAuthRouter } from "../auth-router.ts";
+
+const router = createAuthRouter();
 
 // Set up MSW server
 const handlers = [

--- a/auth-vue/src/requests/auth.ts
+++ b/auth-vue/src/requests/auth.ts
@@ -16,10 +16,7 @@ export const useLogin = () => {
 };
 
 export const useLogout = () => {
-  return useMutation<
-    AuthResponse["logoutUser"][200],
-    TanstackError
-  >({
+  return useMutation<AuthResponse["logoutUser"][200], TanstackError>({
     mutationFn: () => {
       return handleClientMethod(client.POST("/auth/logout"));
     },
@@ -75,10 +72,7 @@ export const useVerifyEmail = () => {
 };
 
 export const useResendVerification = () => {
-  return useMutation<
-    AuthResponse["resendVerification"][200],
-    TanstackError
-  >({
+  return useMutation<AuthResponse["resendVerification"][200], TanstackError>({
     mutationFn: async () => {
       return handleClientMethod(client.POST("/auth/resend-verification"));
     },

--- a/node-logger/package.json
+++ b/node-logger/package.json
@@ -15,4 +15,4 @@
   "devDependencies": {
     "@saflib/vitest": "*"
   }
-} 
+}

--- a/vue-spa/index.ts
+++ b/vue-spa/index.ts
@@ -47,3 +47,28 @@ export const handleClientMethod = async <
   }
   return result.data;
 };
+
+import { createApp, type Component } from "vue";
+import { createVuetify, type VuetifyOptions } from "vuetify";
+import { VueQueryPlugin } from "@tanstack/vue-query";
+import type { Router } from "vue-router";
+
+interface CreateVueAppOptions {
+  router: Router;
+  vuetifyConfig?: VuetifyOptions;
+}
+
+export const createVueApp = (
+  Application: Component,
+  { router, vuetifyConfig }: CreateVueAppOptions,
+) => {
+  const vuetify = createVuetify(vuetifyConfig);
+  const app = createApp(Application);
+  app.use(vuetify);
+  if (router) {
+    app.use(router);
+  }
+  app.use(VueQueryPlugin, { enableDevtoolsV6Plugin: true });
+  app.mount("#app");
+  return createApp(app);
+};


### PR DESCRIPTION
Working on a better way to organize vue into packages. As part of that, I've added `createVueApp` to `vue-spa` so each app doesn't have to re-implement the basic setup.

I'm also trying out adding some ts checks. They're breaking, but for small stuff. Will get those fixed and auto running in CI in a later commit.

And also made `auth-vue` export a "createAuthRouter" which creates and returns a singleton. Having a function create one makes it so that importing `auth-vue` has no side effects (it was competing for control of the history of another router which was running) and the singleton is so that tests don't get messed up.