### PR TITLE
Fix npm exec on Linux

### DIFF
--- a/commander/workflows/templates/index.ts
+++ b/commander/workflows/templates/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-strip-types --disable-warning=ExperimentalWarning
+#!/usr/bin/env -S node --experimental-strip-types --disable-warning=ExperimentalWarning
 import { Command } from "commander";
 import { setupContext } from "@saflib/commander";
 

--- a/dev-tools/bin/saf-docs-cli/index.ts
+++ b/dev-tools/bin/saf-docs-cli/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-strip-types --disable-warning=ExperimentalWarning
+#!/usr/bin/env -S node --experimental-strip-types --disable-warning=ExperimentalWarning
 
 import { Command } from "commander";
 import { buildMonorepoContext } from "@saflib/dev-tools";

--- a/dev-tools/src/saf-docker-cli.ts
+++ b/dev-tools/src/saf-docker-cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-strip-types --disable-warning=ExperimentalWarning
+#!/usr/bin/env -S node --experimental-strip-types --disable-warning=ExperimentalWarning
 
 import { Command } from "commander";
 import { generateDockerfiles } from "./docker.ts";

--- a/dev-tools/src/saf-tests-cli.ts
+++ b/dev-tools/src/saf-tests-cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-strip-types --disable-warning=ExperimentalWarning
+#!/usr/bin/env -S node --experimental-strip-types --disable-warning=ExperimentalWarning
 
 import { Command } from "commander";
 import { gatherHealthAssets } from "./test-assets.ts";

--- a/env/src/saf-env-cli.ts
+++ b/env/src/saf-env-cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-strip-types --disable-warning=ExperimentalWarning
+#!/usr/bin/env -S node --experimental-strip-types --disable-warning=ExperimentalWarning
 import { Command } from "commander";
 import { getCombinedEnvSchema, makeEnvParserSnippet } from "./env.ts";
 import { writeFileSync, existsSync } from "fs";

--- a/monorepo/bin/format.ts
+++ b/monorepo/bin/format.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-strip-types --disable-warning=ExperimentalWarning
+#!/usr/bin/env -S node --experimental-strip-types --disable-warning=ExperimentalWarning
 
 import { execSync } from "child_process";
 

--- a/openapi/bin/saf-specs/index.ts
+++ b/openapi/bin/saf-specs/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-strip-types --disable-warning=ExperimentalWarning
+#!/usr/bin/env -S node --experimental-strip-types --disable-warning=ExperimentalWarning
 import { Command } from "commander";
 import { setupContext } from "@saflib/commander";
 import { addGenerateCommand } from "./generate.ts";

--- a/vitest/test-coverage.ts
+++ b/vitest/test-coverage.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-strip-types
+#!/usr/bin/env -S node --experimental-strip-types
 
 // Run `TZ=UTC vitest run --coverage` in the current directory
 // and tee the output to a file.

--- a/workflows-cli/workflow-cli.ts
+++ b/workflows-cli/workflow-cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --experimental-strip-types --disable-warning=ExperimentalWarning
+#!/usr/bin/env -S node --experimental-strip-types --disable-warning=ExperimentalWarning
 
 import { runWorkflowCli } from "@saflib/workflows";
 import { workflows } from "./list.ts";

--- a/workflows/docs/README.md
+++ b/workflows/docs/README.md
@@ -37,7 +37,7 @@ To bootstrap workflows:
 3. Add the `workflow-cli.ts` file:
 
 ```ts
-#!/usr/bin/env node --experimental-strip-types --disable-warning=ExperimentalWarning
+#!/usr/bin/env -S node --experimental-strip-types --disable-warning=ExperimentalWarning
 
 import metaWorkflows from "saflib-workflows/workflows";
 import { runWorkflowCli } from "saflib-workflows";


### PR DESCRIPTION
Previously this would infinitely recurse invoking `env` over and over
again. It's an exercise for the reader to figure out why.
