### PR TITLE
Some node-centric updates

### DIFF
--- a/auth-service/routes/auth/forgot-password.ts
+++ b/auth-service/routes/auth/forgot-password.ts
@@ -5,13 +5,13 @@ import { type AuthResponse } from "@saflib/auth-spec";
 import { EmailClient } from "@saflib/email";
 import { generatePasswordResetEmail } from "../../email-templates/password-reset.ts";
 import { AuthDB } from "@saflib/auth-db";
-import { safContext } from "@saflib/node";
+import { safStorage } from "@saflib/node";
 
 export const forgotPasswordHandler = createHandler(
   async (req: Request, res: Response) => {
     const { email } = req.body as { email: string };
     const db: AuthDB = req.app.locals.db;
-    const { log } = safContext.getStore()!;
+    const { log } = safStorage.getStore()!;
 
     try {
       const user = await db.users.getByEmail(email);

--- a/auth-service/routes/auth/register.ts
+++ b/auth-service/routes/auth/register.ts
@@ -6,13 +6,13 @@ import { randomBytes } from "crypto";
 import { EmailClient } from "@saflib/email";
 import { generateVerificationEmail } from "../../email-templates/verify-email.ts";
 import { AuthDB } from "@saflib/auth-db";
-import { safContext } from "@saflib/node";
+import { safStorage } from "@saflib/node";
 export const registerHandler = createHandler(async (req, res) => {
   const db: AuthDB = req.app.locals.db;
   try {
     const registerRequest: AuthRequest["registerUser"] = req.body;
     const { email, password } = registerRequest;
-    const { log } = safContext.getStore()!;
+    const { log } = safStorage.getStore()!;
 
     const passwordHash = await argon2.hash(password);
 

--- a/auth-service/routes/auth/resend-verification.ts
+++ b/auth-service/routes/auth/resend-verification.ts
@@ -4,10 +4,10 @@ import { type AuthResponse } from "@saflib/auth-spec";
 import { EmailClient } from "@saflib/email";
 import { generateVerificationEmail } from "../../email-templates/verify-email.ts";
 import { AuthDB } from "@saflib/auth-db";
-import { safContext } from "@saflib/node";
+import { safStorage } from "@saflib/node";
 export const resendVerificationHandler = createHandler(async (req, res) => {
   const db: AuthDB = req.app.locals.db;
-  const { log } = safContext.getStore()!;
+  const { log } = safStorage.getStore()!;
   if (!req.user) {
     res.status(401).json({
       message: "User must be logged in",

--- a/drizzle-sqlite3/errors.ts
+++ b/drizzle-sqlite3/errors.ts
@@ -1,5 +1,7 @@
 // To dissuade services from catching unhandled errors and papering over them programmatically, we log the error details and throw an error with a generic message. If a service catches this error, it should be solved (and/or possibly thrown as a new Error type) in the database library, not the service layer.
 
+import { safStorage } from "@saflib/node";
+
 export class UnhandledDatabaseError extends Error {
   constructor() {
     super("A database library did not catch and handle an error. Check logs.");
@@ -18,6 +20,18 @@ export function queryWrapper<T, A extends any[]>(
     } catch (error) {
       if (error instanceof HandledDatabaseError) {
         throw error;
+      }
+      const ctx = safStorage.getStore();
+      if (ctx) {
+        ctx.log.error(error);
+        if (error instanceof Error) {
+          ctx.log.error(error.stack);
+        }
+      } else {
+        console.error(error);
+        if (error instanceof Error) {
+          console.error(error.stack);
+        }
       }
       throw new UnhandledDatabaseError();
     }

--- a/express/src/middleware/auth.test.ts
+++ b/express/src/middleware/auth.test.ts
@@ -4,7 +4,7 @@ import express from "express";
 import request from "supertest";
 import { createPreMiddleware } from "./composition.ts";
 import { errorHandler } from "./errors.ts"; // Import errorHandler for a complete setup
-import { safContext } from "@saflib/node";
+import { safStorage } from "@saflib/node";
 
 describe("Auth Middleware", () => {
   let app: express.Express;
@@ -17,7 +17,7 @@ describe("Auth Middleware", () => {
     // Add a test route that will be protected by the auth middleware
     app.get("/test", (_req: Request, res: Response) => {
       // If auth middleware passes, req.auth should be populated
-      const { auth } = safContext.getStore()!;
+      const { auth } = safStorage.getStore()!;
       res.status(200).json({ authFromMiddleware: auth });
     });
     // Add error handler to catch errors from middleware

--- a/express/src/middleware/auth.ts
+++ b/express/src/middleware/auth.ts
@@ -1,5 +1,5 @@
 import type { Handler } from "express";
-import { safContext, type Auth } from "@saflib/node";
+import { safStorage, type Auth } from "@saflib/node";
 
 // Extend Express Request type to include user property
 declare global {
@@ -19,7 +19,7 @@ declare global {
  * Throws 401 if required headers are missing.
  */
 export const auth: Handler = (req, res, next): void => {
-  const { auth } = safContext.getStore()!;
+  const { auth } = safStorage.getStore()!;
 
   if (!auth) {
     res.status(401).json({

--- a/express/src/middleware/composition.ts
+++ b/express/src/middleware/composition.ts
@@ -53,7 +53,7 @@ export const createPreMiddleware = (
   }
 
   let authMiddleware: Handler[] = [];
-  if (authRequired || (apiSpec && authRequired !== false)) {
+  if (authRequired !== false) {
     authMiddleware = [auth];
   }
 

--- a/express/src/middleware/context.ts
+++ b/express/src/middleware/context.ts
@@ -1,4 +1,4 @@
-import { type SafContext, safContext } from "@saflib/node";
+import { type SafContext, safStorage } from "@saflib/node";
 import type { Handler } from "express";
 import { createLogger } from "@saflib/node";
 import type { Auth } from "@saflib/node";
@@ -29,7 +29,7 @@ export const contextMiddleware: Handler = (req, _res, next) => {
     log,
     auth,
   };
-  safContext.run(context, () => {
+  safStorage.run(context, () => {
     next();
   });
 };

--- a/express/src/middleware/errors.ts
+++ b/express/src/middleware/errors.ts
@@ -1,6 +1,6 @@
 import createError, { HttpError } from "http-errors";
 import type { Request, Response, NextFunction, Handler } from "express";
-import { safContext } from "@saflib/node";
+import { safStorage } from "@saflib/node";
 /**
  * 404 Handler
  * Catches requests to undefined routes
@@ -21,7 +21,7 @@ export const errorHandler = (
 ): void => {
   // Log error
   const status = err.status || 500;
-  const log = safContext.getStore()?.log;
+  const log = safStorage.getStore()?.log;
 
   if (status >= 500) {
     if (!log || process.env.NODE_ENV === "test") {

--- a/express/src/middleware/openapi.ts
+++ b/express/src/middleware/openapi.ts
@@ -6,7 +6,7 @@ import type {
 import type { OpenAPIV3 } from "express-openapi-validator/dist/framework/types.ts";
 import type { Request } from "express";
 import { createScopeValidator } from "./scopes.ts";
-import { safContext } from "@saflib/node";
+import { safStorage } from "@saflib/node";
 
 declare global {
   namespace Express {
@@ -19,7 +19,7 @@ declare global {
 const validateResponses = {
   onError: (err: Error, _json: any, _req: Request) => {
     // console.log("Response validation error:", err.message);
-    const { log } = safContext.getStore()!;
+    const { log } = safStorage.getStore()!;
     log.error(err);
     if (process.env.NODE_ENV === "test") {
       console.log("======", err.message, "======");

--- a/grpc-servicer/src/server.ts
+++ b/grpc-servicer/src/server.ts
@@ -9,6 +9,7 @@ interface GrpcService {
 
 interface GrpcServerOptions {
   interceptors?: grpc.ServerInterceptor[];
+  port?: number;
 }
 
 export type ServiceImplementationWrapper = (
@@ -22,12 +23,14 @@ export type ServiceImplementationWrapper = (
  * @param services An array of service definitions and their implementations.
  */
 export function startGrpcServer(
-  services: GrpcService[],
+  server: grpc.Server,
   options: GrpcServerOptions = {},
 ): grpc.Server {
-  const port = process.env.GRPC_PORT
-    ? parseInt(process.env.GRPC_PORT, 10)
-    : 50051;
+  const port = options.port
+    ? options.port
+    : process.env.GRPC_PORT
+      ? parseInt(process.env.GRPC_PORT, 10)
+      : 50051;
   if (isNaN(port)) {
     console.error(
       `Invalid GRPC_PORT: ${process.env.GRPC_PORT}. Using default 50051.`,
@@ -36,21 +39,20 @@ export function startGrpcServer(
   }
   const effectivePort = isNaN(port) ? 50051 : port;
 
-  console.log("Initializing gRPC server...");
-  const server = new grpc.Server({
-    interceptors: options.interceptors || [],
-  });
+  // const server = new grpc.Server({
+  //   interceptors: options.interceptors || [],
+  // });
 
-  // Register all provided RPC service handlers
-  services.forEach((serviceInfo) => {
-    console.log(
-      `Registering gRPC service: ${Object.keys(serviceInfo.serviceDefinition)}`,
-    );
-    server.addService(
-      serviceInfo.serviceDefinition,
-      serviceInfo.implementation,
-    );
-  });
+  // // Register all provided RPC service handlers
+  // services.forEach((serviceInfo) => {
+  //   console.log(
+  //     `Registering gRPC service: ${Object.keys(serviceInfo.serviceDefinition)}`,
+  //   );
+  //   server.addService(
+  //     serviceInfo.serviceDefinition,
+  //     serviceInfo.implementation,
+  //   );
+  // });
 
   // Bind the server asynchronously
   console.log("Binding gRPC server to port", effectivePort);

--- a/grpc-servicer/src/server.ts
+++ b/grpc-servicer/src/server.ts
@@ -16,16 +16,10 @@ export type ServiceImplementationWrapper = (
   impl: UntypedServiceImplementation,
 ) => UntypedServiceImplementation;
 
-/**
- * Creates, configures, and starts a gRPC server, handling graceful shutdown.
- * Reads GRPC_PORT from environment variables, defaulting to 50051.
- *
- * @param services An array of service definitions and their implementations.
- */
-export function startGrpcServer(
+export async function startGrpcServer(
   server: grpc.Server,
   options: GrpcServerOptions = {},
-): grpc.Server {
+) {
   const port = options.port
     ? options.port
     : process.env.GRPC_PORT
@@ -35,43 +29,26 @@ export function startGrpcServer(
     console.error(
       `Invalid GRPC_PORT: ${process.env.GRPC_PORT}. Using default 50051.`,
     );
-    // Or throw an error, depending on desired strictness
   }
   const effectivePort = isNaN(port) ? 50051 : port;
 
-  // const server = new grpc.Server({
-  //   interceptors: options.interceptors || [],
-  // });
-
-  // // Register all provided RPC service handlers
-  // services.forEach((serviceInfo) => {
-  //   console.log(
-  //     `Registering gRPC service: ${Object.keys(serviceInfo.serviceDefinition)}`,
-  //   );
-  //   server.addService(
-  //     serviceInfo.serviceDefinition,
-  //     serviceInfo.implementation,
-  //   );
-  // });
-
-  // Bind the server asynchronously
-  console.log("Binding gRPC server to port", effectivePort);
+  let resolve: () => void;
+  let reject: (err: Error) => void;
+  const p = new Promise<void>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
   server.bindAsync(
     `0.0.0.0:${effectivePort}`,
     grpc.ServerCredentials.createInsecure(), // Using insecure for now
-    (err, boundPort) => {
+    (err, _boundPort) => {
       if (err) {
-        console.error(
-          `gRPC server binding failed on port ${effectivePort}:`,
-          err,
-        );
-        // Consider exiting or throwing if binding fails critically
-        process.exit(1); // Exit if binding fails
-        return;
+        reject(err);
       }
-      console.log(`gRPC server started on port ${boundPort}`);
+      resolve();
     },
   );
+  await p;
 
   // Graceful shutdown handler
   const shutdown = () => {
@@ -95,11 +72,4 @@ export function startGrpcServer(
   // Listen for shutdown signals
   process.on("SIGTERM", shutdown);
   process.on("SIGINT", shutdown);
-
-  // Handle server errors (optional but good practice)
-  // server.on('error', (err) => { // Note: grpc.Server doesn't directly emit 'error' like http.Server
-  //   console.error("gRPC Server Error:", err);
-  // });
-
-  return server; // Return the server instance if needed elsewhere
 }

--- a/grpc-servicer/src/server.ts
+++ b/grpc-servicer/src/server.ts
@@ -1,12 +1,6 @@
 import * as grpc from "@grpc/grpc-js";
 import type { UntypedServiceImplementation } from "@grpc/grpc-js";
 
-// Define an interface for the service definition and implementation pairs
-interface GrpcService {
-  serviceDefinition: grpc.ServiceDefinition<grpc.UntypedServiceImplementation>;
-  implementation: grpc.UntypedServiceImplementation;
-}
-
 interface GrpcServerOptions {
   interceptors?: grpc.ServerInterceptor[];
   port?: number;

--- a/node/index.ts
+++ b/node/index.ts
@@ -5,5 +5,5 @@ export {
 } from "./src/logger.ts";
 export { generateRequestId } from "./src/request-id.ts";
 export type { Logger } from "winston";
-export { safContext } from "./src/context.ts";
+export { safStorage } from "./src/context.ts";
 export type { SafContext, Auth } from "./src/context.ts";

--- a/node/src/context.ts
+++ b/node/src/context.ts
@@ -12,4 +12,4 @@ export interface SafContext {
   log: Logger;
   auth?: Auth;
 }
-export const safContext = new AsyncLocalStorage<SafContext>();
+export const safStorage = new AsyncLocalStorage<SafContext>();


### PR DESCRIPTION
* Renamed "safContext" to "safStorage".
* Used it to add error logging for database errors
* Made auth required by default for endpoints
* Made the interface for grpc servers more like the interface for starting express servers