### PR TITLE
Misc workflow improvements

### DIFF
--- a/email/email-vue/pages/last-mock-email-page/LastMockEmailPage.test.ts
+++ b/email/email-vue/pages/last-mock-email-page/LastMockEmailPage.test.ts
@@ -10,7 +10,7 @@ import { getElementByString } from "@saflib/vue/testing";
 import type { VueWrapper } from "@vue/test-utils";
 import { mountTestApp } from "../test-app.ts";
 import { router } from "../test_router.ts";
-import { identityServiceMockHandlers } from "@saflib/auth/mocks";
+import { identityServiceFakeHandlers } from "@saflib/auth/fakes";
 
 const mockEmails: EmailResponseBody["listSentEmails"][200] = [
   {
@@ -37,7 +37,7 @@ const handlers = [
   http.get("http://app.localhost:3000/email/sent", () => {
     return HttpResponse.json(mockEmails);
   }),
-  ...identityServiceMockHandlers,
+  ...identityServiceFakeHandlers,
 ];
 
 describe("LastMockEmailPage", () => {

--- a/express/workflows/add-handler.ts
+++ b/express/workflows/add-handler.ts
@@ -68,13 +68,6 @@ export const AddHandlerWorkflowDefinition = defineWorkflow<
   },
 
   steps: [
-    step(PromptStepMachine, () => ({
-      promptText: `Make sure this package has the correct spec package installed.
-      
-      Run \`npm install\` to install it if it's not already installed.
-      If you don't know what route is being added as a handler, ask.`,
-    })),
-
     step(CopyStepMachine, ({ context }) => ({
       name: context.targetName,
       targetDir: context.targetDir,

--- a/identity/auth/fakes.ts
+++ b/identity/auth/fakes.ts
@@ -1,9 +1,9 @@
 import {
   authMockConstants,
   authMockHandlers,
-  authMockScenarios,
+  authFakeScenarios,
 } from "./requests/mocks.ts";
 
 export const identityServiceFakeHandlers = [...authMockHandlers];
-export const identityServiceFakeScenarios = { ...authMockScenarios };
+export const identityServiceFakeScenarios = { ...authFakeScenarios };
 export const identityServiceFakeConstants = { ...authMockConstants };

--- a/identity/auth/fakes.ts
+++ b/identity/auth/fakes.ts
@@ -1,0 +1,9 @@
+import {
+  authMockConstants,
+  authMockHandlers,
+  authMockScenarios,
+} from "./requests/mocks.ts";
+
+export const identityServiceFakeHandlers = [...authMockHandlers];
+export const identityServiceFakeScenarios = { ...authMockScenarios };
+export const identityServiceFakeConstants = { ...authMockConstants };

--- a/identity/auth/mocks.ts
+++ b/identity/auth/mocks.ts
@@ -1,9 +1,0 @@
-import {
-  authMockConstants,
-  authMockHandlers,
-  authMockScenarios,
-} from "./requests/mocks.ts";
-
-export const identityServiceMockHandlers = [...authMockHandlers];
-export const identityServiceMockScenarios = { ...authMockScenarios };
-export const identityServiceMockConstants = { ...authMockConstants };

--- a/identity/auth/package.json
+++ b/identity/auth/package.json
@@ -6,7 +6,7 @@
     ".": "./index.ts",
     "./strings": "./strings.ts",
     "./i18n": "./i18n.ts",
-    "./mocks": "./mocks.ts"
+    "./fakes": "./fakes.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/identity/auth/pages/admin-users/UserAdmin.test.ts
+++ b/identity/auth/pages/admin-users/UserAdmin.test.ts
@@ -5,11 +5,11 @@ import { type VueWrapper } from "@vue/test-utils";
 import UserAdmin from "./UserAdmin.vue";
 import { mountTestApp } from "../../test-app.ts";
 import {
-  identityServiceMockHandlers,
-  identityServiceMockConstants,
-} from "../../mocks.ts";
+  identityServiceFakeHandlers,
+  identityServiceFakeConstants,
+} from "../../fakes.ts";
 
-const handlers = [...identityServiceMockHandlers];
+const handlers = [...identityServiceFakeHandlers];
 
 describe("UserAdmin.vue", () => {
   stubGlobals();
@@ -51,7 +51,7 @@ describe("UserAdmin.vue", () => {
 
     // Check if user data is rendered (basic check)
     const tableHtml = table.html();
-    expect(tableHtml).toContain(identityServiceMockConstants.defaultUser.email);
+    expect(tableHtml).toContain(identityServiceFakeConstants.defaultUser.email);
     expect(tableHtml).toContain("Never"); // For the null lastLoginAt
   });
 });

--- a/identity/auth/pages/verify-wall/VerifyWallPage.test.ts
+++ b/identity/auth/pages/verify-wall/VerifyWallPage.test.ts
@@ -4,12 +4,12 @@ import { setupMockServer } from "@saflib/sdk/testing/mock";
 import VerifyWallPageAsync from "./VerifyWallPageAsync.vue";
 import { verify_wall_page as strings } from "./VerifyWallPage.strings.ts";
 import { mountTestApp } from "../../test-app.ts";
-import { identityServiceMockHandlers } from "../../mocks.ts";
+import { identityServiceFakeHandlers } from "../../fakes.ts";
 
 describe("VerifyWallPage", () => {
   stubGlobals();
 
-  const server = setupMockServer(identityServiceMockHandlers);
+  const server = setupMockServer(identityServiceFakeHandlers);
   expect(server).toBeDefined();
 
   it("should render the page with instructions", async () => {

--- a/identity/auth/requests/mocks.ts
+++ b/identity/auth/requests/mocks.ts
@@ -28,7 +28,7 @@ const getUsersHandler = createIdentityHandler({
 });
 
 export const authMockHandlers = [getProfileHandler, getUsersHandler];
-export const authMockScenarios = {
+export const authFakeScenarios = {
   userNotEmailVerified: [
     createIdentityHandler({
       verb: "get",
@@ -38,6 +38,20 @@ export const authMockScenarios = {
         return {
           ...defaultUser,
           emailVerified: false,
+        };
+      },
+    }),
+  ],
+  adminUser: [
+    createIdentityHandler({
+      verb: "get",
+      path: "/auth/profile",
+      status: 200,
+      handler: async () => {
+        return {
+          ...defaultUser,
+          emailVerified: true,
+          isAdmin: true,
         };
       },
     }),

--- a/monorepo/tsconfig.json
+++ b/monorepo/tsconfig.json
@@ -15,7 +15,8 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true,
     "verbatimModuleSyntax": true,
-    "skipDefaultLibCheck": true
+    "skipDefaultLibCheck": true,
+    "noImplicitAny": true
   },
   "exclude": ["**/node_modules/**", "**/dist/**"]
 }

--- a/sdk/workflows/add-component.ts
+++ b/sdk/workflows/add-component.ts
@@ -104,12 +104,12 @@ export const AddComponentWorkflowDefinition = defineWorkflow<
       lineReplace: makeLineReplace(context),
     })),
 
-    step(PromptStepMachine, () => ({
-      promptText: `Export the new Vue component in the root "components.ts" file.`,
+    step(PromptStepMachine, ({ context }) => ({
+      promptText: `Make sure ${context.copiedFiles?.vue} is in the root "components.ts" file.`,
     })),
 
-    step(PromptStepMachine, () => ({
-      promptText: `Export the new strings in the root "strings.ts" file.`,
+    step(PromptStepMachine, ({ context }) => ({
+      promptText: `Make sure ${context.copiedFiles?.strings} is in the root "strings.ts" file.`,
     })),
 
     step(UpdateStepMachine, ({ context }) => ({

--- a/sdk/workflows/add-component.ts
+++ b/sdk/workflows/add-component.ts
@@ -126,7 +126,9 @@ export const AddComponentWorkflowDefinition = defineWorkflow<
       fileId: "test",
       promptMessage: `Update **${path.basename(context.copiedFiles!.test)}** to test the component.
       
-      Make sure to use the mock server, the dedicated test app, and the getElementByString helper function.`,
+      * Make sure to use the dedicated test app, and the getElementByString helper function.
+      * You don't really have to mock the server; the component should not load data directly itself. You also don't have to thoroughly test the component; just give it some sample inputs and make sure it renders correctly.
+      `,
     })),
 
     step(TestStepMachine, () => ({

--- a/sdk/workflows/add-component.ts
+++ b/sdk/workflows/add-component.ts
@@ -118,7 +118,8 @@ export const AddComponentWorkflowDefinition = defineWorkflow<
       
       * The component should take as props some combination of the schemas exported by the adjacent "spec" package. For form components, consider using defineModel() with the schemas from the spec package for two-way data binding. Add any strings to the "strings.ts" file, not directly in the component.
       * Do not use any custom styles; use Vuetify components and styling exclusively.
-      * Use Vuetify skeletons for loading states.`,
+      * Use Vuetify skeletons for loading states.
+      * If this is a form, don't use inputs for any uneditable fields. If this is not a form component, don't use input components at all!`,
     })),
 
     step(UpdateStepMachine, ({ context }) => ({

--- a/sdk/workflows/add-query.ts
+++ b/sdk/workflows/add-query.ts
@@ -92,7 +92,9 @@ export const AddQueryWorkflowDefinition = defineWorkflow<
       fileId: "templateFileFake",
       promptMessage: `Update **${context.targetName}.fake.ts** to implement the fake handlers for testing.
       
-      Mainly it should reflect what is given to it. Have it respect query parameters and request bodies.`,
+      Mainly it should reflect what is given to it. Have it respect query parameters and request bodies.
+      If this is a list query, keep the resources in a separately exported array. Otherwise, import that array and modify/use it accordingly.
+      This way operations affect one another (like creating or deleting resources) so that tanstack caching can be tested.`,
     })),
 
     step(UpdateStepMachine, ({ context }) => ({

--- a/sdk/workflows/init.ts
+++ b/sdk/workflows/init.ts
@@ -61,7 +61,6 @@ export const SdkInitWorkflowDefinition = defineWorkflow<
       relDir,
       reversePath,
     };
-    console.log("ctx", ctx);
     return ctx;
   },
 

--- a/sdk/workflows/init.ts
+++ b/sdk/workflows/init.ts
@@ -49,14 +49,15 @@ export const SdkInitWorkflowDefinition = defineWorkflow<
   sourceUrl: import.meta.url,
 
   context: ({ input }) => {
-    const relDir = path.relative(input.cwd, ctx.targetDir);
+    const targetDir = path.join(input.cwd, input.path);
+    const relDir = path.relative(input.cwd, targetDir);
     const numDirs = relDir.split(path.sep).length;
     const reversePath = "../".repeat(numDirs).slice(0, -1);
     const ctx: SdkInitWorkflowContext = {
       ...parsePackageName(input.name, {
         requiredSuffix: "-sdk",
       }),
-      targetDir: path.join(input.cwd, input.path),
+      targetDir,
       relDir,
       reversePath,
     };

--- a/sdk/workflows/init.ts
+++ b/sdk/workflows/init.ts
@@ -29,6 +29,8 @@ const input = [
 
 interface SdkInitWorkflowContext extends ParsePackageNameOutput {
   targetDir: string;
+  relDir: string;
+  reversePath: string;
 }
 
 export const SdkInitWorkflowDefinition = defineWorkflow<
@@ -47,12 +49,19 @@ export const SdkInitWorkflowDefinition = defineWorkflow<
   sourceUrl: import.meta.url,
 
   context: ({ input }) => {
-    return {
+    const relDir = path.relative(input.cwd, ctx.targetDir);
+    const numDirs = relDir.split(path.sep).length;
+    const reversePath = "../".repeat(numDirs).slice(0, -1);
+    const ctx: SdkInitWorkflowContext = {
       ...parsePackageName(input.name, {
         requiredSuffix: "-sdk",
       }),
       targetDir: path.join(input.cwd, input.path),
+      relDir,
+      reversePath,
     };
+    console.log("ctx", ctx);
+    return ctx;
   },
 
   templateFiles: {
@@ -60,6 +69,7 @@ export const SdkInitWorkflowDefinition = defineWorkflow<
     app: path.join(sourceDir, "App.vue"),
     client: path.join(sourceDir, "client.ts"),
     components: path.join(sourceDir, "components.ts"),
+    dockerfile: path.join(sourceDir, "Dockerfile.template"),
     dockerCompose: path.join(sourceDir, "docker-compose.yaml"),
     fakes: path.join(sourceDir, "fakes.ts"),
     i18n: path.join(sourceDir, "i18n.ts"),

--- a/sdk/workflows/templates/Dockerfile.template
+++ b/sdk/workflows/templates/Dockerfile.template
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:labs
+FROM node:22-slim AS builder
+
+# Copy package.json
+WORKDIR /app
+
+#{ copy_packages }#
+RUN npm install
+RUN npm install @rollup/rollup-linux-arm64-gnu
+
+#{ copy_src }#
+
+# Vue app setup
+WORKDIR /app/__rel-dir__

--- a/sdk/workflows/templates/docker-compose.yaml
+++ b/sdk/workflows/templates/docker-compose.yaml
@@ -9,5 +9,5 @@ services:
     command: npm run dev
     volumes:
       - ./:/app/__rel-dir__/
-      - __reverse-path__/vue/:/app/saflib/vue/
-      - __reverse-path__/sdk/:/app/saflib/sdk/
+      - __reverse-path__/saflib/vue/:/app/saflib/vue/
+      - __reverse-path__/saflib/sdk/:/app/saflib/sdk/

--- a/sdk/workflows/templates/docker-compose.yaml
+++ b/sdk/workflows/templates/docker-compose.yaml
@@ -4,10 +4,10 @@ services:
     ports:
       - 5173:5173
     build:
-      context: ../..
-      dockerfile: ./__service-name__/__service-name__-sdk/Dockerfile
+      context: __reverse-path__
+      dockerfile: ./__rel-dir__/Dockerfile
     command: npm run dev
     volumes:
-      - ./:/app/__service-name__/__service-name__-sdk/
-      - ../../vue/:/app/vue/
-      - ../../sdk/:/app/sdk/
+      - ./:/app/__rel-dir__/
+      - __reverse-path__/vue/:/app/saflib/vue/
+      - __reverse-path__/sdk/:/app/saflib/sdk/

--- a/sdk/workflows/templates/fakes.ts
+++ b/sdk/workflows/templates/fakes.ts
@@ -2,7 +2,9 @@
 // These only export the fake files, so that they're only used in tests
 // This also allows the fake in-memory store to automatically refresh the data after each test
 
-// TODO: Export the main mock handlers array
+import { identityServiceFakeHandlers } from "@saflib/auth/fakes";
+
 export const __serviceName__ServiceFakeHandlers = [
   // add fake handlers here
+  ...identityServiceFakeHandlers,
 ];

--- a/sdk/workflows/templates/package.json
+++ b/sdk/workflows/templates/package.json
@@ -14,7 +14,8 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "typecheck": "vue-tsc",
-    "dev": "vite"
+    "dev": "vite",
+    "dev-docker": "npm exec saf-docker generate && docker compose up --build"
   },
   "devDependencies": {
     "@saflib/vitest": "*",

--- a/sdk/workflows/templates/router.ts
+++ b/sdk/workflows/templates/router.ts
@@ -3,8 +3,14 @@ import {
   createRouter,
   type RouteRecordRaw,
 } from "vue-router";
+import { StubComponent } from "@saflib/vue/components";
 
-const routes: RouteRecordRaw[] = [];
+const routes: RouteRecordRaw[] = [
+  {
+    path: "/",
+    component: StubComponent,
+  },
+];
 
 export const router = createRouter({
   history: createWebHistory(),

--- a/vue/components/StubComponent.vue
+++ b/vue/components/StubComponent.vue
@@ -1,0 +1,13 @@
+<template>
+  <v-container class="pa-4">
+    <h1>Stub View</h1>
+    <v-alert type="info"
+      >This is a stub view. There should be an icon on the left. This box should
+      be blue.</v-alert
+    >
+  </v-container>
+</template>
+
+<script setup lang="ts"></script>
+
+<style scoped></style>

--- a/vue/components/index.ts
+++ b/vue/components/index.ts
@@ -1,2 +1,3 @@
 export { AsyncPage } from "./tricky-imports.ts";
 export { default as SpaLink } from "./SpaLink.vue";
+export { default as StubComponent } from "./StubComponent.vue";

--- a/vue/workflows/add-page.ts
+++ b/vue/workflows/add-page.ts
@@ -88,7 +88,8 @@ export const AddSpaPageWorkflowDefinition = defineWorkflow<
       
       Other notes:
       * Don't create the UX just yet; focus on making sure the data is loading properly.
-      * Do not add any sort of loading state or skeleton; that's the job of the "Async" component.`,
+      * Do not add any sort of loading state or skeleton; that's the job of the "Async" component.
+      * Don't break reactivity! Render the data directly from the tanstack queries, or if necessary create a computed property.`,
     })),
 
     step(PromptStepMachine, ({ context }) => ({

--- a/vue/workflows/template/test-app.ts
+++ b/vue/workflows/template/test-app.ts
@@ -3,7 +3,7 @@ import type { ComponentMountingOptions } from "@vue/test-utils";
 import type { Component } from "vue";
 import { router } from "./router.ts";
 import { __subdomain_name___strings } from "./strings.ts";
-import { identityServiceMockHandlers } from "@saflib/auth/mocks";
+import { identityServiceFakeHandlers } from "@saflib/auth/fakes";
 
 export const mountTestApp = <C extends Component>(
   Component: C,
@@ -18,4 +18,4 @@ export const mountTestApp = <C extends Component>(
 };
 
 // TODO: import and add here any other mock handlers from sdk packages this SPA depends on
-export const testAppHandlers = [...identityServiceMockHandlers];
+export const testAppHandlers = [...identityServiceFakeHandlers];

--- a/workflows/bin/saf-workflow/kickoff.ts
+++ b/workflows/bin/saf-workflow/kickoff.ts
@@ -28,7 +28,6 @@ export const addKickoffCommand = (
     .addOption(runModeOption)
     .action(
       async (filePath: string, args: string[], options: { run?: string }) => {
-        console.log("Kickoff command");
         writeFileSync(logFile, "");
         const runMode = options.run;
         const givenRunMode = parseRunMode(runMode);

--- a/workflows/bin/saf-workflow/kickoff.ts
+++ b/workflows/bin/saf-workflow/kickoff.ts
@@ -28,6 +28,7 @@ export const addKickoffCommand = (
     .addOption(runModeOption)
     .action(
       async (filePath: string, args: string[], options: { run?: string }) => {
+        console.log("Kickoff command");
         writeFileSync(logFile, "");
         const runMode = options.run;
         const givenRunMode = parseRunMode(runMode);
@@ -43,6 +44,7 @@ export const addKickoffCommand = (
           workflowDefinition = workflows.find((w) => w.id === filePath);
         }
         if (!workflowDefinition) {
+          console.log("Workflow definition not found");
           process.exit(1);
         }
 

--- a/workflows/bin/saf-workflow/shared/workflow.ts
+++ b/workflows/bin/saf-workflow/shared/workflow.ts
@@ -99,6 +99,7 @@ export class XStateWorkflowRunner extends AbstractWorkflowRunner {
   }
 
   kickoff = async (options?: WorkflowRunOptions): Promise<boolean> => {
+    const t0 = Date.now();
     const actor = createActor(this.machine, { input: this.input });
     this.actor = actor;
     actor.start();
@@ -114,6 +115,8 @@ export class XStateWorkflowRunner extends AbstractWorkflowRunner {
       return false;
     }
     await pollingWaitFor(actor, workflowAllSettled);
+    const t1 = Date.now();
+    console.log(`Time taken: ${(t1 - t0) / 1000 / 60}m`);
     return actor.getSnapshot().status !== "error";
   };
 
@@ -151,6 +154,7 @@ export class XStateWorkflowRunner extends AbstractWorkflowRunner {
   };
 
   goToNextStep = async (): Promise<void> => {
+    const t0 = Date.now();
     const log = getWorkflowLogger();
     if (!this.actor) {
       throw new Error("Workflow not started");
@@ -162,6 +166,8 @@ export class XStateWorkflowRunner extends AbstractWorkflowRunner {
 
     continueWorkflow(this.actor);
     await pollingWaitFor(this.actor, workflowAllSettled);
+    const t1 = Date.now();
+    console.log(`Time taken: ${(t1 - t0) / 1000 / 60}m`);
 
     if (this.actor.getSnapshot().status === "done") {
       console.log("\n--- This workflow has been completed. ---\n");

--- a/workflows/core/make.ts
+++ b/workflows/core/make.ts
@@ -16,6 +16,7 @@ import {
   setup,
   type AnyStateMachine,
   type InputFrom,
+  type OutputFrom,
 } from "xstate";
 import { contextFromInput } from "./utils.ts";
 import type { WorkflowArgument } from "./types.ts";
@@ -223,9 +224,13 @@ export const makeWorkflowMachine = <C, I extends readonly WorkflowArgument[]>(
 export const step = <C, M extends AnyStateMachine>(
   machine: M,
   input: (arg: { context: C & WorkflowContext }) => InputFrom<M>,
+  options: {
+    validate?: (arg: { output: OutputFrom<M> }) => Promise<string | undefined>;
+  } = {},
 ): WorkflowStep<C, M> => {
   return {
     machine,
     input,
+    validate: options.validate || (() => Promise.resolve(undefined)),
   };
 };

--- a/workflows/core/prompt.ts
+++ b/workflows/core/prompt.ts
@@ -164,6 +164,16 @@ interface CursorToolCallLog {
         };
       };
     };
+    semSearchToolCall?: {
+      args: {
+        query: string;
+      };
+      result?: {
+        success: {
+          results: string;
+        };
+      };
+    };
   };
 }
 
@@ -358,6 +368,19 @@ export const executePrompt = async ({
               }
               printLineSlowly(`> Files listed: ${numFiles}`);
               printLineSlowly(`> Dirs listed: ${numDirs}`);
+            }
+          }
+        } else if (json.tool_call.semSearchToolCall) {
+          if (json.subtype === "started") {
+            printLineSlowly(
+              `> Searching for: ${json.tool_call.semSearchToolCall.args.query}`,
+            );
+          }
+          if (json.subtype === "completed") {
+            if (json.tool_call.semSearchToolCall.result?.success) {
+              printLineSlowly(
+                `> Search results: ${json.tool_call.semSearchToolCall.result.success.results}`,
+              );
             }
           }
         } else {

--- a/workflows/core/prompt.ts
+++ b/workflows/core/prompt.ts
@@ -101,7 +101,7 @@ interface CursorToolCallLog {
     };
     globToolCall?: {
       args: {
-        targetDirectory: string;
+        targetDirectory?: string;
         globPattern: string;
       };
       result?: {
@@ -266,7 +266,7 @@ export const executePrompt = async ({
         } else if (json.tool_call.globToolCall) {
           if (json.subtype === "started") {
             printLineSlowly(
-              `> Globbing files: ${relativePath(json.tool_call.globToolCall.args.globPattern)} in ${relativePath(json.tool_call.globToolCall.args.targetDirectory)}`,
+              `> Globbing files: ${relativePath(json.tool_call.globToolCall.args.globPattern)} in ${relativePath(json.tool_call.globToolCall.args.targetDirectory || "entire project")}`,
             );
           } else if (json.subtype === "completed") {
             if (json.tool_call.globToolCall.result?.success) {

--- a/workflows/core/prompt.ts
+++ b/workflows/core/prompt.ts
@@ -346,7 +346,7 @@ export const executePrompt = async ({
                 json.tool_call.grepToolCall.result.success.workspaceResults,
               );
               const linesFound = workspaces.reduce(
-                (acc, workspace) => acc + workspace.content.totalLines,
+                (acc, workspace) => acc + workspace.content.totalLines || 0,
                 0,
               );
               printLineSlowly(`> Grep successful: ${linesFound} lines found`);

--- a/workflows/core/steps/update/update-template-machine.ts
+++ b/workflows/core/steps/update/update-template-machine.ts
@@ -60,12 +60,16 @@ export interface UpdateStepContext extends WorkflowContext {
   hasTodos?: boolean;
 }
 
+export interface UpdateStepOutput extends WorkflowOutput {
+  filePath: string;
+}
+
 /**
  * Prompts the agent to update one of the templateFiles that was copied over by the CopyStepMachine.
  */
 export const UpdateStepMachine = setup({
   types: {
-    output: {} as WorkflowOutput,
+    output: {} as UpdateStepOutput,
     input: {} as UpdateStepInput & WorkflowInput,
     context: {} as UpdateStepContext,
   },
@@ -242,6 +246,7 @@ export const UpdateStepMachine = setup({
       checklist: {
         description: promptMessage.split("\n")[0],
       },
+      filePath: context.filePath,
     };
   },
 });

--- a/workflows/core/types.ts
+++ b/workflows/core/types.ts
@@ -7,6 +7,7 @@ import {
   type InputFrom,
   type PromiseActorLogic,
   type MachineContext,
+  type OutputFrom,
 } from "xstate";
 
 /**
@@ -15,6 +16,7 @@ import {
 export type WorkflowStep<C, M extends AnyStateMachine> = {
   machine: M;
   input: (arg: { context: C & WorkflowContext }) => InputFrom<M>;
+  validate: (arg: { output: OutputFrom<M> }) => Promise<string | undefined>;
 };
 
 /**


### PR DESCRIPTION
Today's an exciting day! Today was the first day I had the agent just running continuously on workflows, and the whole system didn't come crashing down. I think I'm getting to the point where my focus is shifting mostly to just improving workflows, and building product can mostly happen in the background.

To that end, here are some more improvements:
* Renamed identity mocks to fakes, which they are.
* Added an admin scenario.
* Some prompt tweaks for adding components.
* Improved the sdk init so that the docker command is provided, and works, and has identity fakes by default
* Also the sdk test app renders a stub component. That it gets from @saflib/vue, which has one now.
* Some tweaks to adding pages
* Add timestamps to workflows, and duration
* Add a validation option to workflow steps. Doesn't work yet, though, but the types do! I'll add the actual feature in a later PR.
* Some more cursor-agent logging handling improvements. Adding them as I see them.