### PR TITLE
Simplify "subsystem"

### DIFF
--- a/cron/cron-service/http.ts
+++ b/cron/cron-service/http.ts
@@ -48,7 +48,6 @@ export function createCronRouter(options: CronServiceOptions) {
     "/cron",
     createPreMiddleware({
       apiSpec: jsonSpec,
-      subsystemName: options.subsystemName,
     }),
   );
   router.use("/cron", cronRouter);

--- a/cron/cron-service/index.ts
+++ b/cron/cron-service/index.ts
@@ -23,7 +23,7 @@ export function main(options: CronServiceOptions) {
     log.info("Connecting to cron DB...");
     const dbKey = options.dbKey ?? cronDb.connect(options.dbOptions);
     log.info("Starting jobs...");
-    startJobs(options.jobs, { subsystemName: "cron", dbKey });
+    startJobs(options.jobs, { dbKey });
     log.info("Cron service startup complete.");
   } catch (error) {
     logError(error);

--- a/cron/cron-service/src/index.test.ts
+++ b/cron/cron-service/src/index.test.ts
@@ -44,10 +44,7 @@ describe("startJobs", () => {
 
   it("should create default disabled setting if job doesn't exist in DB", async () => {
     // Pass the local db instance to startJobs
-    await startJobs(
-      { "new-job": mockJobs["new-job"] },
-      { subsystemName: "test", dbKey },
-    );
+    await startJobs({ "new-job": mockJobs["new-job"] }, { dbKey });
     const setting = await throwError(
       cronDb.jobSettings.getByName(dbKey, "new-job"),
     ); // Assert on local db
@@ -71,10 +68,7 @@ describe("startJobs", () => {
         }),
       );
     // Pass the local db instance
-    await startJobs(
-      { "fail-job": mockJobs["fail-job"] },
-      { subsystemName: "test", dbKey },
-    );
+    await startJobs({ "fail-job": mockJobs["fail-job"] }, { dbKey });
 
     // Check that the specific error was logged
     expect(logSpy).toHaveBeenCalledWith(
@@ -93,7 +87,7 @@ describe("startJobs", () => {
   it("should run enabled job on schedule tick", async () => {
     await startJobs(
       { "every-second-job": mockJobs["every-second-job"] },
-      { subsystemName: "test", dbKey },
+      { dbKey },
     );
     // Ensure the job is enabled in the DB for this test
     await cronDb.jobSettings.setEnabled(dbKey, "every-second-job", true);
@@ -110,10 +104,7 @@ describe("startJobs", () => {
 
   it("should not run disabled job on schedule tick", async () => {
     await cronDb.jobSettings.setEnabled(dbKey, "disabled-job", false);
-    await startJobs(
-      { "disabled-job": mockJobs["disabled-job"] },
-      { subsystemName: "test", dbKey },
-    );
+    await startJobs({ "disabled-job": mockJobs["disabled-job"] }, { dbKey });
     await vi.advanceTimersByTimeAsync(1000);
     expect(mockJobs["disabled-job"].handler).not.toHaveBeenCalled();
     const setting = await throwError(
@@ -126,7 +117,7 @@ describe("startJobs", () => {
   it("should update status to running, then success on successful run", async () => {
     await startJobs(
       { "every-second-job": mockJobs["every-second-job"] },
-      { subsystemName: "test", dbKey },
+      { dbKey },
     );
     // Ensure the job is enabled in the DB for this test
     await cronDb.jobSettings.setEnabled(dbKey, "every-second-job", true);
@@ -145,7 +136,7 @@ describe("startJobs", () => {
     mockJobHandler.mockRejectedValueOnce(handlerError);
     await startJobs(
       { "every-second-job": mockJobs["every-second-job"] },
-      { subsystemName: "test", dbKey },
+      { dbKey },
     );
     await cronDb.jobSettings.setEnabled(dbKey, "every-second-job", true);
 
@@ -173,7 +164,7 @@ describe("startJobs", () => {
 
     await startJobs(
       { "every-minute-job": mockJobs["every-minute-job"] },
-      { subsystemName: "test", dbKey },
+      { dbKey },
     );
     await vi.advanceTimersByTimeAsync(1000 * 62); // Trigger the job's onTick and timeout
     const setting = await throwError(
@@ -195,10 +186,7 @@ describe("startJobs", () => {
         }),
     );
 
-    await startJobs(
-      { "timeout-default-job": jobConfig },
-      { subsystemName: "test", dbKey },
-    );
+    await startJobs({ "timeout-default-job": jobConfig }, { dbKey });
     await cronDb.jobSettings.setEnabled(dbKey, "timeout-default-job", true);
 
     await vi.advanceTimersByTimeAsync(1000 * 70); // Trigger the job
@@ -235,7 +223,7 @@ describe("startJobs", () => {
 
     await startJobs(
       { "every-second-job": mockJobs["every-second-job"] },
-      { subsystemName: "test", dbKey },
+      { dbKey },
     );
     await cronDb.jobSettings.setEnabled(dbKey, "every-second-job", true);
 

--- a/drizzle-sqlite3/instances.ts
+++ b/drizzle-sqlite3/instances.ts
@@ -31,10 +31,7 @@ export class DbManager<S extends Schema, C extends Config> {
    * If onDisk is a string, the database will be created at the given (absolute) path.
    */
   connect = (options?: DbOptions): DbKey => {
-    const { log } = makeSubsystemReporters(
-      options?.name ? `db.${options.name}` : "db",
-      "connect",
-    );
+    const { log } = makeSubsystemReporters("init", "db.connect");
     log.info("Connecting to database...");
     let dbStorage = ":memory:";
     if (options?.onDisk === true) {

--- a/email/email-node/client/email-client.ts
+++ b/email/email-node/client/email-client.ts
@@ -10,8 +10,8 @@ export const mockingOn =
 
 setImmediate(() => {
   const logger = createLogger({
-    subsystemName: "email-node",
-    operationName: "init",
+    subsystemName: "init",
+    operationName: "initEmailClient",
   });
 
   logger.info("Email: " + (mockingOn ? "MOCKED" : "LIVE"));

--- a/email/email-node/routes/emails/index.ts
+++ b/email/email-node/routes/emails/index.ts
@@ -13,7 +13,6 @@ export function createEmailsRouter(options: EmailsRouterOptions = {}) {
   const preMiddleware = createPreMiddleware({
     apiSpec: options.apiSpec || jsonSpec,
     authRequired: false,
-    subsystemName: "emails",
   });
 
   router.use("/email", preMiddleware);

--- a/express/src/middleware/composition.ts
+++ b/express/src/middleware/composition.ts
@@ -13,7 +13,6 @@ import { blockHtml } from "./blockHtml.ts";
 import { createScopeValidator } from "./scopes.ts";
 
 interface PreMiddlewareOptions {
-  subsystemName?: string;
   apiSpec?: OpenAPIV3.DocumentV3;
   authRequired?: boolean;
   disableCors?: boolean;
@@ -23,8 +22,7 @@ interface PreMiddlewareOptions {
 export const createPreMiddleware = (
   options: PreMiddlewareOptions,
 ): Handler[] => {
-  const { apiSpec, authRequired, disableCors, healthCheck, subsystemName } =
-    options;
+  const { apiSpec, authRequired, disableCors, healthCheck } = options;
 
   let healthMiddleware: Handler = healthRouter;
   if (healthCheck) {
@@ -57,7 +55,7 @@ export const createPreMiddleware = (
     ...sanitizeMiddleware,
     ...corsMiddleware,
     ...openApiValidatorMiddleware,
-    makeContextMiddleware(subsystemName ? "http." + subsystemName : "http"),
+    makeContextMiddleware(),
     unsafeRequestLogger,
     ...authMiddleware,
     createScopeValidator(),

--- a/express/src/middleware/context.ts
+++ b/express/src/middleware/context.ts
@@ -10,7 +10,7 @@ import {
 } from "@saflib/node";
 import type { Handler } from "express";
 
-export const makeContextMiddleware = (subsystemName: string) => {
+export const makeContextMiddleware = () => {
   const contextMiddleware: Handler = (req, _res, next) => {
     const operationName =
       req.openapi?.schema.operationId ??
@@ -37,7 +37,7 @@ export const makeContextMiddleware = (subsystemName: string) => {
     const context: SafContext = {
       requestId: reqId,
       serviceName: getServiceName(),
-      subsystemName,
+      subsystemName: "http",
       operationName,
       auth,
     };

--- a/grpc/grpc-node/context.ts
+++ b/grpc/grpc-node/context.ts
@@ -26,14 +26,11 @@ export type SafServiceImplementationWrapper = (
 
 export const addSafContext: SafServiceImplementationWrapper = (
   impl,
-  definition,
+  _definition,
 ) => {
   const wrappedService: UntypedServiceImplementation = {};
 
   for (const [methodName, methodImpl] of Object.entries(impl)) {
-    const serviceName = definition[methodName].path.split("/")[1];
-    const subsystemName = "grpc." + serviceName;
-
     const impl = methodImpl as handleUnaryCall<any, any>;
     const wrappedMethod: handleUnaryCall<any, any> = (call, callback) => {
       // Create the context for this request
@@ -57,7 +54,7 @@ export const addSafContext: SafServiceImplementationWrapper = (
       const context: SafContext = {
         requestId: reqId,
         serviceName: getServiceName(),
-        subsystemName,
+        subsystemName: "grpc",
         operationName: methodName,
         auth,
       };

--- a/identity/identity-service/routes/auth/index.ts
+++ b/identity/identity-service/routes/auth/index.ts
@@ -27,7 +27,6 @@ export const makeAuthRouter = () => {
     createPreMiddleware({
       apiSpec: jsonSpec,
       authRequired: false,
-      subsystemName: "auth",
     }),
   );
 

--- a/identity/identity-service/routes/users/index.ts
+++ b/identity/identity-service/routes/users/index.ts
@@ -8,7 +8,6 @@ export const makeUsersRouter = () => {
   router.use(
     createPreMiddleware({
       apiSpec: jsonSpec,
-      subsystemName: "users",
     }),
   );
 

--- a/node/src/reporters.ts
+++ b/node/src/reporters.ts
@@ -1,5 +1,5 @@
 import { createLogger } from "./logger.ts";
-import type { SafReporters } from "./types.ts";
+import type { SafReporters, SubsystemName } from "./types.ts";
 import { AsyncLocalStorage } from "async_hooks";
 import { makeSubsystemErrorReporter } from "./errors.ts";
 import { typedEnv } from "@saflib/env";
@@ -22,7 +22,7 @@ export const getSafReporters = (): SafReporters => {
 };
 
 export const makeSubsystemReporters = (
-  subsystemName: string,
+  subsystemName: SubsystemName,
   operationName: string,
 ): SafReporters => {
   const logger = createLogger({

--- a/node/src/types.ts
+++ b/node/src/types.ts
@@ -6,6 +6,14 @@ export interface Auth {
   userScopes: string[];
 }
 
+export type SubsystemName =
+  | "http" // an http server, typically express
+  | "grpc" // a grpc server
+  | "cron" // a cron process running jobs in the background (no server)
+  | "init" // code that's running on startup
+  | "cli" // running as part of a CLI command
+  | "test"; // running as part of a test;
+
 /**
  * Static, serializable context about what's currently going on.
  * These should always be available in backend systems.
@@ -28,16 +36,10 @@ export interface SafContext {
 
   /*
    * Format: "{subsystem}"
-   * e.g. "http" or "grpc". Can be namespaced, like:
-   * - "http.email": an express router with apis that begin with /email/*
-   * - "grpc.schedule": a gRPC service called "Schedule".
-   * - "cron.clean": a set of cron jobs that regularly delete old data.
-   * - "task.campaigns": async tasks queues associated with emails, SMS, etc.
-   * - "ws.notifications": websocket for notifications.
    *
    * Basically, a single server or long-running "process".
    */
-  subsystemName: string;
+  subsystemName: SubsystemName;
 
   /*
    * Format: "{method_name}"

--- a/workflows/src/workflow-cli.ts
+++ b/workflows/src/workflow-cli.ts
@@ -96,8 +96,8 @@ export function runWorkflowCli(workflows: WorkflowMeta[]) {
   const ctx: SafContext = {
     requestId: reqId,
     serviceName: "workflows",
-    operationName: "workflow-cli",
-    subsystemName: "workflows",
+    operationName: "N/A",
+    subsystemName: "cli",
   };
 
   const reporters: SafReporters = {


### PR DESCRIPTION
I was thinking about changing this, at least to have terms that are more subsystem-specific (instead of operationName, it would be routeName, methodName, etc).

But let me try this first: restricting "subsystemName" to a specific list of options. I do think I need some concept of "subsystem" or a name for some high-level portion of a service. I might change operationName later but for now I think this simplifies things nicely.