### PR TITLE
Logging and exception reporting improvements, testing

### DIFF
--- a/auth-service/index.ts
+++ b/auth-service/index.ts
@@ -33,7 +33,7 @@ export async function startAuthService(options?: StartAuthServiceOptions) {
     log.info("Auth service startup complete.");
     // TODO: Remove this
     logError(new Error("Test error"), {
-      level: "debug",
+      level: "warning",
       extra: {
         status: "success",
       },

--- a/auth-service/index.ts
+++ b/auth-service/index.ts
@@ -15,10 +15,7 @@ interface StartAuthServiceOptions {
 }
 
 export async function startAuthService(options?: StartAuthServiceOptions) {
-  const { log, reportError } = makeSubsystemReporters(
-    "init",
-    "startAuthService",
-  );
+  const { log, logError } = makeSubsystemReporters("init", "startAuthService");
   try {
     log.info("Starting auth service...");
     log.info("Connecting to auth DB...");
@@ -35,7 +32,7 @@ export async function startAuthService(options?: StartAuthServiceOptions) {
     startExpressServer(app);
     log.info("Auth service startup complete.");
   } catch (error) {
-    reportError(error);
+    logError(error);
   }
 }
 

--- a/auth-service/index.ts
+++ b/auth-service/index.ts
@@ -31,6 +31,13 @@ export async function startAuthService(options?: StartAuthServiceOptions) {
     const app = createApp({ dbKey, callbacks: options?.callbacks ?? {} });
     startExpressServer(app);
     log.info("Auth service startup complete.");
+    // TODO: Remove this
+    logError(new Error("Test error"), {
+      level: "debug",
+      extra: {
+        status: "success",
+      },
+    });
   } catch (error) {
     logError(error);
   }

--- a/auth-service/index.ts
+++ b/auth-service/index.ts
@@ -31,13 +31,6 @@ export async function startAuthService(options?: StartAuthServiceOptions) {
     const app = createApp({ dbKey, callbacks: options?.callbacks ?? {} });
     startExpressServer(app);
     log.info("Auth service startup complete.");
-    // TODO: Remove this
-    logError(new Error("Test error"), {
-      level: "warning",
-      extra: {
-        status: "success",
-      },
-    });
   } catch (error) {
     logError(error);
   }

--- a/cron-service/index.ts
+++ b/cron-service/index.ts
@@ -36,7 +36,7 @@ export function main(options: CronServiceOptions) {
     log.info("Cron service startup complete.");
     // TODO: Remove this
     logError(new Error("Test error"), {
-      level: "debug",
+      level: "warning",
       extra: {
         status: "success",
       },

--- a/cron-service/index.ts
+++ b/cron-service/index.ts
@@ -34,13 +34,6 @@ export function main(options: CronServiceOptions) {
     });
     startExpressServer(httpApp);
     log.info("Cron service startup complete.");
-    // TODO: Remove this
-    logError(new Error("Test error"), {
-      level: "warning",
-      extra: {
-        status: "success",
-      },
-    });
   } catch (error) {
     logError(error);
   }

--- a/cron-service/index.ts
+++ b/cron-service/index.ts
@@ -16,7 +16,7 @@ export interface CronServiceOptions {
 }
 
 export function main(options: CronServiceOptions) {
-  const { log, reportError } = makeSubsystemReporters("init", "main");
+  const { log, logError } = makeSubsystemReporters("init", "main");
   try {
     log.info("Starting cron service...");
     log.info("Connecting to cron DB...");
@@ -35,6 +35,6 @@ export function main(options: CronServiceOptions) {
     startExpressServer(httpApp);
     log.info("Cron service startup complete.");
   } catch (error) {
-    reportError(error);
+    logError(error);
   }
 }

--- a/cron-service/index.ts
+++ b/cron-service/index.ts
@@ -6,7 +6,7 @@ import type { JobsMap } from "./src/types.ts";
 import type { DbKey, DbOptions } from "@saflib/drizzle-sqlite3";
 import { makeSubsystemReporters } from "@saflib/node";
 
-export type { JobsMap } from "./src/types.ts";
+export type { JobsMap, CustomLogError } from "./src/types.ts";
 
 export interface CronServiceOptions {
   subsystemName?: string;

--- a/cron-service/index.ts
+++ b/cron-service/index.ts
@@ -34,6 +34,13 @@ export function main(options: CronServiceOptions) {
     });
     startExpressServer(httpApp);
     log.info("Cron service startup complete.");
+    // TODO: Remove this
+    logError(new Error("Test error"), {
+      level: "debug",
+      extra: {
+        status: "success",
+      },
+    });
   } catch (error) {
     logError(error);
   }

--- a/cron-service/src/index.ts
+++ b/cron-service/src/index.ts
@@ -149,6 +149,14 @@ export const startJobs = async (
             jobConfig,
             dbKey,
           );
+
+          // TODO: Remove this
+          logError(new Error("Test error"), {
+            level: "debug",
+            extra: {
+              status: "success",
+            },
+          });
         } catch (error) {
           logError(error);
         }

--- a/cron-service/src/index.ts
+++ b/cron-service/src/index.ts
@@ -152,7 +152,7 @@ export const startJobs = async (
 
           // TODO: Remove this
           logError(new Error("Test error"), {
-            level: "debug",
+            level: "warning",
             extra: {
               status: "success",
             },

--- a/cron-service/src/index.ts
+++ b/cron-service/src/index.ts
@@ -149,14 +149,6 @@ export const startJobs = async (
             jobConfig,
             dbKey,
           );
-
-          // TODO: Remove this
-          logError(new Error("Test error"), {
-            level: "warning",
-            extra: {
-              status: "success",
-            },
-          });
         } catch (error) {
           logError(error);
         }

--- a/cron-service/src/index.ts
+++ b/cron-service/src/index.ts
@@ -77,6 +77,8 @@ async function executeJobWithHandling(
               }),
             );
           }
+        } else {
+          logError(error);
         }
 
         // Determine the job status

--- a/cron-service/src/types.ts
+++ b/cron-service/src/types.ts
@@ -1,3 +1,12 @@
+export interface CustomLogErrorMeta {
+  jobName: string;
+}
+
+export type CustomLogError = (
+  error: Error,
+  meta: CustomLogErrorMeta,
+) => boolean;
+
 /**
  * Configuration for a single cron job.
  */
@@ -10,6 +19,8 @@ export interface JobConfig {
   enabled: boolean;
   /** Optional job execution timeout in seconds (defaults to 10 if not provided). */
   timeoutSeconds?: number;
+  /** Optional error reporter for the job. Returns true if the error was logged. */
+  customLogError?: CustomLogError;
 }
 
 /**

--- a/drizzle-sqlite3/errors.ts
+++ b/drizzle-sqlite3/errors.ts
@@ -24,8 +24,8 @@ export function queryWrapper<T, A extends any[]>(
       }
       // In this case, something unhandled happened. Report it, then throw an error
       // without any details, lest the calling code tries to handle it.
-      const { reportError } = getSafReporters();
-      reportError(error);
+      const { logError } = getSafReporters();
+      logError(error);
       throw new UnhandledDatabaseError();
     }
   };

--- a/drizzle-sqlite3/instances.ts
+++ b/drizzle-sqlite3/instances.ts
@@ -30,7 +30,7 @@ export class DbManager<S extends Schema, C extends Config> {
    * If onDisk is a string, the database will be created at the given (absolute) path.
    */
   connect = (options?: DbOptions): DbKey => {
-    const { log, reportError } = makeSubsystemReporters(
+    const { log, logError } = makeSubsystemReporters(
       options?.name ? `db.${options.name}` : "db",
       "connect",
     );
@@ -45,7 +45,7 @@ export class DbManager<S extends Schema, C extends Config> {
       if (options?.doNotCreate) {
         const exists = fs.existsSync(dbStorage);
         if (!exists && process.env.CREATE_DB_ALLOWED !== "true") {
-          reportError(new Error(`Database file does not exist: ${dbStorage}`));
+          logError(new Error(`Database file does not exist: ${dbStorage}`));
         } else if (!exists) {
           log.warn(`Creating database file: ${dbStorage}`);
         } else {

--- a/email-node/client/email-client.ts
+++ b/email-node/client/email-client.ts
@@ -1,3 +1,4 @@
+import { getSafReporters } from "@saflib/node";
 import * as nodemailer from "nodemailer";
 import type { Transporter } from "nodemailer";
 
@@ -78,6 +79,8 @@ export class EmailClient {
   }
 
   async sendEmail(options: EmailOptions): Promise<EmailResult> {
+    const { log } = getSafReporters();
+
     if (!options.to && !options.cc && !options.bcc) {
       throw new Error("No recipients specified");
     }
@@ -95,6 +98,15 @@ export class EmailClient {
     }
 
     const info = await this.transporter.sendMail(options);
+
+    log.info("Email sent", {
+      from: options.from,
+      subject: options.subject,
+      messageId: info.messageId,
+      accepted: info.accepted.length,
+      rejected: info.rejected.length,
+      response: info.response,
+    });
 
     return {
       messageId: info.messageId,

--- a/express/src/index.ts
+++ b/express/src/index.ts
@@ -1,5 +1,8 @@
 // middleware
-export { everyRequestLogger as httpLogger } from "./middleware/httpLogger.ts";
+export {
+  everyRequestLogger,
+  unsafeRequestLogger,
+} from "./middleware/httpLogger.ts";
 export { healthRouter, createHealthHandler } from "./middleware/health.ts";
 export { auth } from "./middleware/auth.ts";
 export { corsRouter } from "./middleware/cors.ts";

--- a/express/src/index.ts
+++ b/express/src/index.ts
@@ -1,5 +1,5 @@
 // middleware
-export { httpLogger } from "./middleware/httpLogger.ts";
+export { everyRequestLogger as httpLogger } from "./middleware/httpLogger.ts";
 export { healthRouter, createHealthHandler } from "./middleware/health.ts";
 export { auth } from "./middleware/auth.ts";
 export { corsRouter } from "./middleware/cors.ts";

--- a/express/src/middleware/composition.ts
+++ b/express/src/middleware/composition.ts
@@ -5,7 +5,7 @@ import { auth } from "./auth.ts";
 import { corsRouter } from "./cors.ts";
 import { errorHandler, notFoundHandler } from "./errors.ts";
 import { createHealthHandler, healthRouter } from "./health.ts";
-import { httpLogger } from "./httpLogger.ts";
+import { everyRequestLogger, unsafeRequestLogger } from "./httpLogger.ts";
 import { createOpenApiValidator } from "./openapi.ts";
 import helmet from "helmet";
 import { makeContextMiddleware } from "./context.ts";
@@ -51,13 +51,14 @@ export const createPreMiddleware = (
   return [
     helmet(),
     healthMiddleware, // before httpLogger to avoid polluting logs
-    httpLogger,
+    everyRequestLogger,
     json(),
     urlencoded({ extended: false }),
     ...sanitizeMiddleware,
     ...corsMiddleware,
     ...openApiValidatorMiddleware,
     makeContextMiddleware(subsystemName ? "http." + subsystemName : "http"),
+    unsafeRequestLogger,
     ...authMiddleware,
     createScopeValidator(),
   ];

--- a/express/src/middleware/context.ts
+++ b/express/src/middleware/context.ts
@@ -44,7 +44,7 @@ export const makeContextMiddleware = (subsystemName: string) => {
 
     const reporters: SafReporters = {
       log: createLogger(context),
-      reportError: defaultErrorReporter,
+      logError: defaultErrorReporter,
     };
 
     safContextStorage.run(context, () => {

--- a/express/src/middleware/errors.ts
+++ b/express/src/middleware/errors.ts
@@ -25,7 +25,7 @@ export const errorHandler = (
   // TODO: Remove this
   const { logError } = getSafReporters();
   logError(new Error("Test error"), {
-    level: "debug",
+    level: "warning",
     extra: {
       status,
     },

--- a/express/src/middleware/errors.ts
+++ b/express/src/middleware/errors.ts
@@ -1,6 +1,6 @@
 import createError, { HttpError } from "http-errors";
 import type { Request, Response, NextFunction, Handler } from "express";
-import { getSafReporters, safReportersStorage } from "@saflib/node";
+import { safReportersStorage } from "@saflib/node";
 /**
  * 404 Handler
  * Catches requests to undefined routes
@@ -21,15 +21,6 @@ export const errorHandler = (
 ): void => {
   // Log error
   const status = err.status || 500;
-
-  // TODO: Remove this
-  const { logError } = getSafReporters();
-  logError(new Error("Test error"), {
-    level: "warning",
-    extra: {
-      status,
-    },
-  });
 
   if (status >= 500) {
     if (process.env.NODE_ENV === "test") {

--- a/express/src/middleware/errors.ts
+++ b/express/src/middleware/errors.ts
@@ -1,6 +1,6 @@
 import createError, { HttpError } from "http-errors";
 import type { Request, Response, NextFunction, Handler } from "express";
-import { safReportersStorage } from "@saflib/node";
+import { getSafReporters, safReportersStorage } from "@saflib/node";
 /**
  * 404 Handler
  * Catches requests to undefined routes
@@ -21,6 +21,15 @@ export const errorHandler = (
 ): void => {
   // Log error
   const status = err.status || 500;
+
+  // TODO: Remove this
+  const { logError } = getSafReporters();
+  logError(new Error("Test error"), {
+    level: "debug",
+    extra: {
+      status,
+    },
+  });
 
   if (status >= 500) {
     if (process.env.NODE_ENV === "test") {

--- a/express/src/middleware/errors.ts
+++ b/express/src/middleware/errors.ts
@@ -28,7 +28,7 @@ export const errorHandler = (
     }
     const store = safReportersStorage.getStore();
     if (store) {
-      store.reportError(err);
+      store.logError(err);
     } else {
       console.log("Error", err);
     }

--- a/express/src/middleware/httpLogger.ts
+++ b/express/src/middleware/httpLogger.ts
@@ -1,12 +1,13 @@
 import type { Handler } from "express";
 import morgan from "morgan";
+import { getSafReporters } from "@saflib/node";
 
 /**
  * HTTP request logging middleware using Morgan.
- * Includes request ID in the log output for request tracing.
+ * Mainly used for debugging in development, not propagated to something like Loki in production.
  * Format: ":date[iso] <:id> :method :url :status :response-time ms - :res[content-length]"
  */
-export const httpLogger: Handler = (() => {
+export const everyRequestLogger: Handler = (() => {
   if (process.env.NODE_ENV === "test") {
     return (_, __, next) => next();
   }
@@ -19,3 +20,36 @@ export const httpLogger: Handler = (() => {
     ":date[iso] <:id> :method :url :status :response-time ms - :res[content-length]",
   );
 })();
+
+const safeMethods = ["GET", "HEAD", "OPTIONS"];
+
+/**
+ * For tracking requests which are "unsafe", that is they make some sort of change.
+ * These are logged to Loki or whatever transport Winston is hooked up to.
+ * They use OpenAPI operationIds to help label the request; these should always be set.
+ */
+export const unsafeRequestLogger: Handler = (req, res, next) => {
+  if (req.method && safeMethods.includes(req.method)) {
+    return next();
+  }
+
+  const { log } = getSafReporters();
+  const operationName = req.openapi?.schema?.operationId || "unknown";
+  res.on("finish", () => {
+    log.info("Request finished", {
+      operationName,
+      method: req.method,
+      originalUrl: req.originalUrl,
+      status: res.statusCode,
+    });
+    if (operationName === "unknown") {
+      log.warn("Unknown operation name", {
+        method: req.method,
+        originalUrl: req.originalUrl,
+        status: res.statusCode,
+      });
+    }
+  });
+
+  next();
+};

--- a/grpc-node/context.ts
+++ b/grpc-node/context.ts
@@ -77,7 +77,7 @@ export const addSafContext: SafServiceImplementationWrapper = (
             }
             // TODO: Remove this
             reporters.logError(new Error("Test error"), {
-              level: "debug",
+              level: "warning",
               extra: {
                 status: status.OK,
               },

--- a/grpc-node/context.ts
+++ b/grpc-node/context.ts
@@ -75,6 +75,13 @@ export const addSafContext: SafServiceImplementationWrapper = (
                 );
               });
             }
+            // TODO: Remove this
+            reporters.logError(new Error("Test error"), {
+              level: "debug",
+              extra: {
+                status: status.OK,
+              },
+            });
             return result;
           } catch (error) {
             const e = error as Error;

--- a/grpc-node/context.ts
+++ b/grpc-node/context.ts
@@ -75,13 +75,6 @@ export const addSafContext: SafServiceImplementationWrapper = (
                 );
               });
             }
-            // TODO: Remove this
-            reporters.logError(new Error("Test error"), {
-              level: "warning",
-              extra: {
-                status: status.OK,
-              },
-            });
             return result;
           } catch (error) {
             const e = error as Error;

--- a/grpc-node/context.ts
+++ b/grpc-node/context.ts
@@ -58,7 +58,7 @@ export const addSafContext: SafServiceImplementationWrapper = (
       const logger = createLogger(context);
       const reporters: SafReporters = {
         log: logger,
-        reportError: defaultErrorReporter,
+        logError: defaultErrorReporter,
       };
       // Run the original implementation within the context
       return safContextStorage.run(context, () => {
@@ -68,7 +68,7 @@ export const addSafContext: SafServiceImplementationWrapper = (
             if (result instanceof Promise) {
               return result.catch((error) => {
                 const e = error as Error;
-                defaultErrorReporter(e);
+                reporters.logError(e);
                 callback(
                   { code: status.INTERNAL, message: e.message } as any,
                   null,
@@ -78,7 +78,7 @@ export const addSafContext: SafServiceImplementationWrapper = (
             return result;
           } catch (error) {
             const e = error as Error;
-            defaultErrorReporter(e);
+            reporters.logError(e);
             callback(
               { code: status.INTERNAL, message: e.message } as any,
               null,

--- a/monorepo/index.ts
+++ b/monorepo/index.ts
@@ -22,7 +22,7 @@ export const throwError = async <T>(
   */
   const { result, error } = await promise;
   if (error) {
-    throw new ErrorClass("Failed to update call log", { cause: error });
+    throw new ErrorClass("Unexpected error", { cause: error });
   }
   return result as NonUndefined<T>; // not sure why TS thinks result might be undefined
 };

--- a/node/src/errors.ts
+++ b/node/src/errors.ts
@@ -1,5 +1,5 @@
 import type { Logger } from "winston";
-import { getSafContext, safContextStorage } from "./context.ts";
+import { getSafContext, getServiceName, safContextStorage } from "./context.ts";
 import { getSafReporters } from "./reporters.ts";
 import type {
   ErrorCollector,
@@ -85,15 +85,18 @@ export const makeSubsystemErrorReporter = (
       level: options?.level || "error",
       extra: options?.extra || {},
       tags: {
+        "service.name": getServiceName(),
         "subsystem.name": subsystemName,
         "operation.name": operationName,
-        "request.id": "none",
       },
     };
 
     getErrorCollectors().forEach((collector) => collector(collectorParam));
 
-    logger.log(collectorParam.level, e.message, {
+    const winstonLevel =
+      collectorParam.level === "warning" ? "warn" : collectorParam.level;
+
+    logger.log(winstonLevel, e.message, {
       stack: e.stack,
       ...options?.extra,
     });

--- a/node/src/errors.ts
+++ b/node/src/errors.ts
@@ -45,8 +45,8 @@ export const defaultErrorReporter: ErrorReporter = (error, options) => {
       "service.name": ctx.serviceName,
       "subsystem.name": ctx.subsystemName,
       "operation.name": ctx.operationName,
-      "request.id": ctx.requestId,
-      "user.id": ctx.auth?.userId?.toString() || "none",
+      "request.id": ctx.requestId || "-",
+      "user.id": ctx.auth?.userId?.toString() || "-",
     },
   };
 
@@ -54,7 +54,6 @@ export const defaultErrorReporter: ErrorReporter = (error, options) => {
 
   // Logger already has SAF context incorporated.
   log.log(collectorParam.level, e.message, {
-    stack: e.stack,
     ...options?.extra,
   });
 };

--- a/node/src/errors.ts
+++ b/node/src/errors.ts
@@ -52,8 +52,11 @@ export const defaultErrorReporter: ErrorReporter = (error, options) => {
 
   getErrorCollectors().forEach((collector) => collector(collectorParam));
 
+  const winstonLevel =
+    collectorParam.level === "warning" ? "warn" : collectorParam.level;
+
   // Logger already has SAF context incorporated.
-  log.log(collectorParam.level, e.message, {
+  log.log(winstonLevel, e.message, {
     ...options?.extra,
   });
 };

--- a/node/src/errors.ts
+++ b/node/src/errors.ts
@@ -32,7 +32,7 @@ export const defaultErrorReporter: ErrorReporter = (error, options) => {
 
   const collectorUser: ErrorCollectorParam["user"] | undefined = ctx.auth
     ? {
-        id: ctx.auth.userId,
+        id: ctx.auth.userId.toString() || "",
       }
     : undefined;
 
@@ -43,8 +43,10 @@ export const defaultErrorReporter: ErrorReporter = (error, options) => {
     extra: options?.extra || {},
     tags: {
       "service.name": ctx.serviceName,
+      "subsystem.name": ctx.subsystemName,
       "operation.name": ctx.operationName,
       "request.id": ctx.requestId,
+      "user.id": ctx.auth?.userId?.toString() || "none",
     },
   };
 

--- a/node/src/errors.ts
+++ b/node/src/errors.ts
@@ -97,7 +97,6 @@ export const makeSubsystemErrorReporter = (
       collectorParam.level === "warning" ? "warn" : collectorParam.level;
 
     logger.log(winstonLevel, e.message, {
-      stack: e.stack,
       ...options?.extra,
     });
   };

--- a/node/src/logger.ts
+++ b/node/src/logger.ts
@@ -98,8 +98,8 @@ export const createLogger = (options?: LoggerContext): Logger => {
     service_name: serviceName,
     subsystem_name: serviceName + "." + options.subsystemName,
     operation_name: options.operationName,
-    request_id: options.requestId,
-    user_id: options.auth?.userId,
+    request_id: options.requestId || "-",
+    user_id: options.auth?.userId || "-",
   };
   return baseLogger.child(snakeCaseOptions);
 };

--- a/node/src/logger.ts
+++ b/node/src/logger.ts
@@ -99,6 +99,7 @@ export const createLogger = (options?: LoggerContext): Logger => {
     subsystem_name: serviceName + "." + options.subsystemName,
     operation_name: options.operationName,
     request_id: options.requestId,
+    user_id: options.auth?.userId,
   };
   return baseLogger.child(snakeCaseOptions);
 };

--- a/node/src/reporters.ts
+++ b/node/src/reporters.ts
@@ -10,7 +10,7 @@ export const getSafReporters = (): SafReporters => {
   if (!store && process.env.NODE_ENV === "test") {
     const testReporters: SafReporters = {
       log: createLogger(),
-      reportError: () => {},
+      logError: () => {},
     };
     return testReporters;
   }
@@ -29,13 +29,13 @@ export const makeSubsystemReporters = (
     operationName,
     requestId: "none",
   });
-  const reportError = makeSubsystemErrorReporter(
+  const logError = makeSubsystemErrorReporter(
     subsystemName,
     operationName,
     logger,
   );
   return {
     log: logger,
-    reportError,
+    logError,
   };
 };

--- a/node/src/reporters.ts
+++ b/node/src/reporters.ts
@@ -27,7 +27,6 @@ export const makeSubsystemReporters = (
   const logger = createLogger({
     subsystemName,
     operationName,
-    requestId: "none",
   });
   const logError = makeSubsystemErrorReporter(
     subsystemName,

--- a/node/src/types.ts
+++ b/node/src/types.ts
@@ -114,7 +114,7 @@ export interface SafReporters {
   /*
    *
    */
-  reportError: ErrorReporter;
+  logError: ErrorReporter;
 
   // TODO: Product Events
   // TODO: Errors

--- a/node/src/types.ts
+++ b/node/src/types.ts
@@ -90,7 +90,7 @@ export interface ErrorCollectorParam {
   error: Error;
 
   user?: {
-    id: number;
+    id: string;
     ip_address?: string;
   };
 

--- a/node/src/types.ts
+++ b/node/src/types.ts
@@ -17,7 +17,7 @@ export interface SafContext {
    * and http servers which are directly accessible by clients. Generally, grpc and http servers receive
    * a request ID and should use it to correlate requests across processes.
    */
-  requestId: string;
+  requestId?: string;
 
   /*
    * Format: "{service}"
@@ -96,7 +96,7 @@ export interface ErrorCollectorParam {
 
   level: ErrorLevels;
   extra: Record<string, unknown>;
-  tags: Record<string, string>;
+  tags: Record<string, string | undefined>;
 }
 
 export type ErrorCollector = (param: ErrorCollectorParam) => void;

--- a/workflows/src/workflow-cli.ts
+++ b/workflows/src/workflow-cli.ts
@@ -102,7 +102,7 @@ export function runWorkflowCli(workflows: WorkflowMeta[]) {
 
   const reporters: SafReporters = {
     log: baseLogger,
-    reportError: defaultErrorReporter,
+    logError: defaultErrorReporter,
   };
 
   safReportersStorage.enterWith(reporters);


### PR DESCRIPTION
* reportError -> logError, so as not to conflict with the [`window` interface](https://developer.mozilla.org/en-US/docs/Web/API/Window/reportError)
* Added a bunch of debug logs, to test that main functions, grpc handlers, http handlers, cron jobs, and state machines (not shown) properly log errors to loki and sentry (also not shown). Will remove them later once I'm reasonably confident errors are propagating correctly.
* Added logging for email sends and unsafe http requests.
* Added user id to logs.
* Add custom error handling to cron service
* Update tags and labels so they're comprehensive, include subsystem, user id
* Remove stack from winston-logged error logging, since loki won't take it