### PR TITLE
Mock, callback, and workspace updates

### DIFF
--- a/auth-rpcs/__mocks__/index.ts
+++ b/auth-rpcs/__mocks__/index.ts
@@ -1,0 +1,16 @@
+import { vi } from "vitest";
+
+export * from "../index.ts";
+
+export const UsersClient = vi.fn().mockImplementation(() => {
+  return {
+    GetUserProfile: vi.fn().mockResolvedValue({
+      profile: {
+        user_id: 1,
+        email: "test@example.com",
+        email_verified: true,
+        name: "Test User",
+      },
+    }),
+  };
+});

--- a/auth-service/routes/auth/reset-password.test.ts
+++ b/auth-service/routes/auth/reset-password.test.ts
@@ -16,13 +16,18 @@ vi.mock("crypto", async (importOriginal) => {
   };
 });
 
+const callbacks = {
+  onPasswordUpdated: async () => {},
+};
+const onPasswordUpdatedSpy = vi.spyOn(callbacks, "onPasswordUpdated");
+
 describe("Reset Password Route", () => {
   let app: express.Express;
 
   beforeEach(() => {
     (passport as any)._serializers = [];
     (passport as any)._deserializers = [];
-    app = createApp({ callbacks: {} });
+    app = createApp({ callbacks });
     vi.useFakeTimers();
   });
 
@@ -60,6 +65,10 @@ describe("Reset Password Route", () => {
       .send({ email: userData.email, password: "new-password123" });
 
     expect(loginResponse.status).toBe(200);
+    expect(onPasswordUpdatedSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ email: userData.email }),
+    );
+    expect(onPasswordUpdatedSpy).toHaveBeenCalledTimes(1);
   });
 
   it("should return 400 for expired token", async () => {

--- a/auth-service/routes/auth/reset-password.ts
+++ b/auth-service/routes/auth/reset-password.ts
@@ -3,9 +3,10 @@ import { createHandler } from "@saflib/express";
 import { type AuthResponse } from "@saflib/auth-spec";
 import { authDb, TokenNotFoundError } from "@saflib/auth-db";
 import { authServiceStorage } from "../../context.ts";
+import { throwError } from "@saflib/monorepo";
 
 export const resetPasswordHandler = createHandler(async (req, res) => {
-  const { dbKey } = authServiceStorage.getStore()!;
+  const { dbKey, callbacks } = authServiceStorage.getStore()!;
   const { token, newPassword } = req.body as {
     token: string;
     newPassword: string;
@@ -45,9 +46,11 @@ export const resetPasswordHandler = createHandler(async (req, res) => {
   );
   await authDb.emailAuth.clearForgotPasswordToken(dbKey, emailAuth.userId);
 
-  const { callbacks } = req.app.get("authOptions") || {};
-  if (callbacks && typeof callbacks.onPasswordUpdated === "function") {
-    await callbacks.onPasswordUpdated(req.user);
+  if (callbacks && callbacks.onPasswordUpdated) {
+    const user = await throwError(
+      authDb.users.getById(dbKey, emailAuth.userId),
+    );
+    await callbacks.onPasswordUpdated(user);
   }
 
   const successResponse: AuthResponse["resetPassword"][200] = {

--- a/auth-service/routes/auth/reset-password.ts
+++ b/auth-service/routes/auth/reset-password.ts
@@ -45,6 +45,11 @@ export const resetPasswordHandler = createHandler(async (req, res) => {
   );
   await authDb.emailAuth.clearForgotPasswordToken(dbKey, emailAuth.userId);
 
+  const { callbacks } = req.app.get("authOptions") || {};
+  if (callbacks && typeof callbacks.onPasswordUpdated === "function") {
+    await callbacks.onPasswordUpdated(req.user);
+  }
+
   const successResponse: AuthResponse["resetPassword"][200] = {
     success: true,
   };

--- a/auth-service/routes/auth/set-password.test.ts
+++ b/auth-service/routes/auth/set-password.test.ts
@@ -72,7 +72,10 @@ describe("Set Password Route", () => {
     });
     expect(oldLoginResponse.status).toBe(401);
 
-    expect(onPasswordUpdatedSpy).toHaveBeenCalled();
+    expect(onPasswordUpdatedSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ email: userData.email }),
+    );
+    expect(onPasswordUpdatedSpy).toHaveBeenCalledTimes(1);
   });
 
   it("should return 401 for unauthenticated user", async () => {

--- a/auth-service/routes/auth/set-password.test.ts
+++ b/auth-service/routes/auth/set-password.test.ts
@@ -5,6 +5,11 @@ import { createApp } from "../../http.ts";
 import passport from "passport";
 import { testRateLimiting } from "./_test-helpers.ts";
 
+const callbacks = {
+  onPasswordUpdated: async () => {},
+};
+const onPasswordUpdatedSpy = vi.spyOn(callbacks, "onPasswordUpdated");
+
 describe("Set Password Route", () => {
   let app: express.Express;
 
@@ -12,7 +17,7 @@ describe("Set Password Route", () => {
     vi.clearAllMocks();
     (passport as any)._serializers = [];
     (passport as any)._deserializers = [];
-    app = createApp({ callbacks: {} });
+    app = createApp({ callbacks });
   });
 
   it("should change password successfully for logged in user", async () => {
@@ -66,6 +71,8 @@ describe("Set Password Route", () => {
       password: "password123",
     });
     expect(oldLoginResponse.status).toBe(401);
+
+    expect(onPasswordUpdatedSpy).toHaveBeenCalled();
   });
 
   it("should return 401 for unauthenticated user", async () => {

--- a/auth-service/routes/auth/set-password.ts
+++ b/auth-service/routes/auth/set-password.ts
@@ -5,7 +5,7 @@ import { authDb, EmailAuthNotFoundError } from "@saflib/auth-db";
 import { authServiceStorage } from "../../context.ts";
 
 export const setPassword = createHandler(async (req, res) => {
-  const { dbKey } = authServiceStorage.getStore()!;
+  const { dbKey, callbacks } = authServiceStorage.getStore()!;
 
   if (!req.user) {
     res.status(401).json({
@@ -59,8 +59,6 @@ export const setPassword = createHandler(async (req, res) => {
     Buffer.from(newPasswordHash),
   );
 
-  // Call onPasswordUpdated callback if defined
-  const { callbacks } = req.app.get("authOptions") || {};
   if (callbacks && typeof callbacks.onPasswordUpdated === "function") {
     await callbacks.onPasswordUpdated(req.user);
   }

--- a/auth-service/routes/auth/set-password.ts
+++ b/auth-service/routes/auth/set-password.ts
@@ -59,6 +59,12 @@ export const setPassword = createHandler(async (req, res) => {
     Buffer.from(newPasswordHash),
   );
 
+  // Call onPasswordUpdated callback if defined
+  const { callbacks } = req.app.get("authOptions") || {};
+  if (callbacks && typeof callbacks.onPasswordUpdated === "function") {
+    await callbacks.onPasswordUpdated(req.user);
+  }
+
   const response: AuthResponse["setPassword"][200] = {
     success: true,
   };

--- a/auth-service/types.ts
+++ b/auth-service/types.ts
@@ -31,6 +31,7 @@ export interface AuthServiceCallbacks {
     isResend: boolean,
   ) => Promise<void>;
   onPasswordReset?: (user: User, resetUrl: string) => Promise<void>;
+  onPasswordUpdated?: (user: User) => Promise<void>;
 }
 
 export interface AuthServerOptions {

--- a/dev-tools/src/monorepo.mock.ts
+++ b/dev-tools/src/monorepo.mock.ts
@@ -10,7 +10,14 @@ export const monorepoPackageMock = {
   // Root package.json
   "/app/package.json": JSON.stringify({
     name: "@foo/foo",
-    workspaces: ["clients/*", "dbs", "saflib/*", "services/*", "specs/*"],
+    workspaces: [
+      "clients/*",
+      "dbs",
+      "libs/**",
+      "saflib/*",
+      "services/*",
+      "specs/*",
+    ],
   }),
 
   // Clients
@@ -40,7 +47,29 @@ export const monorepoPackageMock = {
     },
   }),
 
-  // Lib
+  // Libs (nested packages to test /** functionality)
+  "/app/libs/utils/package.json": JSON.stringify({
+    name: "@foo/utils",
+    dependencies: {
+      lodash: "4.17.21",
+    },
+  }),
+  "/app/libs/shared/common/package.json": JSON.stringify({
+    name: "@foo/common",
+    dependencies: {
+      "@foo/utils": "*",
+      moment: "2.29.4",
+    },
+  }),
+  "/app/libs/shared/validators/package.json": JSON.stringify({
+    name: "@foo/validators",
+    dependencies: {
+      "@foo/common": "*",
+      joi: "17.9.2",
+    },
+  }),
+
+  // Lib (existing custom-lib, keeping for backwards compatibility)
   "/app/lib/custom-lib/package.json": JSON.stringify({
     name: "@foo/custom-lib",
     dependencies: {

--- a/dev-tools/src/workspace.ts
+++ b/dev-tools/src/workspace.ts
@@ -58,17 +58,17 @@ export function getMonorepoPackages(
   const workspacePackageDirectories: directoryPath[] = [];
 
   for (const workspace of workspaces) {
+    // should probably just use a glob library...
     if (workspace.endsWith("/**")) {
       // recursively find all workspaces
       const workspacesDir = path.join(rootDir, workspace.slice(0, -2));
       const workspacesFolders = readdirSync(workspacesDir, {
         recursive: true,
-      }) as string[];
-      for (const fileName of workspacesFolders) {
-        if (fileName.endsWith("package.json")) {
-          workspacePackageDirectories.push(
-            path.join(workspacesDir, fileName.slice(0, -13)),
-          );
+        withFileTypes: true,
+      });
+      for (const file of workspacesFolders) {
+        if (file.isFile() && file.name.endsWith("package.json")) {
+          workspacePackageDirectories.push(file.parentPath);
         }
       }
     } else if (workspace.endsWith("/*")) {
@@ -87,7 +87,6 @@ export function getMonorepoPackages(
       workspacePackageDirectories.push(path.join(rootDir, workspace));
     }
   }
-  console.log(workspacePackageDirectories);
 
   for (const workspacePackageDirectory of workspacePackageDirectories) {
     const workspacePackageJsonPath = path.join(

--- a/dev-tools/src/workspace.ts
+++ b/dev-tools/src/workspace.ts
@@ -58,7 +58,20 @@ export function getMonorepoPackages(
   const workspacePackageDirectories: directoryPath[] = [];
 
   for (const workspace of workspaces) {
-    if (workspace.endsWith("/*")) {
+    if (workspace.endsWith("/**")) {
+      // recursively find all workspaces
+      const workspacesDir = path.join(rootDir, workspace.slice(0, -2));
+      const workspacesFolders = readdirSync(workspacesDir, {
+        recursive: true,
+      }) as string[];
+      for (const fileName of workspacesFolders) {
+        if (fileName.endsWith("package.json")) {
+          workspacePackageDirectories.push(
+            path.join(workspacesDir, fileName.slice(0, -13)),
+          );
+        }
+      }
+    } else if (workspace.endsWith("/*")) {
       const workspacesDir = path.join(rootDir, workspace.slice(0, -1));
       const workspacesFolders = readdirSync(workspacesDir)
         .filter((folder) => !folder.startsWith("."))
@@ -74,6 +87,7 @@ export function getMonorepoPackages(
       workspacePackageDirectories.push(path.join(rootDir, workspace));
     }
   }
+  console.log(workspacePackageDirectories);
 
   for (const workspacePackageDirectory of workspacePackageDirectories) {
     const workspacePackageJsonPath = path.join(


### PR DESCRIPTION
Working more on email-type things.
* Add a basic mock for auth-rpcs.
* Add a callback for when passwords change
* Added handling in `workspace.ts` for "/**" globs in workspaces

For mocks, I'm rethinking how it might work:
* For packages which interface with 3rd party services, if the node env is TEST, they just don't try to interact with the 3rd party service, and instead will always do some simple, happy-path behavior. They may also export some spies for ease of access by tests for consumers of those libraries. This seems like the best way to reuse test utils.
* For packages which interact with other 1st party services, such as grpc clients, they'll have a similar mocking situation, but their behavior won't change based on node env. This way you can still have integration tests.

For globs, I'm trying out having nested packages within services. This is for scenarios when there's something pretty coupled with a service (such as a db, api specs, grpc protos, mock data, or email templates) which have their own separate dependencies, tests, interfaces, and so on. I'm still playing around with how I want to organize these files, but I'm pretty sure I don't want to keep doing what I'm currently doing where things like a server and a db and specs are all in separate root folders.

The benefits are:
* Things which conceptually should be owned together, live together
* To depend on that group of packages, one can add a glob to their root workspace that points to that group
* Fewer `../..`-relative imports if you can organize sub-sections of the larger structure into packages