### PR TITLE
Standardize naming: service and subsystem

### DIFF
--- a/auth-service/Dockerfile
+++ b/auth-service/Dockerfile
@@ -5,10 +5,10 @@ FROM node:alpine3.19
 WORKDIR /app
 COPY tsconfig.json ./
 
-COPY --parents ./package.json ./package-lock.json ./saflib/auth-db/package.json ./saflib/auth-rpcs/package.json ./saflib/auth-service/package.json ./saflib/auth-spec/package.json ./saflib/drizzle-sqlite3/package.json ./saflib/express/package.json ./saflib/grpc-node/package.json ./saflib/grpc-specs/package.json ./saflib/monorepo/package.json ./saflib/node/package.json ./saflib/openapi-specs/package.json ./
+COPY --parents ./package.json ./package-lock.json ./saflib/auth-db/package.json ./saflib/auth-rpcs/package.json ./saflib/auth-service/package.json ./saflib/auth-spec/package.json ./saflib/drizzle-sqlite3/package.json ./saflib/email-node/package.json ./saflib/email-spec/package.json ./saflib/express/package.json ./saflib/grpc-node/package.json ./saflib/grpc-specs/package.json ./saflib/monorepo/package.json ./saflib/node/package.json ./saflib/openapi-specs/package.json ./
 RUN npm install --omit=dev
 
-COPY --parents ./saflib/auth-db ./saflib/auth-rpcs ./saflib/auth-service ./saflib/auth-spec ./saflib/drizzle-sqlite3 ./saflib/express ./saflib/grpc-node ./saflib/grpc-specs ./saflib/monorepo ./saflib/node ./saflib/openapi-specs ./
+COPY --parents ./saflib/auth-db ./saflib/auth-rpcs ./saflib/auth-service ./saflib/auth-spec ./saflib/drizzle-sqlite3 ./saflib/email-node ./saflib/email-spec ./saflib/express ./saflib/grpc-node ./saflib/grpc-specs ./saflib/monorepo ./saflib/node ./saflib/openapi-specs ./
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 CMD ["npm", "run", "healthcheck"]
 WORKDIR /app/saflib/auth-service

--- a/auth-service/http.ts
+++ b/auth-service/http.ts
@@ -5,8 +5,6 @@ import { makeAuthRouter } from "./routes/auth/index.ts";
 import { makeUsersRouter } from "./routes/users/index.ts";
 import { authServiceStorage } from "./context.ts";
 import type { AuthServerOptions } from "./types.ts";
-import { createEmailsRouter } from "@saflib/email-node";
-import { jsonSpec } from "@saflib/auth-spec";
 
 // Define properties added to Express Request objects by middleware
 declare global {
@@ -37,18 +35,6 @@ export function createApp(options: AuthServerOptions) {
       next();
     });
   });
-
-  const serviceName = options.servicePrefix
-    ? options.servicePrefix + ".auth"
-    : "auth";
-
-  app.use(
-    "/auth",
-    createEmailsRouter({
-      apiSpec: jsonSpec,
-      serviceName,
-    }),
-  );
 
   app.use("/auth", makeAuthRouter());
   app.use("/users", makeUsersRouter());

--- a/auth-service/http.ts
+++ b/auth-service/http.ts
@@ -5,6 +5,8 @@ import { makeAuthRouter } from "./routes/auth/index.ts";
 import { makeUsersRouter } from "./routes/users/index.ts";
 import { authServiceStorage } from "./context.ts";
 import type { AuthServerOptions } from "./types.ts";
+import { createEmailsRouter } from "@saflib/email-node";
+import { jsonSpec } from "@saflib/auth-spec";
 
 // Define properties added to Express Request objects by middleware
 declare global {
@@ -35,6 +37,13 @@ export function createApp(options: AuthServerOptions) {
       next();
     });
   });
+
+  app.use(
+    "/auth",
+    createEmailsRouter({
+      apiSpec: jsonSpec,
+    }),
+  );
 
   app.use("/auth", makeAuthRouter());
   app.use("/users", makeUsersRouter());

--- a/auth-service/index.ts
+++ b/auth-service/index.ts
@@ -6,7 +6,7 @@ import { startGrpcServer } from "@saflib/grpc-node";
 import type { DbOptions } from "../drizzle-sqlite3/types.ts";
 import type { User } from "@saflib/auth-db";
 import type { AuthServiceCallbacks } from "./types.ts";
