### PR TITLE
Add cron metrics

### DIFF
--- a/cron-service/Dockerfile
+++ b/cron-service/Dockerfile
@@ -3,9 +3,9 @@ FROM node:alpine3.19
 
 WORKDIR /app
 
-COPY --parents ./package.json ./package-lock.json ./saflib/cron-db/package.json ./saflib/cron-service/package.json ./saflib/cron-spec/package.json ./saflib/drizzle-sqlite3/package.json ./saflib/express/package.json ./saflib/grpc-node/package.json ./saflib/grpc-specs/package.json ./saflib/node/package.json ./saflib/openapi-specs/package.json ./
+COPY --parents ./package.json ./package-lock.json ./saflib/cron-db/package.json ./saflib/cron-service/package.json ./saflib/cron-spec/package.json ./saflib/drizzle-sqlite3/package.json ./saflib/express/package.json ./saflib/grpc-node/package.json ./saflib/grpc-specs/package.json ./saflib/monorepo/package.json ./saflib/node/package.json ./saflib/openapi-specs/package.json ./
 RUN npm install --omit=dev
-COPY --parents ./saflib/cron-db ./saflib/cron-service ./saflib/cron-spec ./saflib/drizzle-sqlite3 ./saflib/express ./saflib/grpc-node ./saflib/grpc-specs ./saflib/node ./saflib/openapi-specs ./
+COPY --parents ./saflib/cron-db ./saflib/cron-service ./saflib/cron-spec ./saflib/drizzle-sqlite3 ./saflib/express ./saflib/grpc-node ./saflib/grpc-specs ./saflib/monorepo ./saflib/node ./saflib/openapi-specs ./
 
 WORKDIR /app/services/cron
 CMD ["npm", "start"]

--- a/cron-service/package.json
+++ b/cron-service/package.json
@@ -15,16 +15,17 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
-    "@saflib/grpc-node": "*",
-    "@saflib/express": "*",
-    "@saflib/node": "*",
-    "@saflib/grpc-specs": "*",
     "@saflib/cron-db": "*",
     "@saflib/cron-spec": "*",
+    "@saflib/express": "*",
+    "@saflib/grpc-node": "*",
+    "@saflib/grpc-specs": "*",
+    "@saflib/monorepo": "*",
+    "@saflib/node": "*",
     "cron": "^4.3.0"
   },
   "devDependencies": {
     "@saflib/vitest": "*",
     "@types/cron": "^2.0.1"
   }
-} 
+}

