### PR TITLE
Generalize nodemailer config

### DIFF
--- a/email-node/__mocks__/index.ts
+++ b/email-node/__mocks__/index.ts
@@ -11,9 +11,7 @@ const originalEnv = { ...typedEnv };
 let id = 0;
 
 beforeEach(() => {
-  typedEnv.NODEMAILER_SMTP_HOST = "mock.smtp.server";
-  typedEnv.NODEMAILER_SMTP_PORT = "587";
-  typedEnv.NODEMAILER_SMTP_FROM = "noreply@your-domain.com";
+  typedEnv.NODEMAILER_TRANSPORT_CONFIG = "{}";
   const transport = createTransport();
   vi.mocked(transport.sendMail).mockImplementation((options: EmailOptions) => {
     // always return a success response

--- a/email-node/client/email-client.ts
+++ b/email-node/client/email-client.ts
@@ -1,11 +1,12 @@
 import { createLogger, getSafReporters } from "@saflib/node";
 import * as nodemailer from "nodemailer";
-import type { TransportOptions, Transporter } from "nodemailer";
+import type { Transporter } from "nodemailer";
 
 import { typedEnv } from "../env.ts";
 
 export const mockingOn =
-  typedEnv.NODE_ENV === "test" || typedEnv.MOCK_INTEGRATIONS === "true";
+  (typedEnv.NODE_ENV === "test" || typedEnv.MOCK_INTEGRATIONS === "true") &&
+  !typedEnv.NODEMAILER_TRANSPORT_CONFIG;
 
 setImmediate(() => {
   const logger = createLogger({

--- a/email-node/client/email-client.ts
+++ b/email-node/client/email-client.ts
@@ -1,6 +1,6 @@
 import { createLogger, getSafReporters } from "@saflib/node";
 import * as nodemailer from "nodemailer";
-import type { Transporter } from "nodemailer";
+import type { TransportOptions, Transporter } from "nodemailer";
 
 import { typedEnv } from "../env.ts";
 
@@ -15,6 +15,8 @@ setImmediate(() => {
 
   logger.info("Email Integration: " + (mockingOn ? "MOCKED" : "LIVE"));
 });
+
+type TransporterConfig = Parameters<typeof nodemailer.createTransport>[0];
 
 export interface SentEmail extends EmailOptions {
   timeSent: number;
@@ -56,34 +58,31 @@ export interface EmailResult {
 }
 
 class EmailClient {
-  private transporter: Transporter;
+  private transporter: Transporter | undefined;
 
   constructor() {
-    let host = typedEnv.NODEMAILER_SMTP_HOST;
-
-    if (mockingOn && !host) {
-      host = "localhost";
+    if (mockingOn) {
+      return;
     }
 
-    if (!host) {
+    if (!typedEnv.NODEMAILER_TRANSPORT_CONFIG) {
       throw new Error(
-        "SMTP configuration error: NODEMAILER_SMTP_HOST must be provided.",
+        "SMTP configuration error: NODEMAILER_TRANSPORT_CONFIG must be provided.",
       );
     }
 
-    const port = typedEnv.NODEMAILER_SMTP_PORT;
-    const user = typedEnv.NODEMAILER_SMTP_USER;
-    const pass = typedEnv.NODEMAILER_SMTP_PASS;
-    // Default secure to true if not explicitly set to 'false'
-    const secure = typedEnv.NODEMAILER_SMTP_SECURE !== "false";
+    let config: TransporterConfig;
+    try {
+      config = JSON.parse(
+        typedEnv.NODEMAILER_TRANSPORT_CONFIG,
+      ) as TransporterConfig;
+    } catch (error) {
+      throw new Error(
+        "SMTP configuration error: NODEMAILER_TRANSPORT_CONFIG must be valid JSON.",
+      );
+    }
 
-    this.transporter = nodemailer.createTransport({
-      host,
-      port: port ? parseInt(port, 10) : undefined,
-      secure: secure,
-      // Only add auth if user and pass are provided
-      auth: user && pass ? { user, pass } : undefined,
-    });
+    this.transporter = nodemailer.createTransport(config);
     if (!this.transporter) {
       throw new Error("Failed to create transporter");
     }
@@ -106,6 +105,10 @@ class EmailClient {
         rejected: [],
         response: "250 2.0.0 OK",
       };
+    }
+
+    if (!this.transporter) {
+      throw new Error("Transporter not initialized");
     }
 
     const info = await this.transporter.sendMail(options);

--- a/email-node/env.schema.json
+++ b/email-node/env.schema.json
@@ -1,26 +1,10 @@
 {
   "type": "object",
   "properties": {
-    "NODEMAILER_SMTP_HOST": {
-      "type": "string"
-    },
-    "NODEMAILER_SMTP_PORT": {
-      "type": "string"
-    },
-    "NODEMAILER_SMTP_FROM": {
-      "type": "string"
-    },
-    "NODEMAILER_SMTP_SECURE": {
+    "NODEMAILER_TRANSPORT_CONFIG": {
       "type": "string",
-      "enum": ["true", "false"],
-      "description": "Whether to use a secure connection to the SMTP server. Set to 'true' to use a secure connection. Defaults to 'true'."
-    },
-    "NODEMAILER_SMTP_USER": {
-      "type": "string"
-    },
-    "NODEMAILER_SMTP_PASS": {
-      "type": "string"
+      "description": "JSON string"
     }
   },
-  "required": ["NODEMAILER_SMTP_HOST", "NODEMAILER_SMTP_PORT"]
+  "required": ["NODEMAILER_TRANSPORT_CONFIG"]
 }

--- a/email-node/env.ts
+++ b/email-node/env.ts
@@ -38,15 +38,10 @@ export interface CombinedEnvSchema {
    * Whether to allow the creation of new databases. Useful for ensuring existing production environments don't inadvertently create new databases.
    */
   ALLOW_DB_CREATION?: "true" | "false";
-  NODEMAILER_SMTP_HOST: string;
-  NODEMAILER_SMTP_PORT: string;
-  NODEMAILER_SMTP_FROM?: string;
   /**
-   * Whether to use a secure connection to the SMTP server. Set to 'true' to use a secure connection. Defaults to 'true'.
+   * JSON string
    */
-  NODEMAILER_SMTP_SECURE?: "true" | "false";
-  NODEMAILER_SMTP_USER?: string;
-  NODEMAILER_SMTP_PASS?: string;
+  NODEMAILER_TRANSPORT_CONFIG: string;
 }
 
-export const typedEnv = process.env as unknown as CombinedEnvSchema;
+export const typedEnv = (globalThis.process ? process.env : {}) as unknown as CombinedEnvSchema;


### PR DESCRIPTION
Rather than have a whole bunch of env variables for the nodemailer transport, I'm putting a json object into a single env variable and putting that in.

Also, I'm trying out more being able to override env variables in development. To test that update email configs worked, if the env variable is set that overrides "MOCK_INTEGRATIONS" so that you can test a live integration in a targeted manner. I'd like a more secure approach in the future, but something like this I think would be useful for both manual and automated local testing of integrations.