-import { createLogger } from "@saflib/node";
+import { makeSubsystemReporters } from "@saflib/node";
 export * from "./types.ts";
 
 interface StartAuthServiceOptions {
@@ -15,25 +15,28 @@ interface StartAuthServiceOptions {
 }
 
 export async function startAuthService(options?: StartAuthServiceOptions) {
-  const logger = createLogger({
-    serviceName: "auth",
-    operationName: "startAuthService",
-    requestId: "",
-  });
-  logger.info("Starting auth service...");
-  logger.info("Connecting to auth DB...");
-  const dbKey = authDb.connect(options?.dbOptions);
-  logger.info("Starting gRPC server...");
-  const grpcServer = makeGrpcServer({
-    dbKey,
-    callbacks: options?.callbacks ?? {},
-  });
-  startGrpcServer(grpcServer);
+  const { log, reportError } = makeSubsystemReporters(
+    "auth",
+    "startAuthService",
+  );
+  try {
+    log.info("Starting auth service...");
+    log.info("Connecting to auth DB...");
+    const dbKey = authDb.connect(options?.dbOptions);
+    log.info("Starting gRPC server...");
+    const grpcServer = makeGrpcServer({
+      dbKey,
+      callbacks: options?.callbacks ?? {},
+    });
+    startGrpcServer(grpcServer);
 
-  logger.info("Starting express server...");
-  const app = createApp({ dbKey, callbacks: options?.callbacks ?? {} });
-  startExpressServer(app);
-  logger.info("Auth service startup complete.");
+    log.info("Starting express server...");
+    const app = createApp({ dbKey, callbacks: options?.callbacks ?? {} });
+    startExpressServer(app);
+    log.info("Auth service startup complete.");
+  } catch (error) {
+    reportError(error);
+  }
 }
 
 export type { User };

--- a/auth-service/index.ts
+++ b/auth-service/index.ts
@@ -6,6 +6,7 @@ import { startGrpcServer } from "@saflib/grpc-node";
 import type { DbOptions } from "../drizzle-sqlite3/types.ts";
 import type { User } from "@saflib/auth-db";
 import type { AuthServiceCallbacks } from "./types.ts";
+import { createLogger } from "@saflib/node";
 export * from "./types.ts";
 
 interface StartAuthServiceOptions {
@@ -14,15 +15,25 @@ interface StartAuthServiceOptions {
 }
 
 export async function startAuthService(options?: StartAuthServiceOptions) {
+  const logger = createLogger({
+    serviceName: "auth",
+    operationName: "startAuthService",
+    requestId: "",
+  });
+  logger.info("Starting auth service...");
+  logger.info("Connecting to auth DB...");
   const dbKey = authDb.connect(options?.dbOptions);
+  logger.info("Starting gRPC server...");
   const grpcServer = makeGrpcServer({
     dbKey,
     callbacks: options?.callbacks ?? {},
   });
   startGrpcServer(grpcServer);
 
+  logger.info("Starting express server...");
   const app = createApp({ dbKey, callbacks: options?.callbacks ?? {} });
   startExpressServer(app);
+  logger.info("Auth service startup complete.");
 }
 
 export type { User };

--- a/auth-service/package.json
+++ b/auth-service/package.json
@@ -17,6 +17,7 @@
     "@saflib/auth-db": "*",
     "@saflib/auth-rpcs": "*",
     "@saflib/auth-spec": "*",
+    "@saflib/email-node": "*",
     "@saflib/express": "*",
     "@saflib/grpc-node": "*",
     "@saflib/monorepo": "*",

--- a/auth-service/routes/auth/index.ts
+++ b/auth-service/routes/auth/index.ts
@@ -19,20 +19,14 @@ import { jsonSpec } from "@saflib/auth-spec";
 import * as cookieParser from "cookie-parser";
 import { csrfDSC } from "../../middleware/csrf.ts";
 
-interface AuthRouterOptions {
-  servicePrefix?: string;
-}
-
-export const makeAuthRouter = (options: AuthRouterOptions = {}) => {
+export const makeAuthRouter = () => {
   const router = express.Router();
 
   router.use(
     createPreMiddleware({
       apiSpec: jsonSpec,
       authRequired: false,
-      serviceName: options.servicePrefix
-        ? options.servicePrefix + ".auth.http"
-        : "auth.http",
+      subsystemName: "auth",
     }),
   );
 

--- a/auth-service/routes/auth/register.test.ts
+++ b/auth-service/routes/auth/register.test.ts
@@ -73,9 +73,6 @@ describe("Register Route", () => {
       expect.any(String),
       false,
     );
-
-    const sentEmails = await request(app).get("/auth/email/sent");
-    expect(sentEmails.body).toEqual([]);
   });
 
   it("should return 409 for duplicate email", async () => {

--- a/auth-service/routes/users/index.ts
+++ b/auth-service/routes/users/index.ts
@@ -8,7 +8,7 @@ export const makeUsersRouter = () => {
   router.use(
     createPreMiddleware({
       apiSpec: jsonSpec,
-      serviceName: "auth.http.users",
+      subsystemName: "users",
     }),
   );
 

--- a/cron-service/http.ts
+++ b/cron-service/http.ts
@@ -9,7 +9,7 @@ import type { JobsMap } from "./src/types.ts";
 import type { DbOptions } from "@saflib/drizzle-sqlite3";
 
 export interface CronServiceOptions {
-  serviceName: string;
+  subsystemName?: string;
   dbOptions?: DbOptions;
   dbKey?: DbKey;
   jobs: JobsMap;
@@ -35,7 +35,7 @@ export function createApp(options: CronServiceOptions) {
   app.use(
     createPreMiddleware({
       apiSpec: jsonSpec,
-      serviceName: options.serviceName + ".cron",
+      subsystemName: options.subsystemName,
     }),
   );
   app.use("/cron", cronRouter);

--- a/cron-service/index.ts
+++ b/cron-service/index.ts
@@ -4,31 +4,37 @@ import { cronDb } from "@saflib/cron-db";
 import { createApp } from "./http.ts";
 import type { JobsMap } from "./src/types.ts";
 import type { DbKey, DbOptions } from "@saflib/drizzle-sqlite3";
-import { createLogger } from "@saflib/node";
+import { makeSubsystemReporters } from "@saflib/node";
 
 export type { JobsMap } from "./src/types.ts";
 
 export interface CronServiceOptions {
-  serviceName?: string;
+  subsystemName?: string;
   dbOptions?: DbOptions;
   dbKey?: DbKey;
   jobs: JobsMap;
 }
 
 export function main(options: CronServiceOptions) {
-  const logger = createLogger({
-    serviceName: "cron",
-    operationName: "main",
-    requestId: "",
-  });
-  logger.info("Starting cron service...");
-  logger.info("Connecting to cron DB...");
-  const dbKey = options.dbKey ?? cronDb.connect(options.dbOptions);
-  const serviceName = options.serviceName ?? "cron";
-  logger.info("Starting jobs...");
-  startJobs(options.jobs, { serviceName, dbKey });
-  logger.info("Starting express server...");
-  const httpApp = createApp({ dbKey, jobs: options.jobs, serviceName });
-  startExpressServer(httpApp);
-  logger.info("Cron service startup complete.");
+  const { log, reportError } = makeSubsystemReporters("cron", "main");
+  try {
+    log.info("Starting cron service...");
+    log.info("Connecting to cron DB...");
+    const dbKey = options.dbKey ?? cronDb.connect(options.dbOptions);
+    log.info("Starting jobs...");
+    startJobs(options.jobs, { subsystemName: "cron", dbKey });
+    log.info("Starting express server...");
+    const subsystemName = options.subsystemName
+      ? options.subsystemName + ".cron"
+      : "cron";
+    const httpApp = createApp({
+      dbKey,
+      jobs: options.jobs,
+      subsystemName,
+    });
+    startExpressServer(httpApp);
+    log.info("Cron service startup complete.");
+  } catch (error) {
+    reportError(error);
+  }
 }

--- a/cron-service/index.ts
+++ b/cron-service/index.ts
@@ -4,6 +4,7 @@ import { cronDb } from "@saflib/cron-db";
 import { createApp } from "./http.ts";
 import type { JobsMap } from "./src/types.ts";
 import type { DbKey, DbOptions } from "@saflib/drizzle-sqlite3";
+import { createLogger } from "@saflib/node";
 
 export type { JobsMap } from "./src/types.ts";
 
@@ -15,9 +16,19 @@ export interface CronServiceOptions {
 }
 
 export function main(options: CronServiceOptions) {
+  const logger = createLogger({
+    serviceName: "cron",
+    operationName: "main",
+    requestId: "",
+  });
+  logger.info("Starting cron service...");
+  logger.info("Connecting to cron DB...");
   const dbKey = options.dbKey ?? cronDb.connect(options.dbOptions);
   const serviceName = options.serviceName ?? "cron";
+  logger.info("Starting jobs...");
   startJobs(options.jobs, { serviceName, dbKey });
+  logger.info("Starting express server...");
   const httpApp = createApp({ dbKey, jobs: options.jobs, serviceName });
   startExpressServer(httpApp);
+  logger.info("Cron service startup complete.");
 }

--- a/cron-service/routes/list-cron-jobs.test.ts
+++ b/cron-service/routes/list-cron-jobs.test.ts
@@ -17,7 +17,7 @@ describe("GET /jobs", () => {
   beforeEach(async () => {
     // Recreate db instance for each test for isolation
     dbKey = cronDb.connect();
-    app = createApp({ dbKey, jobs: mockJobs, serviceName: "cron" });
+    app = createApp({ dbKey, jobs: mockJobs });
 
     seededSettings = []; // Reset seeded settings
 

--- a/cron-service/routes/update-cron-job-settings.test.ts
+++ b/cron-service/routes/update-cron-job-settings.test.ts
@@ -18,7 +18,7 @@ describe("PUT /jobs/settings", () => {
   beforeEach(async () => {
     // Recreate db instance for each test for isolation
     dbKey = cronDb.connect();
-    app = createApp({ dbKey, jobs: mockJobs, serviceName: "cron" });
+    app = createApp({ dbKey, jobs: mockJobs });
   });
 
   it("should update the enabled status of an existing job and return the updated setting", async () => {

--- a/cron-service/src/index.test.ts
+++ b/cron-service/src/index.test.ts
@@ -46,7 +46,7 @@ describe("startJobs", () => {
     // Pass the local db instance to startJobs
     await startJobs(
       { "new-job": mockJobs["new-job"] },
-      { serviceName: "test-service", dbKey },
+      { subsystemName: "test", dbKey },
     );
     const setting = await throwError(
       cronDb.jobSettings.getByName(dbKey, "new-job"),
@@ -73,7 +73,7 @@ describe("startJobs", () => {
     // Pass the local db instance
     await startJobs(
       { "fail-job": mockJobs["fail-job"] },
-      { serviceName: "test-service", dbKey },
+      { subsystemName: "test", dbKey },
     );
 
     // Check that the specific error was logged
@@ -93,7 +93,7 @@ describe("startJobs", () => {
   it("should run enabled job on schedule tick", async () => {
     await startJobs(
       { "every-second-job": mockJobs["every-second-job"] },
-      { serviceName: "test-service", dbKey },
+      { subsystemName: "test", dbKey },
     );
     // Ensure the job is enabled in the DB for this test
     await cronDb.jobSettings.setEnabled(dbKey, "every-second-job", true);
@@ -112,7 +112,7 @@ describe("startJobs", () => {
     await cronDb.jobSettings.setEnabled(dbKey, "disabled-job", false);
     await startJobs(
       { "disabled-job": mockJobs["disabled-job"] },
-      { serviceName: "test-service", dbKey },
+      { subsystemName: "test", dbKey },
     );
     await vi.advanceTimersByTimeAsync(1000);
     expect(mockJobs["disabled-job"].handler).not.toHaveBeenCalled();
@@ -126,7 +126,7 @@ describe("startJobs", () => {
   it("should update status to running, then success on successful run", async () => {
     await startJobs(
       { "every-second-job": mockJobs["every-second-job"] },
-      { serviceName: "test-service", dbKey },
+      { subsystemName: "test", dbKey },
     );
     // Ensure the job is enabled in the DB for this test
     await cronDb.jobSettings.setEnabled(dbKey, "every-second-job", true);
@@ -145,7 +145,7 @@ describe("startJobs", () => {
     mockJobHandler.mockRejectedValueOnce(handlerError);
     await startJobs(
       { "every-second-job": mockJobs["every-second-job"] },
-      { serviceName: "test-service", dbKey },
+      { subsystemName: "test", dbKey },
     );
     await cronDb.jobSettings.setEnabled(dbKey, "every-second-job", true);
 
@@ -173,7 +173,7 @@ describe("startJobs", () => {
 
     await startJobs(
       { "every-minute-job": mockJobs["every-minute-job"] },
-      { serviceName: "test-service", dbKey },
+      { subsystemName: "test", dbKey },
     );
     await vi.advanceTimersByTimeAsync(1000 * 62); // Trigger the job's onTick and timeout
     const setting = await throwError(
@@ -197,7 +197,7 @@ describe("startJobs", () => {
 
     await startJobs(
       { "timeout-default-job": jobConfig },
-      { serviceName: "test-service", dbKey },
+      { subsystemName: "test", dbKey },
     );
     await cronDb.jobSettings.setEnabled(dbKey, "timeout-default-job", true);
 
@@ -235,7 +235,7 @@ describe("startJobs", () => {
 
     await startJobs(
       { "every-second-job": mockJobs["every-second-job"] },
-      { serviceName: "test-service", dbKey },
+      { subsystemName: "test", dbKey },
     );
     await cronDb.jobSettings.setEnabled(dbKey, "every-second-job", true);
 

--- a/cron-service/src/index.ts
+++ b/cron-service/src/index.ts
@@ -65,7 +65,6 @@ async function executeJobWithHandling(
 
         // If race succeeds without error
         statusToSet = "success";
-        log.info(`Job ${jobName} finished successfully.`);
       } catch (error) {
         reportError(error);
         const isErrorInstance = error instanceof Error;

--- a/cron-service/src/index.ts
+++ b/cron-service/src/index.ts
@@ -1,7 +1,6 @@
 import { CronJob } from "cron";
 import {
   createLogger,
-  createServiceLogger,
   defaultErrorReporter,
   generateRequestId,
   getSafReporters,
@@ -107,7 +106,11 @@ export const startJobs = async (
   jobsToStart: JobsMap,
   config: StartJobConfig,
 ) => {
-  const logger = createServiceLogger(config.serviceName);
+  const logger = createLogger({
+    serviceName: config.serviceName,
+    operationName: "startJobs",
+    requestId: "",
+  });
   const reportError = makeServiceErrorReporter(config.serviceName, logger);
   const { serviceName, dbKey } = config;
   for (const [jobName, jobConfig] of Object.entries(jobsToStart)) {

--- a/drizzle-sqlite3/types.ts
+++ b/drizzle-sqlite3/types.ts
@@ -6,6 +6,7 @@ export type Schema = Record<string, unknown>;
 export type DbKey = symbol;
 
 export interface DbOptions {
+  name?: string;
   onDisk?: boolean | string;
   doNotCreate?: boolean;
 }

--- a/email-node/routes/emails/get-sent-emails.test.ts
+++ b/email-node/routes/emails/get-sent-emails.test.ts
@@ -10,7 +10,7 @@ describe("getSentEmails", () => {
 
   beforeEach(() => {
     app = express();
-    app.use("/", createEmailsRouter({ serviceName: "test" }));
+    app.use("/", createEmailsRouter());
     app.use(recommendedErrorHandlers);
   });
 

--- a/email-node/routes/emails/index.ts
+++ b/email-node/routes/emails/index.ts
@@ -4,17 +4,16 @@ import { createPreMiddleware } from "@saflib/express";
 import { jsonSpec } from "@saflib/email-spec";
 
 export interface EmailsRouterOptions {
-  serviceName: string; // Should be just the name of the service, such as at the docker level
   apiSpec?: any;
 }
 
-export function createEmailsRouter(options: EmailsRouterOptions) {
+export function createEmailsRouter(options: EmailsRouterOptions = {}) {
   const router = express.Router();
 
   const preMiddleware = createPreMiddleware({
     apiSpec: options.apiSpec || jsonSpec,
     authRequired: false,
-    serviceName: options.serviceName + ".http.emails",
+    subsystemName: "emails",
   });
 
   router.use("/email", preMiddleware);

--- a/express/src/middleware/auth.test.ts
+++ b/express/src/middleware/auth.test.ts
@@ -11,7 +11,7 @@ describe("Auth Middleware", () => {
 
   beforeEach(() => {
     app = express();
-    app.use(createPreMiddleware({ authRequired: true, serviceName: "test" }));
+    app.use(createPreMiddleware({ authRequired: true }));
     app.get("/test", (_req, res) => {
       const { auth } = getSafContext();
       res.status(200).json({ authFromMiddleware: auth });

--- a/express/src/middleware/composition.ts
+++ b/express/src/middleware/composition.ts
@@ -13,7 +13,7 @@ import { blockHtml } from "./blockHtml.ts";
 import { createScopeValidator } from "./scopes.ts";
 
 interface PreMiddlewareOptions {
-  serviceName: string;
+  subsystemName?: string;
   apiSpec?: OpenAPIV3.DocumentV3;
   authRequired?: boolean;
   disableCors?: boolean;
@@ -23,7 +23,7 @@ interface PreMiddlewareOptions {
 export const createPreMiddleware = (
   options: PreMiddlewareOptions,
 ): Handler[] => {
-  const { apiSpec, authRequired, disableCors, healthCheck, serviceName } =
+  const { apiSpec, authRequired, disableCors, healthCheck, subsystemName } =
     options;
 
   let healthMiddleware: Handler = healthRouter;
@@ -57,7 +57,7 @@ export const createPreMiddleware = (
     ...sanitizeMiddleware,
     ...corsMiddleware,
     ...openApiValidatorMiddleware,
-    makeContextMiddleware(serviceName),
+    makeContextMiddleware(subsystemName ? "http." + subsystemName : "http"),
     ...authMiddleware,
     createScopeValidator(),
   ];

--- a/express/src/middleware/context.ts
+++ b/express/src/middleware/context.ts
@@ -6,10 +6,11 @@ import {
   safReportersStorage,
   type Auth,
   defaultErrorReporter,
+  getServiceName,
 } from "@saflib/node";
 import type { Handler } from "express";
 
-export const makeContextMiddleware = (serviceName: string) => {
+export const makeContextMiddleware = (subsystemName: string) => {
   const contextMiddleware: Handler = (req, _res, next) => {
     const operationName =
       req.openapi?.schema.operationId ??
@@ -35,7 +36,8 @@ export const makeContextMiddleware = (serviceName: string) => {
 
     const context: SafContext = {
       requestId: reqId,
-      serviceName,
+      serviceName: getServiceName(),
+      subsystemName,
       operationName,
       auth,
     };

--- a/express/src/middleware/scopes.test.ts
+++ b/express/src/middleware/scopes.test.ts
@@ -44,6 +44,7 @@ describe("createScopeValidator", () => {
   const mockContext: SafContext = {
     requestId: "123",
     serviceName: "test",
+    subsystemName: "test",
     operationName: "test",
   };
 

--- a/grpc-node/context.ts
+++ b/grpc-node/context.ts
@@ -9,6 +9,7 @@ import {
   safContextStorage,
   type SafReporters,
   safReportersStorage,
+  getServiceName,
 } from "@saflib/node";
 import { SafAuth } from "@saflib/grpc-specs";
 import { createLogger } from "@saflib/node";
@@ -23,7 +24,7 @@ export type SafServiceImplementationWrapper = (
 
 export const addSafContext: SafServiceImplementationWrapper = (
   impl,
-  serviceName,
+  subsystemName,
 ) => {
   const wrappedService: UntypedServiceImplementation = {};
 
@@ -49,7 +50,8 @@ export const addSafContext: SafServiceImplementationWrapper = (
       }
       const context: SafContext = {
         requestId: reqId,
-        serviceName,
+        serviceName: getServiceName(),
+        subsystemName,
         operationName: methodName,
         auth,
       };

--- a/grpc-node/context.ts
+++ b/grpc-node/context.ts
@@ -30,7 +30,7 @@ export const addSafContext: SafServiceImplementationWrapper = (
   for (const [methodName, methodImpl] of Object.entries(impl)) {
     const wrappedMethod: UntypedHandleCall = (call: any, callback: any) => {
       // Create the context for this request
-      const reqId = call.request?.request?.id || "no-request-id";
+      const reqId: string = call.request?.request?.id || "no-request-id";
       let auth: Auth | undefined = undefined;
       const authFromRequest = call.request.auth;
       if (authFromRequest instanceof SafAuth) {
@@ -53,7 +53,7 @@ export const addSafContext: SafServiceImplementationWrapper = (
         operationName: methodName,
         auth,
       };
-      const logger = createLogger(reqId);
+      const logger = createLogger(context);
       const reporters: SafReporters = {
         log: logger,
         reportError: defaultErrorReporter,

--- a/node/index.ts
+++ b/node/index.ts
@@ -2,6 +2,7 @@ export * from "./src/logger.ts";
 export * from "./src/reporters.ts";
 export * from "./src/context.ts";
 export * from "./src/errors.ts";
+export * from "./src/loki.ts";
 export type { Logger } from "winston";
 
 export * from "./src/types.ts";

--- a/node/package.json
+++ b/node/package.json
@@ -6,11 +6,6 @@
   "exports": {
     ".": "./index.ts"
   },
-  "scripts": {
-    "test": "vitest run",
-    "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
-  },
   "dependencies": {
     "winston": "^3.0.0"
   },

--- a/node/package.json
+++ b/node/package.json
@@ -7,7 +7,8 @@
     ".": "./index.ts"
   },
   "dependencies": {
-    "winston": "^3.0.0"
+    "winston": "^3.0.0",
+    "winston-loki": "^6.1.3"
   },
   "devDependencies": {
     "@saflib/vitest": "*"

--- a/node/src/context.ts
+++ b/node/src/context.ts
@@ -57,6 +57,9 @@ export const setServiceName = (name: string) => {
 };
 
 export const getServiceName = (): string => {
+  if (process.env.NODE_ENV === "test") {
+    return "test";
+  }
   if (!serviceName) {
     throw new Error("Service name is not set");
   }

--- a/node/src/context.ts
+++ b/node/src/context.ts
@@ -4,8 +4,9 @@ import crypto from "crypto";
 
 export const testContext: SafContext = {
   requestId: "test-id",
-  serviceName: "test-service",
-  operationName: "test-operation",
+  serviceName: "test",
+  subsystemName: "test",
+  operationName: "test",
 };
 
 export const safContextStorage = new AsyncLocalStorage<SafContext>();
@@ -49,3 +50,15 @@ export function generateRequestId(): string {
     randomBytes.toString("hex", 10, 16),
   ].join("-");
 }
+
+let serviceName: string | undefined = undefined;
+export const setServiceName = (name: string) => {
+  serviceName = name;
+};
+
+export const getServiceName = (): string => {
+  if (!serviceName) {
+    throw new Error("Service name is not set");
+  }
+  return serviceName;
+};

--- a/node/src/errors.ts
+++ b/node/src/errors.ts
@@ -57,8 +57,14 @@ export const defaultErrorReporter: ErrorReporter = (error, options) => {
   });
 };
 
-export const makeServiceErrorReporter = (
-  serviceName: string,
+/**
+ * During setup, subsystems should use this to create their own
+ * set of reporters. "Operation name" should be the name of the
+ * function.
+ */
+export const makeSubsystemErrorReporter = (
+  subsystemName: string,
+  operationName: string,
   logger: Logger,
 ): ErrorReporter => {
   return (error, options) => {
@@ -77,9 +83,9 @@ export const makeServiceErrorReporter = (
       level: options?.level || "error",
       extra: options?.extra || {},
       tags: {
-        "service.name": serviceName,
-        "operation.name": "(none)",
-        "request.id": "(none)",
+        "subsystem.name": subsystemName,
+        "operation.name": operationName,
+        "request.id": "none",
       },
     };
 

--- a/node/src/logger.ts
+++ b/node/src/logger.ts
@@ -79,21 +79,23 @@ export const createLogger = (options?: SafContext): Logger => {
   if (!options) {
     throw new Error("SAF Context is required outside of unit tests");
   }
+  /*
+   * I think I need to nail down my infra terminology here
+   *
+   * Host - A physical machine running some set of services.
+   * Service - A cohesive backend for a domain. Auth, Product, AI, Payment, Logging.
+   *   | Includes everything from the db layer up to the API layer.
+   * Subsystem - A distinct long-running server or thread. HTTP, GRPC, Cron, Jobs.
+   *
+   * A service may run all its subsystems on one single host, or spread them across
+   * a number of hosts, with different hosts running different subsystems.
+   * Each service has a single image, which runs subsystems based on env variables.
+   */
   const snakeCaseOptions = {
+    server_name: options.serviceName.split(".")[0],
     service_name: options.serviceName,
     operation_name: options.operationName,
     request_id: options.requestId,
   };
   return baseLogger.child(snakeCaseOptions);
-};
-
-/**
- * Service loggers should only be used for service-level events, such as service startup.
- */
-export const createServiceLogger = (serviceName: string): Logger => {
-  return baseLogger.child({
-    service_name: serviceName,
-    operation_name: "(none)",
-    request_id: "(none)",
-  });
 };

--- a/node/src/logger.ts
+++ b/node/src/logger.ts
@@ -2,7 +2,7 @@ import winston, { type Logger, format } from "winston";
 import { type TransformableInfo } from "logform";
 import { Writable } from "node:stream";
 import { type SafContext } from "./types.ts";
-import { testContext } from "./context.ts";
+import { getServiceName, testContext } from "./context.ts";
 
 export const consoleTransport = new winston.transports.Console({
   silent: process.env.NODE_ENV === "test",
@@ -94,6 +94,7 @@ export const createLogger = (options?: LoggerContext): Logger => {
    * Each service has a single image, which runs subsystems based on env variables.
    */
   const snakeCaseOptions = {
+    service_name: getServiceName(),
     subsystem_name: options.subsystemName,
     operation_name: options.operationName,
     request_id: options.requestId,

--- a/node/src/logger.ts
+++ b/node/src/logger.ts
@@ -65,6 +65,8 @@ export const removeAllSimpleStreamTransports = () => {
 
 let allStreamTransports: winston.transports.StreamTransportInstance[] = [];
 
+type LoggerContext = Omit<SafContext, "serviceName">;
+
 /**
  * Creates a child logger with the specified request ID. Any servers or processors
  * should use this to create a unique logger for each request or job or what have you.
@@ -72,7 +74,7 @@ let allStreamTransports: winston.transports.StreamTransportInstance[] = [];
  * by the caller, such as in the proto envelope, so that requests which span processes
  * can be correlated.
  */
-export const createLogger = (options?: SafContext): Logger => {
+export const createLogger = (options?: LoggerContext): Logger => {
   if (!options && process.env.NODE_ENV === "test") {
     return baseLogger.child(testContext);
   }
@@ -92,8 +94,7 @@ export const createLogger = (options?: SafContext): Logger => {
    * Each service has a single image, which runs subsystems based on env variables.
    */
   const snakeCaseOptions = {
-    server_name: options.serviceName.split(".")[0],
-    service_name: options.serviceName,
+    subsystem_name: options.subsystemName,
     operation_name: options.operationName,
     request_id: options.requestId,
   };

--- a/node/src/logger.ts
+++ b/node/src/logger.ts
@@ -79,7 +79,12 @@ export const createLogger = (options?: SafContext): Logger => {
   if (!options) {
     throw new Error("SAF Context is required outside of unit tests");
   }
-  return baseLogger.child(options);
+  const snakeCaseOptions = {
+    service_name: options.serviceName,
+    operation_name: options.operationName,
+    request_id: options.requestId,
+  };
+  return baseLogger.child(snakeCaseOptions);
 };
 
 /**
@@ -87,8 +92,8 @@ export const createLogger = (options?: SafContext): Logger => {
  */
 export const createServiceLogger = (serviceName: string): Logger => {
   return baseLogger.child({
-    serviceName,
-    operationName: "(none)",
-    requestId: "(none)",
+    service_name: serviceName,
+    operation_name: "(none)",
+    request_id: "(none)",
   });
 };

--- a/node/src/loki.ts
+++ b/node/src/loki.ts
@@ -1,0 +1,14 @@
+import winston from "winston";
+import LokiTransport from "winston-loki";
+import { addTransport } from "./logger.ts";
+
+export const addLokiTransport = () => {
+  addTransport(
+    // TODO: use env variables
+    new LokiTransport({
+      host: "http://loki:3100",
+      format: winston.format.json(),
+      useWinstonMetaAsLabels: true,
+    }),
+  );
+};

--- a/node/src/loki.ts
+++ b/node/src/loki.ts
@@ -1,14 +1,22 @@
 import winston from "winston";
 import LokiTransport from "winston-loki";
 import { addTransport } from "./logger.ts";
+import { getServiceName } from "./context.ts";
 
 export const addLokiTransport = () => {
+  const serviceName = getServiceName();
+  if (!serviceName) {
+    throw new Error("Service name is not set");
+  }
   addTransport(
     // TODO: use env variables
     new LokiTransport({
       host: "http://loki:3100",
       format: winston.format.json(),
       useWinstonMetaAsLabels: true,
+      labels: {
+        service_name: serviceName,
+      },
     }),
   );
 };

--- a/node/src/reporters.ts
+++ b/node/src/reporters.ts
@@ -1,6 +1,7 @@
 import { createLogger } from "./logger.ts";
 import type { SafReporters } from "./types.ts";
 import { AsyncLocalStorage } from "async_hooks";
+import { makeSubsystemErrorReporter } from "./errors.ts";
 
 export const safReportersStorage = new AsyncLocalStorage<SafReporters>();
 
@@ -17,4 +18,24 @@ export const getSafReporters = (): SafReporters => {
     throw new Error("SafReporters not found");
   }
   return store;
+};
+
+export const makeSubsystemReporters = (
+  subsystemName: string,
+  operationName: string,
+): SafReporters => {
+  const logger = createLogger({
+    subsystemName,
+    operationName,
+    requestId: "none",
+  });
+  const reportError = makeSubsystemErrorReporter(
+    subsystemName,
+    operationName,
+    logger,
+  );
+  return {
+    log: logger,
+    reportError,
+  };
 };

--- a/node/src/types.ts
+++ b/node/src/types.ts
@@ -20,11 +20,24 @@ export interface SafContext {
   requestId: string;
 
   /*
-   * Format: "{service}.{subsystem}"
-   * e.g. api.http or api.grpc.
-   * The former name should match the docker service and npm package name, the latter should match a file in the package folder.
+   * Format: "{service}"
+   * e.g. "auth", "payment", "logging", or the name of a product.
+   * The name should match the docker service and npm package name.
    */
   serviceName: string;
+
+  /*
+   * Format: "{subsystem}"
+   * e.g. "http" or "grpc". Can be namespaced, like:
+   * - "http.email": an express router with apis that begin with /email/*
+   * - "grpc.schedule": a gRPC service called "Schedule".
+   * - "cron.clean": a set of cron jobs that regularly delete old data.
+   * - "task.campaigns": async tasks queues associated with emails, SMS, etc.
+   * - "ws.notifications": websocket for notifications.
+   *
+   * Basically, a single server or long-running "process".
+   */
+  subsystemName: string;
 
   /*
    * Format: "{method_name}"

--- a/node/vitest.config.js
+++ b/node/vitest.config.js
@@ -1,4 +1,0 @@
-// package-name/vitest.config.js
-import { defaultConfig } from "@saflib/vitest/vitest.config.js";
-
-export default defaultConfig;

--- a/package-lock.json
+++ b/package-lock.json
@@ -238,7 +238,8 @@
     "node": {
       "name": "@saflib/node",
       "dependencies": {
-        "winston": "^3.0.0"
+        "winston": "^3.0.0",
+        "winston-loki": "^6.1.3"
       },
       "devDependencies": {
         "@saflib/vitest": "*"
@@ -2578,6 +2579,214 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@napi-rs/snappy-android-arm-eabi": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-android-arm-eabi/-/snappy-android-arm-eabi-7.2.2.tgz",
+      "integrity": "sha512-H7DuVkPCK5BlAr1NfSU8bDEN7gYs+R78pSHhDng83QxRnCLmVIZk33ymmIwurmoA1HrdTxbkbuNl+lMvNqnytw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-android-arm64": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-android-arm64/-/snappy-android-arm64-7.2.2.tgz",
+      "integrity": "sha512-2R/A3qok+nGtpVK8oUMcrIi5OMDckGYNoBLFyli3zp8w6IArPRfg1yOfVUcHvpUDTo9T7LOS1fXgMOoC796eQw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-darwin-arm64": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-darwin-arm64/-/snappy-darwin-arm64-7.2.2.tgz",
+      "integrity": "sha512-USgArHbfrmdbuq33bD5ssbkPIoT7YCXCRLmZpDS6dMDrx+iM7eD2BecNbOOo7/v1eu6TRmQ0xOzeQ6I/9FIi5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-darwin-x64": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-darwin-x64/-/snappy-darwin-x64-7.2.2.tgz",
+      "integrity": "sha512-0APDu8iO5iT0IJKblk2lH0VpWSl9zOZndZKnBYIc+ei1npw2L5QvuErFOTeTdHBtzvUHASB+9bvgaWnQo4PvTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-freebsd-x64": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-freebsd-x64/-/snappy-freebsd-x64-7.2.2.tgz",
+      "integrity": "sha512-mRTCJsuzy0o/B0Hnp9CwNB5V6cOJ4wedDTWEthsdKHSsQlO7WU9W1yP7H3Qv3Ccp/ZfMyrmG98Ad7u7lG58WXA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-linux-arm-gnueabihf": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-arm-gnueabihf/-/snappy-linux-arm-gnueabihf-7.2.2.tgz",
+      "integrity": "sha512-v1uzm8+6uYjasBPcFkv90VLZ+WhLzr/tnfkZ/iD9mHYiULqkqpRuC8zvc3FZaJy5wLQE9zTDkTJN1IvUcZ+Vcg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-linux-arm64-gnu": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-arm64-gnu/-/snappy-linux-arm64-gnu-7.2.2.tgz",
+      "integrity": "sha512-LrEMa5pBScs4GXWOn6ZYXfQ72IzoolZw5txqUHVGs8eK4g1HR9HTHhb2oY5ySNaKakG5sOgMsb1rwaEnjhChmQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-linux-arm64-musl": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-arm64-musl/-/snappy-linux-arm64-musl-7.2.2.tgz",
+      "integrity": "sha512-3orWZo9hUpGQcB+3aTLW7UFDqNCQfbr0+MvV67x8nMNYj5eAeUtMmUE/HxLznHO4eZ1qSqiTwLbVx05/Socdlw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-linux-x64-gnu": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-x64-gnu/-/snappy-linux-x64-gnu-7.2.2.tgz",
+      "integrity": "sha512-jZt8Jit/HHDcavt80zxEkDpH+R1Ic0ssiVCoueASzMXa7vwPJeF4ZxZyqUw4qeSy7n8UUExomu8G8ZbP6VKhgw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-linux-x64-musl": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-x64-musl/-/snappy-linux-x64-musl-7.2.2.tgz",
+      "integrity": "sha512-Dh96IXgcZrV39a+Tej/owcd9vr5ihiZ3KRix11rr1v0MWtVb61+H1GXXlz6+Zcx9y8jM1NmOuiIuJwkV4vZ4WA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-win32-arm64-msvc": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-win32-arm64-msvc/-/snappy-win32-arm64-msvc-7.2.2.tgz",
+      "integrity": "sha512-9No0b3xGbHSWv2wtLEn3MO76Yopn1U2TdemZpCaEgOGccz1V+a/1d16Piz3ofSmnA13HGFz3h9NwZH9EOaIgYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-win32-ia32-msvc": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-win32-ia32-msvc/-/snappy-win32-ia32-msvc-7.2.2.tgz",
+      "integrity": "sha512-QiGe+0G86J74Qz1JcHtBwM3OYdTni1hX1PFyLRo3HhQUSpmi13Bzc1En7APn+6Pvo7gkrcy81dObGLDSxFAkQQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-win32-x64-msvc": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-win32-x64-msvc/-/snappy-win32-x64-msvc-7.2.2.tgz",
+      "integrity": "sha512-a43cyx1nK0daw6BZxVcvDEXxKMFLSBSDTAhsFD0VqSKcC7MGUBMaqyoWUcMiI7LBSz4bxUmxDWKfCYzpEmeb3w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@noble/hashes": {
@@ -5348,6 +5557,15 @@
       "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
       "license": "MIT"
     },
+    "node_modules/async-exit-hook": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/async-exit-hook/-/async-exit-hook-2.0.1.tgz",
+      "integrity": "sha512-NW2cX8m1Q7KPA7a5M2ULQeZ2wR5qI5PAbw5L0UOMxdioVk9PMZ0h1TmyZEkPYrCvYjDlFICusOu1dlEKAAeXBw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -5617,6 +5835,18 @@
       },
       "engines": {
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/btoa": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/btoa/-/btoa-1.2.1.tgz",
+      "integrity": "sha512-SB4/MIGlsiVkMcHmT+pSmIPoNDoHg+7cMzmt3Uxt628MTz2487DKSqK/fuhFBrkuqrYv5UCEnACpF4dTFNKc/g==",
+      "license": "(MIT OR Apache-2.0)",
+      "bin": {
+        "btoa": "bin/btoa.js"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/buffer": {
@@ -12147,6 +12377,35 @@
         "node": ">=8.0.0"
       }
     },
+    "node_modules/snappy": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/snappy/-/snappy-7.2.2.tgz",
+      "integrity": "sha512-iADMq1kY0v3vJmGTuKcFWSXt15qYUz7wFkArOrsSg0IFfI3nJqIJvK2/ZbEIndg7erIJLtAVX2nSOqPz7DcwbA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/snappy-android-arm-eabi": "7.2.2",
+        "@napi-rs/snappy-android-arm64": "7.2.2",
+        "@napi-rs/snappy-darwin-arm64": "7.2.2",
+        "@napi-rs/snappy-darwin-x64": "7.2.2",
+        "@napi-rs/snappy-freebsd-x64": "7.2.2",
+        "@napi-rs/snappy-linux-arm-gnueabihf": "7.2.2",
+        "@napi-rs/snappy-linux-arm64-gnu": "7.2.2",
+        "@napi-rs/snappy-linux-arm64-musl": "7.2.2",
+        "@napi-rs/snappy-linux-x64-gnu": "7.2.2",
+        "@napi-rs/snappy-linux-x64-musl": "7.2.2",
+        "@napi-rs/snappy-win32-arm64-msvc": "7.2.2",
+        "@napi-rs/snappy-win32-ia32-msvc": "7.2.2",
+        "@napi-rs/snappy-win32-x64-msvc": "7.2.2"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -13128,6 +13387,12 @@
         "requires-port": "^1.0.0"
       }
     },
+    "node_modules/url-polyfill": {
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/url-polyfill/-/url-polyfill-1.1.13.tgz",
+      "integrity": "sha512-tXzkojrv2SujumYthZ/WjF7jaSfNhSXlYMpE5AYdL2I3D7DCeo+mch8KtW2rUuKjDg+3VXODXHVgipt8yGY/eQ==",
+      "license": "MIT"
+    },
     "node_modules/url-template": {
       "version": "2.0.8",
       "resolved": "https://registry.npmjs.org/url-template/-/url-template-2.0.8.tgz",
@@ -14019,6 +14284,22 @@
       },
       "engines": {
         "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/winston-loki": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/winston-loki/-/winston-loki-6.1.3.tgz",
+      "integrity": "sha512-DjWtJ230xHyYQWr9mZJa93yhwHttn3JEtSYWP8vXZWJOahiQheUhf+88dSIidbGXB3u0oLweV6G1vkL/ouT62Q==",
+      "license": "MIT",
+      "dependencies": {
+        "async-exit-hook": "2.0.1",
+        "btoa": "^1.2.1",
+        "protobufjs": "^7.2.4",
+        "url-polyfill": "^1.1.12",
+        "winston-transport": "^4.3.0"
+      },
+      "optionalDependencies": {
+        "snappy": "^7.2.2"
       }
     },
     "node_modules/winston-transport": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -46,6 +46,7 @@
         "@saflib/auth-db": "*",
         "@saflib/auth-rpcs": "*",
         "@saflib/auth-spec": "*",
+        "@saflib/email-node": "*",
         "@saflib/express": "*",
         "@saflib/grpc-node": "*",
         "@saflib/monorepo": "*",

--- a/workflows/src/workflow-cli.ts
+++ b/workflows/src/workflow-cli.ts
@@ -91,10 +91,13 @@ export function runWorkflowCli(workflows: WorkflowMeta[]) {
     ),
   });
 
+  // Currently this context is not being used...
+  // Just putting strings here for typing.
   const ctx: SafContext = {
     requestId: reqId,
-    serviceName: "workflows-cli",
+    serviceName: "workflows",
     operationName: "workflow-cli",
+    subsystemName: "workflows",
   };
 
   const reporters: SafReporters = {


### PR DESCRIPTION
Follow-ups to #72 

I got Loki mostly working, but had to make some tweaks to get formatting to work correctly.

I also standardized how I think about backend services being broken down:
* host: a machine (probably virtual) for running services
* service: an abstract, domain service with APIs and such (payment, auth, logging, product, etc)
* subsystem: a server or independent "process" that's part of a service: an http server, a grpc service, websocket server, cron jobs, async tasks, or messaging systems for example.

So I updated the SAF context to match this idea, where now there are service names (which are defined on startup and shared across the entire process) and subsystem names (which are managed by the individual subsystem, provided to operations via the common async local storage).

At this point just Loki has access to this information, but I plan to have exceptions, metrics, and such all have these common attributes as well.