### PR TITLE
Refactor link, router logic a bit

### DIFF
--- a/identity/auth/pages/verify-email/VerifyEmailPage.vue
+++ b/identity/auth/pages/verify-email/VerifyEmailPage.vue
@@ -105,7 +105,7 @@ import {
   getProfile,
 } from "../../requests/auth";
 import { TanstackError } from "@saflib/sdk";
-import { linkToHref } from "@saflib/links";
+import { linkToHrefWithHost } from "@saflib/vue";
 import { authLinks } from "@saflib/auth-links";
 import { useQuery } from "@tanstack/vue-query";
 import { useReverseT } from "../../i18n.ts";
@@ -189,7 +189,7 @@ const handleResend = async () => {
 
 const thisUrlEncoded = btoa(window.location.href);
 
-const loginLink = linkToHref(authLinks.login, {
+const loginLink = linkToHrefWithHost(authLinks.login, {
   params: { redirect: thisUrlEncoded },
 });
 

--- a/identity/auth/requests/auth.ts
+++ b/identity/auth/requests/auth.ts
@@ -1,5 +1,5 @@
 import { useMutation, useQueryClient, queryOptions } from "@tanstack/vue-query";
-import { client, emailClient } from "./client.ts";
+import { getClient, getEmailClient } from "./client.ts";
 import type {
   IdentityResponseBody,
   IdentityRequestBody,
@@ -10,7 +10,7 @@ import type { Ref } from "vue";
 export const useLogin = () => {
   return useMutation({
     mutationFn: (body: IdentityRequestBody["loginUser"]) => {
-      return handleClientMethod(client.POST("/auth/login", { body }));
+      return handleClientMethod(getClient().POST("/auth/login", { body }));
     },
   });
 };
@@ -18,7 +18,7 @@ export const useLogin = () => {
 export const useLogout = () => {
   return useMutation({
     mutationFn: () => {
-      return handleClientMethod(client.POST("/auth/logout"));
+      return handleClientMethod(getClient().POST("/auth/logout"));
     },
   });
 };
@@ -26,7 +26,7 @@ export const useLogout = () => {
 export const useRegister = () => {
   return useMutation({
     mutationFn: (body: IdentityRequestBody["registerUser"]) => {
-      return handleClientMethod(client.POST("/auth/register", { body }));
+      return handleClientMethod(getClient().POST("/auth/register", { body }));
     },
   });
 };
@@ -34,7 +34,9 @@ export const useRegister = () => {
 export const useForgotPassword = () => {
   return useMutation({
     mutationFn: (body: IdentityRequestBody["forgotPassword"]) => {
-      return handleClientMethod(client.POST("/auth/forgot-password", { body }));
+      return handleClientMethod(
+        getClient().POST("/auth/forgot-password", { body }),
+      );
     },
   });
 };
@@ -42,7 +44,9 @@ export const useForgotPassword = () => {
 export const useResetPassword = () => {
   return useMutation({
     mutationFn: (body: IdentityRequestBody["resetPassword"]) => {
-      return handleClientMethod(client.POST("/auth/reset-password", { body }));
+      return handleClientMethod(
+        getClient().POST("/auth/reset-password", { body }),
+      );
     },
   });
 };
@@ -50,7 +54,9 @@ export const useResetPassword = () => {
 export const useSetPassword = () => {
   return useMutation({
     mutationFn: (body: IdentityRequestBody["setPassword"]) => {
-      return handleClientMethod(client.POST("/auth/set-password", { body }));
+      return handleClientMethod(
+        getClient().POST("/auth/set-password", { body }),
+      );
     },
   });
 };
@@ -58,7 +64,9 @@ export const useSetPassword = () => {
 export const useVerifyEmail = () => {
   return useMutation({
     mutationFn: (body: IdentityRequestBody["verifyEmail"]) => {
-      return handleClientMethod(client.POST("/auth/verify-email", { body }));
+      return handleClientMethod(
+        getClient().POST("/auth/verify-email", { body }),
+      );
     },
   });
 };
@@ -69,7 +77,7 @@ export const useResendVerification = () => {
     TanstackError
   >({
     mutationFn: async () => {
-      return handleClientMethod(client.POST("/auth/resend-verification"));
+      return handleClientMethod(getClient().POST("/auth/resend-verification"));
     },
   });
 };
@@ -78,7 +86,7 @@ export const useUpdateProfile = () => {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: (body: IdentityRequestBody["updateUserProfile"]) => {
-      return handleClientMethod(client.PUT("/auth/profile", { body }));
+      return handleClientMethod(getClient().PUT("/auth/profile", { body }));
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["profile"] });
@@ -90,7 +98,7 @@ export const getProfile = () => {
   return queryOptions({
     queryKey: ["profile"],
     queryFn: async () => {
-      return handleClientMethod(client.GET("/auth/profile"));
+      return handleClientMethod(getClient().GET("/auth/profile"));
     },
   });
 };
@@ -100,7 +108,7 @@ export const getSentAuthEmails = (email?: Ref<string | undefined>) => {
     queryKey: ["sent-emails", "auth", email],
     queryFn: async () => {
       return handleClientMethod(
-        emailClient.GET("/email/sent", {
+        getEmailClient().GET("/email/sent", {
           params: { query: { userEmail: email?.value } },
         }),
       );

--- a/identity/auth/requests/client.ts
+++ b/identity/auth/requests/client.ts
@@ -2,8 +2,21 @@ import type { paths } from "@saflib/identity-spec";
 import type { paths as emailPaths } from "@saflib/email-spec";
 import { createSafClient, TanstackError } from "@saflib/sdk";
 
-export const client = createSafClient<paths>("identity");
-export const emailClient = createSafClient<emailPaths>("identity");
+let client: ReturnType<typeof createSafClient<paths>> | null = null;
+let emailClient: ReturnType<typeof createSafClient<emailPaths>> | null = null;
+
+export const getClient = () => {
+  if (!client) {
+    client = createSafClient<paths>("identity");
+  }
+  return client;
+};
+export const getEmailClient = () => {
+  if (!emailClient) {
+    emailClient = createSafClient<emailPaths>("identity");
+  }
+  return emailClient;
+};
 
 declare module "@tanstack/vue-query" {
   interface Register {

--- a/identity/auth/requests/users.ts
+++ b/identity/auth/requests/users.ts
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/vue-query";
-import { client } from "./client";
+import { getClient } from "./client";
 import type { IdentityResponseBody } from "@saflib/identity-spec";
 import { handleClientMethod } from "@saflib/sdk";
 import { TanstackError } from "@saflib/sdk";
@@ -7,7 +7,7 @@ export const useUsersQuery = () => {
   return useQuery<IdentityResponseBody["listUsers"][200], TanstackError>({
     queryKey: ["auth", "users"],
     queryFn: async () => {
-      return handleClientMethod(client.GET("/users"));
+      return handleClientMethod(getClient().GET("/users"));
     },
   });
 };

--- a/links/index.ts
+++ b/links/index.ts
@@ -19,6 +19,7 @@ export type LinkMap = Record<string, Link>;
  */
 export interface LinkOptions {
   params?: Record<string, string>;
+  domain?: string;
 }
 
 /**
@@ -29,7 +30,12 @@ export const linkToHref = (link: Link, options?: LinkOptions): string => {
   let domain = "";
   let protocol = "";
   if (globalThis.document) {
-    domain = document.location.hostname.split(".").slice(-2).join(".");
+    if (!options?.domain) {
+      throw new Error(
+        "domain is required when using linkToHref in the browser",
+      );
+    }
+    domain = options.domain;
     protocol = document.location.protocol;
   } else {
     domain = typedEnv.DOMAIN;

--- a/links/index.ts
+++ b/links/index.ts
@@ -54,13 +54,3 @@ export const linkToHref = (link: Link, options?: LinkOptions): string => {
   }
   return `${protocol}//${link.subdomain ? `${link.subdomain}.` : ""}${domain}${path}`;
 };
-
-/**
- * Simple utility to do a full page redirect to a link.
- *
- * TODO: This should use vue-router instead of window.location.href where possible.
- */
-export const navigateToLink = (link: Link, options?: LinkOptions) => {
-  const href = linkToHref(link, options);
-  window.location.href = href;
-};

--- a/links/index.ts
+++ b/links/index.ts
@@ -15,27 +15,6 @@ export type Link = {
 export type LinkMap = Record<string, Link>;
 
 /**
- * Given a Link object, return props which will work with vuetify components such as v-list-item and b-btn.
- * What is returned is based on the current domain; if the link is to the same subdomain, this returns a "to" prop,
- * otherwise it returns an "href" prop. That way a link will use vue-router wherever possible, to avoid full page
- * reloads.
- */
-export const linkToProps = (link: Link) => {
-  const currentSubdomain = document.location.hostname
-    .split(".")
-    .slice(0, -2)
-    .join(".");
-  if (currentSubdomain === link.subdomain) {
-    return {
-      to: link.path,
-    };
-  }
-  return {
-    href: linkToHref(link),
-  };
-};
-
-/**
  * Options for creating a fully-qualified url.
  */
 export interface LinkOptions {

--- a/links/links.test.ts
+++ b/links/links.test.ts
@@ -1,39 +1,44 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import { linkToHref } from "./index.ts";
 import { typedEnv } from "@saflib/env";
+import { setClientName } from "@saflib/vue";
 beforeEach(() => {
   globalThis.document = {
-    location: { hostname: "subdomain-a.docker.localhost", protocol: "http:" },
+    location: { hostname: "test.docker.localhost", protocol: "http:" },
   } as unknown as Document;
+  setClientName("test");
 });
 
 describe("linkToHref", () => {
   it("returns the correct href for a link", () => {
-    expect(linkToHref({ subdomain: "test", path: "/" })).toBe(
-      "http://test.docker.localhost/",
-    );
+    expect(
+      linkToHref(
+        { subdomain: "test", path: "/" },
+        { domain: "docker.localhost" },
+      ),
+    ).toBe("http://test.docker.localhost/");
   });
 
   it("adds query params to the href", () => {
     expect(
       linkToHref(
         { subdomain: "test", path: "/", params: ["a", "b"] },
-        { params: { a: "1", b: "2" } },
+        { params: { a: "1", b: "2" }, domain: "docker.localhost" },
       ),
     ).toBe("http://test.docker.localhost/?a=1&b=2");
   });
 
   it("handles an empty subdomain", () => {
-    expect(linkToHref({ subdomain: "", path: "/" })).toBe(
-      "http://docker.localhost/",
-    );
+    expect(
+      linkToHref({ subdomain: "", path: "/" }, { domain: "docker.localhost" }),
+    ).toBe("http://docker.localhost/");
   });
 
   it("throws an error if a param is not found in the link", () => {
     expect(() =>
       linkToHref(
         { subdomain: "test", path: "/", params: ["a", "b"] },
-        { params: { a: "1", c: "2" } },
+        { params: { a: "1", c: "2" }, domain: "docker.localhost" },
       ),
     ).toThrow("Param c not found in link /");
   });

--- a/links/links.test.ts
+++ b/links/links.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it } from "vitest";
-import { linkToHref, linkToProps } from "./index.ts";
+import { linkToHref } from "./index.ts";
 import { typedEnv } from "@saflib/env";
 beforeEach(() => {
   globalThis.document = {
@@ -45,15 +45,5 @@ describe("linkToHref", () => {
     expect(linkToHref({ subdomain: "test", path: "/" })).toBe(
       "https://test.some.domain/",
     );
-  });
-});
-describe("linkToProps", () => {
-  it("returns href for links to other subdomains, and to for links to the same subdomain", () => {
-    expect(linkToProps({ subdomain: "subdomain-a", path: "/" })).toEqual({
-      to: "/",
-    });
-    expect(linkToProps({ subdomain: "subdomain-b", path: "/" })).toEqual({
-      href: "http://subdomain-b.docker.localhost/",
-    });
   });
 });

--- a/monorepo/tsconfig.json
+++ b/monorepo/tsconfig.json
@@ -14,6 +14,8 @@
     "skipLibCheck": true,
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
-    "verbatimModuleSyntax": true
-  }
+    "verbatimModuleSyntax": true,
+    "skipDefaultLibCheck": true
+  },
+  "exclude": ["**/node_modules/**", "**/dist/**"]
 }

--- a/playwright/global.setup.ts
+++ b/playwright/global.setup.ts
@@ -1,6 +1,7 @@
 import { expect, test as setup } from "@playwright/test";
 
 const serviceSubdomains = process.env.SERVICE_SUBDOMAINS?.split(",") || [];
+const domain = process.env.DOMAIN;
 
 setup("check docker service health", async ({ page }) => {
   let response;
@@ -12,9 +13,7 @@ setup("check docker service health", async ({ page }) => {
     anyUnhealthy = false;
     for (const serviceSubdomain of serviceSubdomains) {
       // uses @saflib/express's health middleware
-      response = await page.goto(
-        `http://${serviceSubdomain}.docker.localhost/health`,
-      );
+      response = await page.goto(`http://${serviceSubdomain}.${domain}/health`);
       if (response && response.status() !== 200) {
         anyUnhealthy = true;
         break;

--- a/sdk/index.ts
+++ b/sdk/index.ts
@@ -6,6 +6,7 @@
 import { QueryClient } from "@tanstack/vue-query";
 import createClient from "openapi-fetch";
 import { isTestEnv } from "./wip-env.ts";
+import { getProtocol, getHost } from "@saflib/vue";
 
 export { isTestEnv };
 
@@ -13,16 +14,17 @@ export { isTestEnv };
  * Given a "paths" openapi generated type and a subdomain, creates a typed `openapi-fetch` client which queries the given subdomain. Uses the current domain and protocol. Handles CSRF token injection, and works in tests.
  */
 export const createSafClient = <Q extends {}>(
-  subdomain: string,
+  serviceSubdomain: string,
 ): ReturnType<typeof createClient<Q>> => {
   let protocol = "http";
   let host = "localhost:3000";
   if (typeof document !== "undefined") {
-    protocol = document.location.protocol;
-    host = document.location.host.split(".").slice(-2).join(".");
+    protocol = getProtocol();
+    host = getHost();
   }
+  const baseUrl = `${protocol}//${serviceSubdomain}.${host}`;
   return createClient<Q>({
-    baseUrl: `${protocol}//${subdomain}.${host}`,
+    baseUrl,
     credentials: "include",
     fetch: (request) => {
       // this is little noop wrapper is required for msw to work

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -10,8 +10,9 @@ import { typedEnv } from "./env.ts";
 import fs from "fs";
 
 const subdomains = typedEnv.CLIENT_SUBDOMAINS?.split(",") ?? [];
+const domain = typedEnv.DOMAIN;
 const hosts = subdomains.map((subdomain) =>
-  subdomain === "" ? "docker.localhost" : `${subdomain}.docker.localhost`,
+  subdomain === "" ? domain : `${subdomain}.${domain}`,
 );
 
 const subDomainProxyPlugin: Plugin = {
@@ -24,7 +25,11 @@ const subDomainProxyPlugin: Plugin = {
       }
       for (const host of hosts) {
         if (req.headers.host === host) {
-          const subdomain = host.split(".").slice(0, -2).join(".");
+          const subdomain = host
+            .replace(`${domain}`, "")
+            .split(".")
+            .filter(Boolean)
+            .join(".");
           req.url = `/${subdomain}/index.html`;
           next();
           return;

--- a/vue/components/SpaLink.vue
+++ b/vue/components/SpaLink.vue
@@ -20,7 +20,7 @@
  * If you just want a simple piece-of-text link, though, this is your component.
  */
 
-import { type Link, linkToProps } from "@saflib/links";
+import { type Link, linkToProps } from "@saflib/vue";
 
 const { link } = defineProps<{ link: Link }>();
 const linkProps = linkToProps(link);

--- a/vue/components/SpaLink.vue
+++ b/vue/components/SpaLink.vue
@@ -20,7 +20,8 @@
  * If you just want a simple piece-of-text link, though, this is your component.
  */
 
-import { type Link, linkToProps } from "@saflib/vue";
+import { type Link } from "@saflib/links";
+import { linkToProps } from "@saflib/vue";
 
 const { link } = defineProps<{ link: Link }>();
 const linkProps = linkToProps(link);

--- a/vue/src/events.ts
+++ b/vue/src/events.ts
@@ -1,5 +1,5 @@
 import { useRoute } from "vue-router";
-
+import { getClientName } from "./utils.ts";
 /**
  * A function that receives product events as they're emitted.
  */
@@ -29,21 +29,6 @@ export const makeProductEventLogger = <T extends ProductEventCommon>() => {
   };
 };
 
-let clientName = "unknown";
-/**
- * Call when the SPA starts, providing the name of the client. It should be the same as the package name, without the org prefix, so "web-auth" or "web-landing".
- */
-export const setClientName = (client: string) => {
-  clientName = client;
-};
-
-/**
- * Getter for the client name.
- */
-export const getClientName = () => {
-  return clientName;
-};
-
 /**
  * Common fields for all product events.
  */
@@ -68,7 +53,7 @@ export type ProductEventCommon = {
 export const useClientCommon = (componentName: string): ProductEventCommon => {
   const route = useRoute();
   return {
-    client: clientName,
+    client: getClientName(),
     view: route && route.name ? String(route.name) : "unnamed-route",
     component: componentName,
   };

--- a/vue/src/utils.test.ts
+++ b/vue/src/utils.test.ts
@@ -1,0 +1,13 @@
+import { linkToProps } from "./utils";
+import { describe, it, expect } from "vitest";
+
+describe("linkToProps", () => {
+  it("returns href for links to other subdomains, and to for links to the same subdomain", () => {
+    expect(linkToProps({ subdomain: "subdomain-a", path: "/" })).toEqual({
+      to: "/",
+    });
+    expect(linkToProps({ subdomain: "subdomain-b", path: "/" })).toEqual({
+      href: "http://subdomain-b.docker.localhost/",
+    });
+  });
+});

--- a/vue/src/utils.test.ts
+++ b/vue/src/utils.test.ts
@@ -1,13 +1,15 @@
-import { linkToProps } from "./utils";
+import { linkToProps, setClientName, getHost } from "./utils";
 import { describe, it, expect } from "vitest";
 
 describe("linkToProps", () => {
   it("returns href for links to other subdomains, and to for links to the same subdomain", () => {
+    setClientName("subdomain-a");
     expect(linkToProps({ subdomain: "subdomain-a", path: "/" })).toEqual({
       to: "/",
     });
+    const domain = getHost();
     expect(linkToProps({ subdomain: "subdomain-b", path: "/" })).toEqual({
-      href: "http://subdomain-b.docker.localhost/",
+      href: `http://subdomain-b.${domain}/`,
     });
   });
 });

--- a/vue/src/utils.ts
+++ b/vue/src/utils.ts
@@ -38,7 +38,8 @@ let clientName = "";
 export const setClientName = (client: string) => {
   if (
     client !== "root" &&
-    !document.location.hostname.startsWith(`${client}.`)
+    !document.location.hostname.startsWith(`${client}.`) &&
+    process.env.NODE_ENV !== "test"
   ) {
     throw new Error(
       `Client name ${client} does not match hostname ${document.location.hostname}`,
@@ -64,7 +65,7 @@ export const getClientName = () => {
  */
 export const linkToProps = (link: Link) => {
   let currentSubdomain = getClientName();
-  if (process.env.NODE_ENV === "test") {
+  if (process.env.NODE_ENV === "test" && !currentSubdomain) {
     currentSubdomain = "test";
   }
   if (!currentSubdomain) {

--- a/vue/src/utils.ts
+++ b/vue/src/utils.ts
@@ -82,3 +82,16 @@ export const linkToProps = (link: Link) => {
 export const linkToHrefWithHost = (link: Link, options?: LinkOptions) => {
   return linkToHref(link, { domain: getHost(), ...options });
 };
+
+/**
+ * Simple utility to do a full page redirect to a link.
+ *
+ * TODO: This should use vue-router instead of window.location.href where possible.
+ */
+export const navigateToLink = (link: Link, options?: LinkOptions) => {
+  const href = linkToHref(link, {
+    domain: getHost(),
+    ...options,
+  });
+  window.location.href = href;
+};

--- a/vue/src/utils.ts
+++ b/vue/src/utils.ts
@@ -1,4 +1,4 @@
-import { type Link, linkToHref } from "@saflib/links";
+import { type Link, type LinkOptions, linkToHref } from "@saflib/links";
 
 /**
  * Utility to get the current host, including the port, e.g. "localhost:3000".
@@ -77,4 +77,8 @@ export const linkToProps = (link: Link) => {
   return {
     href: linkToHref(link, { domain: getHost() }),
   };
+};
+
+export const linkToHrefWithHost = (link: Link, options?: LinkOptions) => {
+  return linkToHref(link, { domain: getHost(), ...options });
 };

--- a/vue/src/utils.ts
+++ b/vue/src/utils.ts
@@ -6,7 +6,6 @@ import { type Link, type LinkOptions, linkToHref } from "@saflib/links";
 export const getHost = () => {
   let host = "localhost:3000";
   if (typeof document !== "undefined" && process.env.NODE_ENV !== "test") {
-    console.log("node env?", process.env.NODE_ENV);
     if (!getClientName()) {
       throw new Error(
         "You must call setClientName with your subdomain before using getHost",

--- a/vue/src/utils.ts
+++ b/vue/src/utils.ts
@@ -31,7 +31,7 @@ export const getProtocol = () => {
   return protocol;
 };
 
-let clientName = "unknown";
+let clientName = "";
 /**
  * Call when the SPA starts, providing the name of the client. It should be the same as the subdomain, or "root" if it's the root domain.
  */

--- a/vue/src/utils.ts
+++ b/vue/src/utils.ts
@@ -6,7 +6,13 @@ import { type Link, linkToHref } from "@saflib/links";
 export const getHost = () => {
   let host = "localhost:3000";
   if (typeof document !== "undefined") {
-    host = document.location.host.replace(getClientName(), "");
+    if (!getClientName()) {
+      throw new Error(
+        "You must call setClientName with your subdomain before using getHost",
+      );
+    }
+    const clientName = getClientName();
+    host = document.location.host.replace(clientName, "");
     if (host.startsWith(".")) {
       host = host.slice(1);
     }
@@ -69,6 +75,6 @@ export const linkToProps = (link: Link) => {
     };
   }
   return {
-    href: linkToHref(link),
+    href: linkToHref(link, { domain: getHost() }),
   };
 };

--- a/vue/src/utils.ts
+++ b/vue/src/utils.ts
@@ -53,12 +53,16 @@ export const getClientName = () => {
  * What is returned is based on the current domain; if the link is to the same subdomain, this returns a "to" prop,
  * otherwise it returns an "href" prop. That way a link will use vue-router wherever possible, to avoid full page
  * reloads.
+ *
+ * The current domain is derived from the client name, which is also the subdomain.
  */
 export const linkToProps = (link: Link) => {
-  const currentSubdomain = document.location.hostname
-    .split(".")
-    .slice(0, -2)
-    .join(".");
+  const currentSubdomain = getClientName();
+  if (!currentSubdomain) {
+    throw new Error(
+      "You must call setClientName with your subdomain before using linkToProps",
+    );
+  }
   if (currentSubdomain === link.subdomain) {
     return {
       to: link.path,

--- a/vue/src/utils.ts
+++ b/vue/src/utils.ts
@@ -1,10 +1,15 @@
+import { type Link, linkToHref } from "@saflib/links";
+
 /**
  * Utility to get the current host, including the port, e.g. "localhost:3000".
  */
 export const getHost = () => {
   let host = "localhost:3000";
   if (typeof document !== "undefined") {
-    host = document.location.host.split(".").slice(-2).join(".");
+    host = document.location.host.replace(getClientName(), "");
+    if (host.startsWith(".")) {
+      host = host.slice(1);
+    }
   }
   return host;
 };
@@ -18,4 +23,48 @@ export const getProtocol = () => {
     protocol = document.location.protocol;
   }
   return protocol;
+};
+
+let clientName = "unknown";
+/**
+ * Call when the SPA starts, providing the name of the client. It should be the same as the subdomain, or "root" if it's the root domain.
+ */
+export const setClientName = (client: string) => {
+  if (
+    client !== "root" &&
+    !document.location.hostname.startsWith(`${client}.`)
+  ) {
+    throw new Error(
+      `Client name ${client} does not match hostname ${document.location.hostname}`,
+    );
+  }
+  clientName = client;
+};
+
+/**
+ * Getter for the client name.
+ */
+export const getClientName = () => {
+  return clientName;
+};
+
+/**
+ * Given a Link object, return props which will work with vuetify components such as v-list-item and b-btn.
+ * What is returned is based on the current domain; if the link is to the same subdomain, this returns a "to" prop,
+ * otherwise it returns an "href" prop. That way a link will use vue-router wherever possible, to avoid full page
+ * reloads.
+ */
+export const linkToProps = (link: Link) => {
+  const currentSubdomain = document.location.hostname
+    .split(".")
+    .slice(0, -2)
+    .join(".");
+  if (currentSubdomain === link.subdomain) {
+    return {
+      to: link.path,
+    };
+  }
+  return {
+    href: linkToHref(link),
+  };
 };

--- a/vue/src/utils.ts
+++ b/vue/src/utils.ts
@@ -5,7 +5,8 @@ import { type Link, type LinkOptions, linkToHref } from "@saflib/links";
  */
 export const getHost = () => {
   let host = "localhost:3000";
-  if (typeof document !== "undefined") {
+  if (typeof document !== "undefined" && process.env.NODE_ENV !== "test") {
+    console.log("node env?", process.env.NODE_ENV);
     if (!getClientName()) {
       throw new Error(
         "You must call setClientName with your subdomain before using getHost",
@@ -63,7 +64,10 @@ export const getClientName = () => {
  * The current domain is derived from the client name, which is also the subdomain.
  */
 export const linkToProps = (link: Link) => {
-  const currentSubdomain = getClientName();
+  let currentSubdomain = getClientName();
+  if (process.env.NODE_ENV === "test") {
+    currentSubdomain = "test";
+  }
   if (!currentSubdomain) {
     throw new Error(
       "You must call setClientName with your subdomain before using linkToProps",


### PR DESCRIPTION
Reworking things to enable more than one product in a repo. This requires letting "domain" be more than two segments, so I can have "app1.docker.localhost" and "app2.docker.localhost" both serve as domains for local development.

*That* means reworking the links and vue libraries a bit, moving some of the vue-specific link logic to the vue library, and updating the "client name" to always be the subdomain. This way the client name is consistent (no need for it to be different than the subdomain) and also the link logic can use the subdomain to determine what the "domain" is.

For this to work, I also need logic which requires the subdomain to be set (like the sdk client) to run after the frontend code even has a chance to set the client name/subdomain.

In summary, figuring out how to have two separate products live in the same repo and deployment made me have to adjust and fix some things.

Also Cursor has started complaining about the typescript server pushing against its memory limit... I might need to figure out how to optimize types. I threw some quick adjustments in this change to see if it helps, but I'll need a proper set up and experimentation to really make headway there.