### PR TITLE
Add grpc metrics

### DIFF
--- a/auth-service/grpc.ts
+++ b/auth-service/grpc.ts
@@ -2,10 +2,7 @@ import { authDb } from "@saflib/auth-db";
 import { authServiceStorage } from "./context.ts";
 import { addSafContext, makeGrpcServerContextWrapper } from "@saflib/grpc-node";
 import * as grpc from "@grpc/grpc-js";
-import {
-  UsersServiceDefinition,
-  UsersServiceImpl,
-} from "./rpcs/users/index.ts";
+import { UsersServiceDefinition, UsersService } from "./rpcs/users/index.ts";
 import type { AuthServerOptions } from "./types.ts";
 
 export function makeGrpcServer(options: AuthServerOptions): grpc.Server {
@@ -20,9 +17,13 @@ export function makeGrpcServer(options: AuthServerOptions): grpc.Server {
 
   const server = new grpc.Server();
 
+  // TODO: Improve the ergonomics of this. Maybe addSafService(service, )
   server.addService(
-    UsersServiceDefinition,
-    addSafContext(addAuthServiceContext(UsersServiceImpl), "users"),
+    UsersService.definition,
+    addSafContext(
+      addAuthServiceContext(new UsersService()),
+      UsersServiceDefinition,
+    ),
   );
 
   return server;

--- a/auth-service/rpcs/users/index.ts
+++ b/auth-service/rpcs/users/index.ts
@@ -1,9 +1,8 @@
-import type { UntypedServiceImplementation } from "@grpc/grpc-js";
 import { UnimplementedUsersService } from "@saflib/auth-rpcs";
 import { handleGetUserProfile } from "./get-user-profile.ts";
 
 export const UsersServiceDefinition = UnimplementedUsersService.definition;
 
-export const UsersServiceImpl: UntypedServiceImplementation = {
-  GetUserProfile: handleGetUserProfile,
-};
+export class UsersService extends UnimplementedUsersService {
+  GetUserProfile = handleGetUserProfile;
+}

--- a/express/package.json
+++ b/express/package.json
@@ -18,8 +18,7 @@
     "express-prom-bundle": "^8.0.0",
     "helmet": "^8.1.0",
     "http-errors": "^2.0.0",
-    "morgan": "^1.0.0",
-    "prom-client": "^15.1.3"
+    "morgan": "^1.0.0"
   },
   "devDependencies": {
     "@saflib/node-express-dev": "*",

--- a/grpc-node/context.ts
+++ b/grpc-node/context.ts
@@ -2,8 +2,6 @@ import type {
   UntypedServiceImplementation,
   UntypedHandleCall,
   handleUnaryCall,
-  ServerUnaryCall,
-  sendUnaryData,
 } from "@grpc/grpc-js";
 import type { ServiceImplementationWrapper } from "@saflib/grpc-node";
 import {
@@ -13,13 +11,12 @@ import {
   type SafReporters,
   safReportersStorage,
   getServiceName,
-  getSafReporters,
 } from "@saflib/node";
 import { SafAuth } from "@saflib/grpc-specs";
 import { createLogger } from "@saflib/node";
-import { status } from "@grpc/grpc-js";
 import { AsyncLocalStorage } from "async_hooks";
 import { defaultErrorReporter } from "../node/src/errors.ts";
+import { runGrpcMethod } from "./runner.ts";
 
 export type SafServiceImplementationWrapper = (
   impl: UntypedServiceImplementation,
@@ -76,29 +73,6 @@ export const addSafContext: SafServiceImplementationWrapper = (
   }
   return wrappedService;
 };
-
-export function runGrpcMethod(
-  methodImpl: handleUnaryCall<any, any>,
-  call: ServerUnaryCall<any, any>,
-  callback: sendUnaryData<any>,
-) {
-  const { logError } = getSafReporters();
-  try {
-    const result = methodImpl(call, callback) as any;
-    if (result instanceof Promise) {
-      return result.catch((error) => {
-        const e = error as Error;
-        logError(e);
-        callback({ code: status.INTERNAL, message: e.message } as any, null);
-      });
-    }
-    return result;
-  } catch (error) {
-    const e = error as Error;
-    logError(e);
-    callback({ code: status.INTERNAL, message: e.message } as any, null);
-  }
-}
 
 export function makeGrpcServerContextWrapper(
   storage: AsyncLocalStorage<any>,

--- a/grpc-node/metrics.ts
+++ b/grpc-node/metrics.ts
@@ -1,0 +1,19 @@
+const grpcMetricName = "grpc_request_duration_seconds";
+const grpcMetricHelp =
+  "duration histogram of grpc responses labeled with: status_code, grpc_service, grpc_method";
+import client from "prom-client";
+
+// simplified (options-removed) version of express-prom-bundle's makeHttpMetric
+// https://github.com/jochen-schweizer/express-prom-bundle/blob/f9a0a7622a398da828c865b2c8a79b42150f6815/src/index.js#L95-L129
+export function makeGrpcMetric() {
+  const labels = ["status_code", "grpc_service", "grpc_method"];
+
+  return new client.Histogram({
+    name: grpcMetricName,
+    help: grpcMetricHelp,
+    labelNames: labels,
+    buckets: [0.003, 0.03, 0.1, 0.3, 1.5, 10],
+  });
+}
+
+export const grpcMetric = makeGrpcMetric();

--- a/grpc-node/metrics.ts
+++ b/grpc-node/metrics.ts
@@ -17,3 +17,10 @@ export function makeGrpcMetric() {
 }
 
 export const grpcMetric = makeGrpcMetric();
+
+export interface GrpcLabels {
+  [key: string]: string | number;
+  status_code: number;
+  grpc_service: string;
+  grpc_method: string;
+}

--- a/grpc-node/runner.ts
+++ b/grpc-node/runner.ts
@@ -1,0 +1,30 @@
+import type {
+  handleUnaryCall,
+  sendUnaryData,
+  ServerUnaryCall,
+} from "@grpc/grpc-js";
+import { status } from "@grpc/grpc-js";
+import { getSafReporters } from "@saflib/node";
+
+export function runGrpcMethod(
+  methodImpl: handleUnaryCall<any, any>,
+  call: ServerUnaryCall<any, any>,
+  callback: sendUnaryData<any>,
+) {
+  const { logError } = getSafReporters();
+  try {
+    const result = methodImpl(call, callback) as any;
+    if (result instanceof Promise) {
+      return result.catch((error) => {
+        const e = error as Error;
+        logError(e);
+        callback({ code: status.INTERNAL, message: e.message } as any, null);
+      });
+    }
+    return result;
+  } catch (error) {
+    const e = error as Error;
+    logError(e);
+    callback({ code: status.INTERNAL, message: e.message } as any, null);
+  }
+}

--- a/grpc-node/runner.ts
+++ b/grpc-node/runner.ts
@@ -5,13 +5,27 @@ import type {
 } from "@grpc/grpc-js";
 import { status } from "@grpc/grpc-js";
 import { getSafReporters } from "@saflib/node";
+// import { grpcMetric } from "./metrics.ts";
 
 export function runGrpcMethod(
   methodImpl: handleUnaryCall<any, any>,
   call: ServerUnaryCall<any, any>,
+  // originalCallback: sendUnaryData<any>,
   callback: sendUnaryData<any>,
 ) {
   const { logError } = getSafReporters();
+
+  // grpcMetric.startTimer();
+  // const start = Date.now();
+  // const callback = (error: any, value: any) => {
+  //   const duration = Date.now() - start;
+  //   grpcMetric.observe(duration, {
+  //     status_code: error ? status.INTERNAL : status.OK,
+  //     grpc_service: call.service,
+  //     grpc_method: call.method,
+  //   });
+  //   originalCallback(error, value);
+  // };
   try {
     const result = methodImpl(call, callback) as any;
     if (result instanceof Promise) {

--- a/node/index.ts
+++ b/node/index.ts
@@ -3,6 +3,7 @@ export * from "./src/reporters.ts";
 export * from "./src/context.ts";
 export * from "./src/errors.ts";
 export * from "./src/loki.ts";
-export type { Logger } from "winston";
-
+export * from "./src/metrics.ts";
 export * from "./src/types.ts";
+
+export type { Logger } from "winston";

--- a/node/package.json
+++ b/node/package.json
@@ -8,7 +8,8 @@
   },
   "dependencies": {
     "winston": "^3.0.0",
-    "winston-loki": "^6.1.3"
+    "winston-loki": "^6.1.3",
+    "prom-client": "^15.1.3"
   },
   "devDependencies": {
     "@saflib/vitest": "*"

--- a/node/src/metrics.ts
+++ b/node/src/metrics.ts
@@ -1,0 +1,12 @@
+import client from "prom-client";
+import { getServiceName } from "./context.ts";
+
+const collectDefaultMetrics = client.collectDefaultMetrics;
+
+export function collectSystemMetrics() {
+  collectDefaultMetrics({
+    labels: {
+      service_name: getServiceName(),
+    },
+  });
+}


### PR DESCRIPTION
Filling out metrics to send to prometheus, this time for grpc. Pulled out a grpc "runner" which handles errors, and now also tracks duration. And I added a function to have prom-client collect system (default) metrics.

Also:
* Do some refactoring of how grpc services get added. I swear I remember trying to subclass the abstract service class before and typing not working or whatever, but now it works 🤷 
* Move prom-client to the node package, since it's generally for node