### PR TITLE
Handle i18n in "get string" methods

### DIFF
--- a/playwright/index.ts
+++ b/playwright/index.ts
@@ -20,11 +20,28 @@ interface ElementStringObject {
   label?: string;
 }
 
+const convertI18NInterpolationToRegex = (str: string) => {
+  if (str.includes("{")) {
+    return new RegExp(str.replace(/\{(.*?)\}/g, ".*"));
+  }
+  return str;
+};
+
 type ElementString = string | ElementStringObject;
 
 export const getByString = (page: Page, stringThing: ElementString) => {
   if (typeof stringThing === "string") {
-    return page.getByText(stringThing, { exact: true });
+    if (stringThing.includes("{")) {
+      console.log(
+        "converting",
+        stringThing,
+        "to",
+        convertI18NInterpolationToRegex(stringThing),
+      );
+    }
+    return page.getByText(convertI18NInterpolationToRegex(stringThing), {
+      exact: true,
+    });
   }
   if (stringThing["aria-label"]) {
     return page.getByLabel(stringThing["aria-label"], { exact: true });

--- a/playwright/index.ts
+++ b/playwright/index.ts
@@ -31,14 +31,6 @@ type ElementString = string | ElementStringObject;
 
 export const getByString = (page: Page, stringThing: ElementString) => {
   if (typeof stringThing === "string") {
-    if (stringThing.includes("{")) {
-      console.log(
-        "converting",
-        stringThing,
-        "to",
-        convertI18NInterpolationToRegex(stringThing),
-      );
-    }
     return page.getByText(convertI18NInterpolationToRegex(stringThing), {
       exact: true,
     });

--- a/playwright/index.ts
+++ b/playwright/index.ts
@@ -20,9 +20,15 @@ interface ElementStringObject {
   label?: string;
 }
 
+const regexCharacters = ["(", ")", ".", "*", "+", "?", "^", "$", "|", "/"];
+
 const convertI18NInterpolationToRegex = (str: string) => {
   if (str.includes("{")) {
-    return new RegExp(str.replace(/\{(.*?)\}/g, ".*"));
+    let escapedStr = str;
+    for (const char of regexCharacters) {
+      escapedStr = escapedStr.replace(char, `\\${char}`);
+    }
+    return new RegExp(escapedStr.replace(/\{(.*?)\}/g, ".*"));
   }
   return str;
 };

--- a/playwright/index.ts
+++ b/playwright/index.ts
@@ -1,5 +1,6 @@
 import type { Page } from "@playwright/test";
 export * from "./screenshots.ts";
+import { convertI18NInterpolationToRegex } from "@saflib/vue-spa/i18n-utils";
 
 export const tightAndroidViewport = { width: 430, height: 700 };
 
@@ -19,19 +20,6 @@ interface ElementStringObject {
   "aria-label"?: string;
   label?: string;
 }
-
-const regexCharacters = ["(", ")", ".", "*", "+", "?", "^", "$", "|", "/"];
-
-const convertI18NInterpolationToRegex = (str: string) => {
-  if (str.includes("{")) {
-    let escapedStr = str;
-    for (const char of regexCharacters) {
-      escapedStr = escapedStr.replace(char, `\\${char}`);
-    }
-    return new RegExp(escapedStr.replace(/\{(.*?)\}/g, ".*"));
-  }
-  return str;
-};
 
 type ElementString = string | ElementStringObject;
 

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -7,7 +7,8 @@
     ".": "./index.ts"
   },
   "dependencies": {
-    "@playwright/test": "^1.53.2"
+    "@playwright/test": "^1.53.2",
+    "@saflib/vue-spa": "*"
   },
   "devDependencies": {
     "@saflib/vitest": "*"

--- a/vue-spa/i18n-utils.ts
+++ b/vue-spa/i18n-utils.ts
@@ -1,0 +1,21 @@
+const regexCharacters = ["(", ")", ".", "*", "+", "?", "^", "$", "|", "/"];
+
+/**
+ * Utility function to convert the vue-i18n message format syntax to a
+ * regex for finding an instance of that string, in particular for tests.
+ * https://vue-i18n.intlify.dev/guide/essentials/syntax.html
+ *
+ * This is stored and exported separately from the rest of this package
+ * so that libraries such as playwright don't import vue files, which
+ * they can't handle.
+ */
+export const convertI18NInterpolationToRegex = (str: string) => {
+  if (str.includes("{")) {
+    let escapedStr = str;
+    for (const char of regexCharacters) {
+      escapedStr = escapedStr.replace(char, `\\${char}`);
+    }
+    return new RegExp(escapedStr.replace(/\{(.*?)\}/g, ".*"));
+  }
+  return str;
+};

--- a/vue-spa/package.json
+++ b/vue-spa/package.json
@@ -11,7 +11,8 @@
     "./workflows": "./workflows/index.ts",
     "./tanstack": "./src/tanstack.ts",
     "./testing": "./testing/index.ts",
-    "./vitest-config": "./testing/vitest-config.js"
+    "./vitest-config": "./testing/vitest-config.js",
+    "./i18n-utils": "./i18n-utils.ts"
   },
   "scripts": {
     "typecheck": "tsc --project tsconfig.app.json"

--- a/vue-spa/src/index.ts
+++ b/vue-spa/src/index.ts
@@ -6,3 +6,4 @@ export * from "./events.ts";
 import "./assets.d.ts";
 export * from "./app.ts";
 export * from "./strings.ts";
+export * from "./utils.ts";

--- a/vue-spa/src/utils.ts
+++ b/vue-spa/src/utils.ts
@@ -1,0 +1,16 @@
+// works in vitest or browser
+export const getHost = () => {
+  let host = "localhost:3000";
+  if (typeof document !== "undefined") {
+    host = document.location.host.split(".").slice(-2).join(".");
+  }
+  return host;
+};
+
+export const getProtocol = () => {
+  let protocol = "http:";
+  if (typeof document !== "undefined") {
+    protocol = document.location.protocol;
+  }
+  return protocol;
+};

--- a/vue-spa/testing/string-utils.ts
+++ b/vue-spa/testing/string-utils.ts
@@ -1,5 +1,6 @@
 import { expect } from "vitest";
 import { type VueWrapper } from "@vue/test-utils";
+import { convertI18NInterpolationToRegex } from "../i18n-utils";
 
 interface ElementStringObject {
   placeholder?: string;
@@ -7,19 +8,6 @@ interface ElementStringObject {
   "data-testid"?: string;
   label?: string;
 }
-
-const regexCharacters = ["(", ")", ".", "*", "+", "?", "^", "$", "|", "/"];
-
-const convertI18NInterpolationToRegex = (str: string) => {
-  if (str.includes("{")) {
-    let escapedStr = str;
-    for (const char of regexCharacters) {
-      escapedStr = escapedStr.replace(char, `\\${char}`);
-    }
-    return new RegExp(escapedStr.replace(/\{(.*?)\}/g, ".*"));
-  }
-  return str;
-};
 
 // Store strings for Vue components in Record<string, ElementString>
 // Then you can v-bind them to the component, and also use them in tests for reliable element selection


### PR DESCRIPTION
I'm really liking having separate strings from the view and referencing them in tests. It reduces a bunch of busy-work updating hardcoded strings and getting them just right for the tests to pass.

I recently added i18n support and [string interpolation](https://vue-i18n.intlify.dev/guide/essentials/syntax.html) breaks these helpers.

So, now these helper methods will recognize the {brackets} and replace them with `.*`. I also escape other regex characters that happen to be in the string.

Also added a couple other small utilities for vue components.