--- a/cron-service/src/index.ts
+++ b/cron-service/src/index.ts
@@ -43,7 +43,11 @@ async function executeJobWithHandling(
       const { logError } = getSafReporters();
       let statusToSet: "success" | "fail" | "timed out" = "fail"; // Default to fail
 
-      const labels: CronLabels = { job_name: jobName, status: "running" };
+      const labels: CronLabels = {
+        service_name: getServiceName(),
+        job_name: jobName,
+        status: "running",
+      };
       const timer = cronMetric.startTimer(labels);
       try {
         // Set status to running *before* starting the handler/timeout race

--- a/cron-service/src/index.ts
+++ b/cron-service/src/index.ts
@@ -12,11 +12,10 @@ import {
   getServiceName,
 } from "@saflib/node";
 import { cronDb } from "@saflib/cron-db";
-
 import type { JobConfig, JobsMap } from "./types.ts";
 import type { DbKey } from "@saflib/drizzle-sqlite3";
 import { JobSettingNotFoundError } from "@saflib/cron-db";
-
+import { cronMetric, type CronLabels } from "./metrics.ts";
 // --- Helper Function for Job Execution and Error Handling ---
 
 async function executeJobWithHandling(
@@ -44,6 +43,8 @@ async function executeJobWithHandling(
       const { logError } = getSafReporters();
       let statusToSet: "success" | "fail" | "timed out" = "fail"; // Default to fail
 
+      const labels: CronLabels = { job_name: jobName, status: "running" };
+      const timer = cronMetric.startTimer(labels);
       try {
         // Set status to running *before* starting the handler/timeout race
         await cronDb.jobSettings.setLastRunStatus(dbKey, jobName, "running");
@@ -65,6 +66,7 @@ async function executeJobWithHandling(
 
         // If race succeeds without error
         statusToSet = "success";
+        labels.status = "success";
       } catch (error) {
         // Log the error
         const isErrorInstance = error instanceof Error;
@@ -88,10 +90,13 @@ async function executeJobWithHandling(
 
         if (errorMessage.includes("timed out")) {
           statusToSet = "timed out";
+          labels.status = "timeout";
         } else {
           statusToSet = "fail";
+          labels.status = "error";
         }
       } finally {
+        timer();
         try {
           await cronDb.jobSettings.setLastRunStatus(
             dbKey,

--- a/cron-service/src/metrics.ts
+++ b/cron-service/src/metrics.ts
@@ -1,0 +1,25 @@
+import { metricHistogramDefaultBuckets } from "@saflib/monorepo";
+import client from "prom-client";
+
+const cronMetricName = "cron_job_duration_seconds";
+const cronMetricHelp = "duration histogram of cron jobs";
+
+export function makeCronMetric() {
+  const labels = ["service_name", "status", "job_name"];
+
+  return new client.Histogram({
+    name: cronMetricName,
+    help: cronMetricHelp,
+    labelNames: labels,
+    buckets: metricHistogramDefaultBuckets,
+  });
+}
+
+export const cronMetric = makeCronMetric();
+
+export interface CronLabels {
+  [key: string]: string | number;
+  service_name: string;
+  status: "success" | "error" | "timeout" | "running";
+  job_name: string;
+}

--- a/express/src/middleware/metrics.ts
+++ b/express/src/middleware/metrics.ts
@@ -1,16 +1,21 @@
+import { getServiceName } from "@saflib/node";
 import promBundle from "express-prom-bundle";
 
 export const metricsMiddleware = promBundle({
   includeMethod: true,
   includePath: true,
   includeStatusCode: true,
+  customLabels: {
+    service_name: "",
+  },
   includeUp: true,
   transformLabels: (labels, req, res) => {
+    labels.service_name = getServiceName();
     // For 404s stemming from random requests trying to find vulnerabilities
     if (res.statusCode === 404 && !req.openapi) {
-      // apparently you don't return a new labels object... interesting
       labels.path = "/#404";
     }
+    // OPTIONS tend to pollute metrics, so group successful ones
     if (res.statusCode === 204 && req.method === "OPTIONS") {
       labels.path = "/#options";
     }

--- a/grpc-node/metrics.ts
+++ b/grpc-node/metrics.ts
@@ -1,18 +1,20 @@
+import { metricHistogramDefaultBuckets } from "@saflib/monorepo";
+import client from "prom-client";
+
 const grpcMetricName = "grpc_request_duration_seconds";
 const grpcMetricHelp =
-  "duration histogram of grpc responses labeled with: status_code, grpc_service, grpc_method";
-import client from "prom-client";
+  "duration histogram of grpc responses labeled with: status_code, grpc_service, method";
 
 // simplified (options-removed) version of express-prom-bundle's makeHttpMetric
 // https://github.com/jochen-schweizer/express-prom-bundle/blob/f9a0a7622a398da828c865b2c8a79b42150f6815/src/index.js#L95-L129
 export function makeGrpcMetric() {
-  const labels = ["status_code", "grpc_service", "grpc_method"];
+  const labels = ["service_name", "status_code", "grpc_service", "method"];
 
   return new client.Histogram({
     name: grpcMetricName,
     help: grpcMetricHelp,
     labelNames: labels,
-    buckets: [0.003, 0.03, 0.1, 0.3, 1.5, 10],
+    buckets: metricHistogramDefaultBuckets,
   });
 }
 
@@ -20,6 +22,7 @@ export const grpcMetric = makeGrpcMetric();
 
 export interface GrpcLabels {
   [key: string]: string | number;
+  service_name: string;
   status_code: number;
   // unfortunately, "service" is overloaded, so it's prefixed with "grpc_"
   grpc_service: string;

--- a/grpc-node/runner.ts
+++ b/grpc-node/runner.ts
@@ -19,12 +19,13 @@ export function runGrpcMethod(
   originalCallback: sendUnaryData<any>,
 ) {
   const { logError } = getSafReporters();
-  const { subsystemName, operationName } = getSafContext();
+  const { subsystemName, operationName, serviceName } = getSafContext();
 
   const labels: GrpcLabels = {
+    service_name: serviceName,
     status_code: -1,
     grpc_service: subsystemName,
-    grpc_method: operationName,
+    method: operationName,
   };
 
   const timer = grpcMetric.startTimer(labels);

--- a/monorepo/index.ts
+++ b/monorepo/index.ts
@@ -34,3 +34,5 @@ declare global {
     filename: string;
   }
 }
+
+export const metricHistogramDefaultBuckets = [0.003, 0.03, 0.1, 0.3, 1.5, 10];

--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,7 @@
         "@saflib/express": "*",
         "@saflib/grpc-node": "*",
         "@saflib/grpc-specs": "*",
+        "@saflib/monorepo": "*",
         "@saflib/node": "*",
         "cron": "^4.3.0"
       },
@@ -195,8 +196,7 @@
         "express-prom-bundle": "^8.0.0",
         "helmet": "^8.1.0",
         "http-errors": "^2.0.0",
-        "morgan": "^1.0.0",
-        "prom-client": "^15.1.3"
+        "morgan": "^1.0.0"
       },
       "devDependencies": {
         "@saflib/node-express-dev": "*",
@@ -241,6 +241,7 @@
     "node": {
       "name": "@saflib/node",
       "dependencies": {
+        "prom-client": "^15.1.3",
         "winston": "^3.0.0",
         "winston-loki": "^6.1.3"
       },


### PR DESCRIPTION
Okay, this will cover everything for now, basically.

Also tweak existing metrics a bit to:
* add `service_name` so there's a consistent label to associate with what I'm calling services
* `grpc_method` -> `method`. That's consistent with the http metrics. The only reason I have `grpc_service` prefixed with grpc is because it overlaps with what I'm considering to be services.