### PR TITLE
Vue, auth, identity, doc updates

### DIFF
--- a/identity/auth/requests/mocks.ts
+++ b/identity/auth/requests/mocks.ts
@@ -1,6 +1,6 @@
 import { createIdentityHandler } from "../typed-mock.ts";
 
-const defaultUser = {
+export const defaultUser = {
   id: "1",
   email: "john.doe@example.com",
   name: "John Doe",

--- a/identity/identity-http/env.schema.json
+++ b/identity/identity-http/env.schema.json
@@ -5,6 +5,10 @@
       "type": "string",
       "description": "Comma-separated list of emails who will get the 'admin' scope. Emails must be validated to receive this scope."
     },
+    "IDENTITY_SERVICE_ADMIN_SIGNUP_ONLY": {
+      "type": "string",
+      "description": "When set to 'true', only emails listed in IDENTITY_SERVICE_ADMIN_EMAILS may register. All other signups return 403."
+    },
     "IDENTITY_SERVICE_DISABLE_RATE_LIMITING": {
       "type": "string",
       "description": "Whether to disable rate limiting. Set to 'true' to disable."

--- a/identity/identity-http/env.ts
+++ b/identity/identity-http/env.ts
@@ -29,6 +29,10 @@ export interface IdentityHttpEnvSchema {
    */
   IDENTITY_SERVICE_ADMIN_EMAILS?: string;
   /**
+   * When set to 'true', only emails listed in IDENTITY_SERVICE_ADMIN_EMAILS may register. All other signups return 403.
+   */
+  IDENTITY_SERVICE_ADMIN_SIGNUP_ONLY?: string;
+  /**
    * Whether to disable rate limiting. Set to 'true' to disable.
    */
   IDENTITY_SERVICE_DISABLE_RATE_LIMITING?: string;
@@ -77,6 +81,4 @@ export interface IdentityHttpEnvSchema {
 /**
  * `process.env` casted to the `IdentityHttpEnvSchema` type.
  */
-export const typedEnv = (globalThis.process
-  ? process.env
-  : {}) as unknown as IdentityHttpEnvSchema;
+export const typedEnv = (globalThis.process ? process.env : {}) as unknown as IdentityHttpEnvSchema;

--- a/identity/identity-http/routes/auth/register.ts
+++ b/identity/identity-http/routes/auth/register.ts
@@ -11,12 +11,26 @@ import { authServiceStorage } from "@saflib/identity-common";
 import { linkToHref } from "@saflib/links";
 import { authLinks } from "@saflib/auth-links";
 import { getSafReporters } from "@saflib/node";
+import { typedEnv } from "../../env.ts";
 
 export const registerHandler = createHandler(async (req, res) => {
   const { dbKey } = authServiceStorage.getStore()!;
   const registerRequest: IdentityRequestBody["registerUser"] = req.body;
   const { email, password, name, givenName, familyName } = registerRequest;
   const { logError } = getSafReporters();
+
+  if (typedEnv.IDENTITY_SERVICE_ADMIN_SIGNUP_ONLY === "true") {
+    const adminEmails = req.app.get("saf:admin emails") as Set<string>;
+    const isAllowedEmail = [...adminEmails].some(
+      (e) => e.trim().toLowerCase() === email.trim().toLowerCase(),
+    );
+    if (!isAllowedEmail) {
+      res.status(403).json({
+        message: "Signup is restricted to allowed emails only.",
+      });
+      return;
+    }
+  }
 
   const passwordHash = await argon2.hash(password);
 

--- a/identity/identity-spec/dist/openapi.d.ts
+++ b/identity/identity-spec/dist/openapi.d.ts
@@ -4,733 +4,742 @@
  */
 
 export interface paths {
-  "/auth/register": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/register": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Register New User */
+        post: operations["registerUser"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Register New User */
-    post: operations["registerUser"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/login": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Authenticate User */
+        post: operations["loginUser"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Authenticate User */
-    post: operations["loginUser"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/logout": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Logout User */
+        post: operations["logoutUser"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Logout User */
-    post: operations["logoutUser"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/verify": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/verify": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Verify Authentication Status
+         * @description Used by Caddy for forward authentication. Verifies if the user is authenticated and adds user information headers for downstream services.
+         */
+        get: operations["verifyAuth"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Verify Authentication Status
-     * @description Used by Caddy for forward authentication. Verifies if the user is authenticated and adds user information headers for downstream services.
-     */
-    get: operations["verifyAuth"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/forgot-password": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/forgot-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Request Password Reset */
+        post: operations["forgotPassword"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Request Password Reset */
-    post: operations["forgotPassword"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/reset-password": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/reset-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Reset Password Using Token */
+        post: operations["resetPassword"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Reset Password Using Token */
-    post: operations["resetPassword"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/verify-email": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/verify-email": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Verify Email Address */
+        post: operations["verifyEmail"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Verify Email Address */
-    post: operations["verifyEmail"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/resend-verification": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/resend-verification": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Resend Verification Email */
+        post: operations["resendVerification"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Resend Verification Email */
-    post: operations["resendVerification"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/set-password": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/set-password": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Change User Password */
+        post: operations["setPassword"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    get?: never;
-    put?: never;
-    /** Change User Password */
-    post: operations["setPassword"];
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/auth/profile": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/auth/profile": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Get User Profile
+         * @description Get the profile information for the currently logged in user. Returns an empty object if the user is not authenticated.
+         */
+        get: operations["getUserProfile"];
+        /**
+         * Update User Profile
+         * @description Update the profile information for the currently logged in user
+         */
+        put: operations["updateUserProfile"];
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /**
-     * Get User Profile
-     * @description Get the profile information for the currently logged in user. Returns an empty object if the user is not authenticated.
-     */
-    get: operations["getUserProfile"];
-    /**
-     * Update User Profile
-     * @description Update the profile information for the currently logged in user
-     */
-    put: operations["updateUserProfile"];
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
-  "/users": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/users": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List all users */
+        get: operations["listUsers"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** List all users */
-    get: operations["listUsers"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    Error: components["schemas"]["error"];
-    User: components["schemas"]["user"];
-    user: {
-      id?: string;
-      /** Format: email */
-      email?: string;
-      /** @description Whether the user's email address has been verified */
-      emailVerified?: boolean;
-      /** @description User's full name (optional) */
-      name?: string;
-      /** @description User's given name (optional) */
-      givenName?: string;
-      /** @description User's family name (optional) */
-      familyName?: string;
-      /**
-       * Format: date-time
-       * @description Date and time the user was created
-       */
-      createdAt?: string;
-      /**
-       * Format: date-time
-       * @description Date and time the user last logged in
-       */
-      lastLoginAt?: string;
-      /**
-       * Format: date-time
-       * @description Date and time the user's email was verified
-       */
-      verifiedAt?: string;
-      /** @description List of user's permission scopes */
-      scopes?: string[];
-      /** @description Whether the user has admin privileges */
-      isAdmin?: boolean;
+    schemas: {
+        Error: components["schemas"]["error"];
+        User: components["schemas"]["user"];
+        user: {
+            id?: string;
+            /** Format: email */
+            email?: string;
+            /** @description Whether the user's email address has been verified */
+            emailVerified?: boolean;
+            /** @description User's full name (optional) */
+            name?: string;
+            /** @description User's given name (optional) */
+            givenName?: string;
+            /** @description User's family name (optional) */
+            familyName?: string;
+            /**
+             * Format: date-time
+             * @description Date and time the user was created
+             */
+            createdAt?: string;
+            /**
+             * Format: date-time
+             * @description Date and time the user last logged in
+             */
+            lastLoginAt?: string;
+            /**
+             * Format: date-time
+             * @description Date and time the user's email was verified
+             */
+            verifiedAt?: string;
+            /** @description List of user's permission scopes */
+            scopes?: string[];
+            /** @description Whether the user has admin privileges */
+            isAdmin?: boolean;
+        };
+        error: {
+            /** @description A short, machine-readable error code, for when HTTP status codes are not sufficient. */
+            code?: string;
+            /**
+             * @description A human-readable description of the error.
+             * @example The requested resource could not be found.
+             */
+            message?: string;
+        };
     };
-    error: {
-      /** @description A short, machine-readable error code, for when HTTP status codes are not sufficient. */
-      code?: string;
-      /**
-       * @description A human-readable description of the error.
-       * @example The requested resource could not be found.
-       */
-      message?: string;
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  registerUser: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    registerUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** Format: email */
+                    email: string;
+                    password: string;
+                    /** @description User's full name (optional) */
+                    name?: string;
+                    /** @description User's given name (optional) */
+                    givenName?: string;
+                    /** @description User's family name (optional) */
+                    familyName?: string;
+                };
+            };
+        };
+        responses: {
+            /** @description User registered successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["user"];
+                };
+            };
+            /** @description Signup restricted (e.g. admin-only mode); request not allowed */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+            /** @description Email already exists */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
     };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** Format: email */
-          email: string;
-          password: string;
-          /** @description User's full name (optional) */
-          name?: string;
-          /** @description User's given name (optional) */
-          givenName?: string;
-          /** @description User's family name (optional) */
-          familyName?: string;
+    loginUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** Format: email */
+                    email: string;
+                    password: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Successful login */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["user"];
+                };
+            };
+            /** @description Invalid credentials */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
     };
-    responses: {
-      /** @description User registered successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    logoutUser: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["user"];
+        requestBody?: never;
+        responses: {
+            /** @description Successful logout */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": Record<string, never>;
+                };
+            };
         };
-      };
-      /** @description Email already exists */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["error"];
-        };
-      };
     };
-  };
-  loginUser: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    verifyAuth: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description User is authenticated */
+            200: {
+                headers: {
+                    /** @description The authenticated user's ID */
+                    "X-User-ID"?: string;
+                    /** @description The authenticated user's email */
+                    "X-User-Email"?: string;
+                    /** @description Comma-separated list of user's permission scopes */
+                    "X-User-Scopes"?: string;
+                    /** @description Whether the authenticated user's email is verified ('true' or 'false') */
+                    "X-User-Email-Verified"?: "true" | "false";
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["user"];
+                };
+            };
+            /** @description User is not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+            /** @description CSRF token mismatch */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
     };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** Format: email */
-          email: string;
-          password: string;
+    forgotPassword: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** Format: email */
+                    email: string;
+                };
+            };
+        };
+        responses: {
+            /** @description If the user exists, a recovery email was sent */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        success: boolean;
+                        /** @description A generic message indicating that if the user exists, a recovery email was sent */
+                        message: string;
+                    };
+                };
+            };
+            /** @description Invalid email format */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
     };
-    responses: {
-      /** @description Successful login */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    resetPassword: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["user"];
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description The temporary password token received via email */
+                    token: string;
+                    /** @description The new password to set */
+                    newPassword: string;
+                };
+            };
         };
-      };
-      /** @description Invalid credentials */
-      401: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description Password successfully reset */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        success: boolean;
+                    };
+                };
+            };
+            /** @description Invalid token or password */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
         };
-        content: {
-          "application/json": components["schemas"]["error"];
-        };
-      };
     };
-  };
-  logoutUser: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    verifyEmail: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description The verification token sent in the email */
+                    token: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Email verified successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["user"];
+                };
+            };
+            /** @description Invalid or expired token */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+            /** @description User not logged in */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+            /** @description User not authorized to verify email */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description Successful logout */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    resendVerification: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": Record<string, never>;
+        requestBody?: never;
+        responses: {
+            /** @description Verification email sent successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        success: boolean;
+                        /** @description A generic message indicating that the verification email was sent */
+                        message: string;
+                    };
+                };
+            };
+            /** @description User not logged in */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
         };
-      };
     };
-  };
-  verifyAuth: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    setPassword: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /** @description The user's current password for verification */
+                    currentPassword: string;
+                    /** @description The new password to set */
+                    newPassword: string;
+                };
+            };
+        };
+        responses: {
+            /** @description Password changed successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        success: boolean;
+                    };
+                };
+            };
+            /** @description User not logged in or invalid current password */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description User is authenticated */
-      200: {
-        headers: {
-          /** @description The authenticated user's ID */
-          "X-User-ID"?: string;
-          /** @description The authenticated user's email */
-          "X-User-Email"?: string;
-          /** @description Comma-separated list of user's permission scopes */
-          "X-User-Scopes"?: string;
-          /** @description Whether the authenticated user's email is verified ('true' or 'false') */
-          "X-User-Email-Verified"?: "true" | "false";
-          [name: string]: unknown;
+    getUserProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["user"];
+        requestBody?: never;
+        responses: {
+            /** @description User profile retrieved successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["user"];
+                };
+            };
         };
-      };
-      /** @description User is not authenticated */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["error"];
-        };
-      };
-      /** @description CSRF token mismatch */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["error"];
-        };
-      };
     };
-  };
-  forgotPassword: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    updateUserProfile: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": {
+                    /**
+                     * Format: email
+                     * @description User's email address
+                     */
+                    email?: string;
+                    /** @description Whether the user's email address has been verified */
+                    emailVerified?: boolean;
+                    /** @description User's full name */
+                    name?: string | null;
+                    /** @description User's given name (first name) */
+                    givenName?: string | null;
+                    /** @description User's family name (last name) */
+                    familyName?: string | null;
+                };
+            };
+        };
+        responses: {
+            /** @description User profile updated successfully */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["user"];
+                };
+            };
+            /** @description Invalid request data */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+            /** @description User not authenticated */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+            /** @description Email already exists (if trying to update email to one that's already taken) */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
     };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** Format: email */
-          email: string;
+    listUsers: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-      };
+        requestBody?: never;
+        responses: {
+            /** @description A list of user objects */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["user"][];
+                };
+            };
+            /** @description Unauthorized - missing or invalid auth headers, or not logged in. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+            /** @description Forbidden - user does not have admin privileges. */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
     };
-    responses: {
-      /** @description If the user exists, a recovery email was sent */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            success: boolean;
-            /** @description A generic message indicating that if the user exists, a recovery email was sent */
-            message: string;
-          };
-        };
-      };
-      /** @description Invalid email format */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["error"];
-        };
-      };
-    };
-  };
-  resetPassword: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** @description The temporary password token received via email */
-          token: string;
-          /** @description The new password to set */
-          newPassword: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Password successfully reset */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            success: boolean;
-          };
-        };
-      };
-      /** @description Invalid token or password */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["error"];
-        };
-      };
-    };
-  };
-  verifyEmail: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** @description The verification token sent in the email */
-          token: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Email verified successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["user"];
-        };
-      };
-      /** @description Invalid or expired token */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["error"];
-        };
-      };
-      /** @description User not logged in */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["error"];
-        };
-      };
-      /** @description User not authorized to verify email */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["error"];
-        };
-      };
-    };
-  };
-  resendVerification: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description Verification email sent successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            success: boolean;
-            /** @description A generic message indicating that the verification email was sent */
-            message: string;
-          };
-        };
-      };
-      /** @description User not logged in */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["error"];
-        };
-      };
-    };
-  };
-  setPassword: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /** @description The user's current password for verification */
-          currentPassword: string;
-          /** @description The new password to set */
-          newPassword: string;
-        };
-      };
-    };
-    responses: {
-      /** @description Password changed successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": {
-            success: boolean;
-          };
-        };
-      };
-      /** @description User not logged in or invalid current password */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["error"];
-        };
-      };
-    };
-  };
-  getUserProfile: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description User profile retrieved successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["user"];
-        };
-      };
-    };
-  };
-  updateUserProfile: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody: {
-      content: {
-        "application/json": {
-          /**
-           * Format: email
-           * @description User's email address
-           */
-          email?: string;
-          /** @description Whether the user's email address has been verified */
-          emailVerified?: boolean;
-          /** @description User's full name */
-          name?: string | null;
-          /** @description User's given name (first name) */
-          givenName?: string | null;
-          /** @description User's family name (last name) */
-          familyName?: string | null;
-        };
-      };
-    };
-    responses: {
-      /** @description User profile updated successfully */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["user"];
-        };
-      };
-      /** @description Invalid request data */
-      400: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["error"];
-        };
-      };
-      /** @description User not authenticated */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["error"];
-        };
-      };
-      /** @description Email already exists (if trying to update email to one that's already taken) */
-      409: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["error"];
-        };
-      };
-    };
-  };
-  listUsers: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description A list of user objects */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["user"][];
-        };
-      };
-      /** @description Unauthorized - missing or invalid auth headers, or not logged in. */
-      401: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["error"];
-        };
-      };
-      /** @description Forbidden - user does not have admin privileges. */
-      403: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content: {
-          "application/json": components["schemas"]["error"];
-        };
-      };
-    };
-  };
 }

--- a/identity/identity-spec/dist/openapi.json
+++ b/identity/identity-spec/dist/openapi.json
@@ -10,14 +10,19 @@
       "post": {
         "summary": "Register New User",
         "operationId": "registerUser",
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["email", "password"],
+                "required": [
+                  "email",
+                  "password"
+                ],
                 "additionalProperties": false,
                 "properties": {
                   "email": {
@@ -56,6 +61,16 @@
               }
             }
           },
+          "403": {
+            "description": "Signup restricted (e.g. admin-only mode); request not allowed",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          },
           "409": {
             "description": "Email already exists",
             "content": {
@@ -73,14 +88,19 @@
       "post": {
         "summary": "Authenticate User",
         "operationId": "loginUser",
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["email", "password"],
+                "required": [
+                  "email",
+                  "password"
+                ],
                 "additionalProperties": false,
                 "properties": {
                   "email": {
@@ -123,7 +143,9 @@
       "post": {
         "summary": "Logout User",
         "operationId": "logoutUser",
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "responses": {
           "200": {
             "description": "Successful logout",
@@ -144,7 +166,9 @@
         "summary": "Verify Authentication Status",
         "description": "Used by Caddy for forward authentication. Verifies if the user is authenticated and adds user information headers for downstream services.",
         "operationId": "verifyAuth",
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "responses": {
           "200": {
             "description": "User is authenticated",
@@ -171,7 +195,10 @@
               "X-User-Email-Verified": {
                 "schema": {
                   "type": "string",
-                  "enum": ["true", "false"]
+                  "enum": [
+                    "true",
+                    "false"
+                  ]
                 },
                 "description": "Whether the authenticated user's email is verified ('true' or 'false')"
               }
@@ -211,14 +238,18 @@
       "post": {
         "summary": "Request Password Reset",
         "operationId": "forgotPassword",
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["email"],
+                "required": [
+                  "email"
+                ],
                 "additionalProperties": false,
                 "properties": {
                   "email": {
@@ -237,7 +268,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["success", "message"],
+                  "required": [
+                    "success",
+                    "message"
+                  ],
                   "additionalProperties": false,
                   "properties": {
                     "success": {
@@ -269,14 +303,19 @@
       "post": {
         "summary": "Reset Password Using Token",
         "operationId": "resetPassword",
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["token", "newPassword"],
+                "required": [
+                  "token",
+                  "newPassword"
+                ],
                 "additionalProperties": false,
                 "properties": {
                   "token": {
@@ -300,7 +339,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["success"],
+                  "required": [
+                    "success"
+                  ],
                   "additionalProperties": false,
                   "properties": {
                     "success": {
@@ -328,14 +369,18 @@
       "post": {
         "summary": "Verify Email Address",
         "operationId": "verifyEmail",
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["token"],
+                "required": [
+                  "token"
+                ],
                 "additionalProperties": false,
                 "properties": {
                   "token": {
@@ -395,7 +440,9 @@
       "post": {
         "summary": "Resend Verification Email",
         "operationId": "resendVerification",
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "responses": {
           "200": {
             "description": "Verification email sent successfully",
@@ -403,7 +450,10 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["success", "message"],
+                  "required": [
+                    "success",
+                    "message"
+                  ],
                   "additionalProperties": false,
                   "properties": {
                     "success": {
@@ -435,14 +485,19 @@
       "post": {
         "summary": "Change User Password",
         "operationId": "setPassword",
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "requestBody": {
           "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
-                "required": ["currentPassword", "newPassword"],
+                "required": [
+                  "currentPassword",
+                  "newPassword"
+                ],
                 "additionalProperties": false,
                 "properties": {
                   "currentPassword": {
@@ -466,7 +521,9 @@
               "application/json": {
                 "schema": {
                   "type": "object",
-                  "required": ["success"],
+                  "required": [
+                    "success"
+                  ],
                   "additionalProperties": false,
                   "properties": {
                     "success": {
@@ -495,7 +552,9 @@
         "summary": "Get User Profile",
         "description": "Get the profile information for the currently logged in user. Returns an empty object if the user is not authenticated.",
         "operationId": "getUserProfile",
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "responses": {
           "200": {
             "description": "User profile retrieved successfully",
@@ -513,7 +572,9 @@
         "summary": "Update User Profile",
         "description": "Update the profile information for the currently logged in user",
         "operationId": "updateUserProfile",
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "requestBody": {
           "required": true,
           "content": {
@@ -599,10 +660,14 @@
       "get": {
         "summary": "List all users",
         "operationId": "listUsers",
-        "tags": ["auth"],
+        "tags": [
+          "auth"
+        ],
         "security": [
           {
-            "scopes": ["users:read"]
+            "scopes": [
+              "users:read"
+            ]
           }
         ],
         "responses": {

--- a/identity/identity-spec/routes/auth/register-user.yaml
+++ b/identity/identity-spec/routes/auth/register-user.yaml
@@ -36,6 +36,12 @@ registerUser:
         application/json:
           schema:
             $ref: "../../schemas/user.yaml"
+    "403":
+      description: Signup restricted (e.g. admin-only mode); request not allowed
+      content:
+        application/json:
+          schema:
+            $ref: "../../schemas/error.yaml"
     "409":
       description: Email already exists
       content:

--- a/node/src/context.ts
+++ b/node/src/context.ts
@@ -2,6 +2,7 @@ import { AsyncLocalStorage } from "async_hooks";
 import type { SafContext, SafContextWithAuth } from "./types.ts";
 import crypto from "crypto";
 import { typedEnv } from "@saflib/env";
+import createError from "http-errors";
 
 /**
  * Context provided during testing.
@@ -43,7 +44,7 @@ export const getSafContextWithAuth = (): SafContextWithAuth => {
     throw new Error("SafContext not found");
   }
   if (!store.auth) {
-    throw new Error("Auth not found");
+    throw createError(401, "Unauthorized");
   }
   return store as SafContextWithAuth;
 };

--- a/openapi/docs/02-api-design.md
+++ b/openapi/docs/02-api-design.md
@@ -90,6 +90,37 @@ Resources should reference each other **by ID**, not by nesting. If a menu conta
 
 When a page needs to display resolved data (e.g. recipe titles inside a menu), the frontend fetches and joins them — or the API provides a dedicated endpoint that returns the resolved view (as a distinct schema, not by deeply nesting core resources).
 
+## HTTP Status Codes
+
+Use status codes consistently so clients can distinguish **syntax errors** (bad request shape), **semantic/validation errors** (invalid references or business rules), **auth**, and **not found**.
+
+### 400 Bad Request
+
+Use for **malformed or invalid request format**: missing required fields, wrong types, invalid values for enums or formats. The client sent something the server cannot parse or that fails schema validation.
+
+In most cases, _you do not need to specify 400 responses in the OpenAPI spec_. Most of these originate from OpenAPI request validation; only specify 400 responses if the API implementation needs to also do request validation.
+
+### 401 Unauthorized
+
+Use when the request **lacks valid auth** or the auth token is missing/expired. The client needs to authenticate (or re-authenticate) before retrying.
+
+### 403 Forbidden
+
+Use when the client **is authenticated** but **not allowed** to perform this action on this resource (e.g. not a member of the collection, insufficient role). The resource may exist; the caller simply doesn’t have permission.
+
+### 404 Not Found
+
+Use when the **primary resource** identified by the URL (e.g. the recipe in `GET /recipes/:id`) does not exist. The request is valid and authorized, but the thing you’re asking for isn’t there.
+
+### 422 Unprocessable Entity
+
+Use when the request is **well-formed and authorized**, but **semantically invalid** because a **referenced resource doesn’t exist** or a business rule is violated. Typical cases:
+
+- The client sends a `collectionId` (or other reference) in the body or query, and that collection (or entity) does not exist — return **422** with a code like `COLLECTION_NOT_FOUND`, not 403 or 404.
+- A parent resource is referenced by ID and that parent doesn’t exist (e.g. creating a menu in a non-existent collection).
+
+Use 422 (not 404) when the **target of the request** is valid (e.g. “create a recipe” or “list recipes”) but a **reference inside** the request is invalid. That keeps 404 reserved for “the resource in the URL doesn’t exist” and makes it clear to the client that the failure is a validation problem (fix the reference), not “you’re not allowed” (403) or “this URL is wrong” (404).
+
 ## Batch Endpoints
 
 When a child resource will be fetched for multiple parents at once on a single page, design a **batch-capable endpoint** rather than requiring the frontend to make N requests.

--- a/sdk/docs/04-fakes.md
+++ b/sdk/docs/04-fakes.md
@@ -2,7 +2,11 @@
 
 For SAF components, testing is [fairly focused on testing rendering](../../vue/docs/04-testing.md#testing-interactions). In order to test how a component renders, it often needs to be provided data, and also it's a good idea to make sure the component loads itself correctly. Given these requirements, it's important to have a way to run the components on a fake version of the backends it depends on, and the SDK package is the [appropriate place to do that](../../best-practices.md#ownership-of-mocks-fakes-shims).
 
-Fakes are built with [Mock Service Worker](https://mswjs.io/) because this intercepts network requests and so doesn't need to depend on how SAF frontend components do networking. SAF provides a helper function for creating fake handlers which enforce typechecking based on the OpenAPI spec for the service: [`typedCreateHandler`](./ref/@saflib/sdk/testing/functions/typedCreateHandler.md). SDK packages should export:
+Fakes are built with [Mock Service Worker](https://mswjs.io/) because this intercepts network requests and so doesn't need to depend on how SAF frontend components do networking. SAF provides a helper function for creating fake handlers which enforce typechecking based on the OpenAPI spec for the service: [`typedCreateHandler`](./ref/@saflib/sdk/testing/functions/typedCreateHandler.md).
+
+**Important:** Query parameters and path parameters in fake handlers are always `string` or `string[]` — never boolean or number. Compare with string literals (e.g. `query.publicOnly === "true"`, not `=== true`).
+
+SDK packages should export:
 
 - An array of handlers which are the baseline behavior of endpoints to the service.
 - Constants which can be referenced by tests; basically bits of the data that the server returns by default.

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -9,7 +9,7 @@ import type { ClientResult } from "./types.ts";
  * Given a "paths" openapi generated type and a subdomain, creates a typed `openapi-fetch` client which queries the given subdomain. Uses the current domain and protocol. Handles CSRF token injection, and works in tests.
  */
 export const createSafClient = <Q extends {}>(
-  serviceSubdomain: string
+  serviceSubdomain: string,
 ): ReturnType<typeof createClient<Q>> => {
   let protocol = "http";
   let host = "localhost:3000";
@@ -49,6 +49,7 @@ export const createTanstackQueryClient = () => {
               case 401:
               case 403:
               case 404:
+              case 422:
               case 500:
               case 0: // network error
                 return false;
@@ -67,7 +68,7 @@ export const createTanstackQueryClient = () => {
  * Wrapper around an openapi-fetch client fetch method to handle errors and return the data in a way that is compatible with Tanstack Query.
  */
 export const handleClientMethod = async <T>(
-  request: Promise<ClientResult<T>>
+  request: Promise<ClientResult<T>>,
 ): Promise<T> => {
   let result: ClientResult<T>;
   try {

--- a/vue/components/AsyncPage.vue
+++ b/vue/components/AsyncPage.vue
@@ -3,9 +3,11 @@
     <v-progress-circular indeterminate />
   </div>
 
-  <v-alert v-else-if="isError" type="error" class="my-4">
-    {{ errorMessage }}
-  </v-alert>
+  <template v-else-if="isError">
+    <slot name="error" :error="firstError" :error-message="errorMessage">
+      <AsyncPageError :error="firstError" :message="errorMessage" />
+    </slot>
+  </template>
 
   <component :is="props.pageComponent" v-else v-bind="props.pageProps" />
 </template>
@@ -14,6 +16,7 @@
 import { computed } from "vue";
 import type { Component } from "vue";
 import type { LoaderQueries } from "../types.ts";
+import AsyncPageError from "./AsyncPageError.vue";
 
 interface Props {
   loader?: () => LoaderQueries;

--- a/vue/components/AsyncPageError.vue
+++ b/vue/components/AsyncPageError.vue
@@ -1,0 +1,35 @@
+<template>
+  <v-alert type="error" class="my-4">
+    {{ displayMessage }}
+  </v-alert>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = defineProps<{
+  error?: unknown;
+  message?: string;
+}>();
+
+const displayMessage = computed(() => {
+  if (props.message) return props.message;
+  const error = props.error;
+  if (!error) return "An unexpected error occurred.";
+  const status = (error as { status?: number })?.status;
+  switch (status) {
+    case 401:
+      return "Not Logged In";
+    case 403:
+      return "Forbidden";
+    case 404:
+      return "Not Found";
+    case 500:
+      return "Server Error";
+    case 0:
+      return "Connection Error";
+    default:
+      return `Failed to load data (Error ${status})`;
+  }
+});
+</script>

--- a/vue/components/index.ts
+++ b/vue/components/index.ts
@@ -1,4 +1,5 @@
 export { AsyncPage } from "./tricky-imports.ts";
+export { default as AsyncPageError } from "./AsyncPageError.vue";
 export { default as SpaLink } from "./SpaLink.vue";
 export { default as StubComponent } from "./StubComponent.vue";
 export { default as SnackbarQueue } from "./SnackbarQueue.vue";

--- a/vue/docs/02-components.md
+++ b/vue/docs/02-components.md
@@ -102,6 +102,8 @@ By keeping them in separate files, they can be exported and used by processes wh
 
 **Each sub-component should have its own strings file** (e.g. `MyDialog.strings.ts`). Don't pile all strings into the view's strings file — it becomes hard to manage and makes it unclear which strings belong to which component.
 
+**Duplication across components is fine.** If a create form and an edit form use the same labels, each should have its own strings file with its own copy. They get separate i18n keys (e.g. `create_menu_form.name_label` vs `menu_edit_form.name_label`), which means they can be translated independently per context — even if the English text is identical. Don't try to share strings across routes or components to reduce duplication; the added import complexity and path fragility isn't worth it.
+
 For localization, see [i18n](./03-i18n.md).
 
 ### Logic Files: Pure Business Logic
@@ -131,6 +133,8 @@ it("returns false when name is empty", () => {
 
 The component then imports and calls these functions, keeping its `<script setup>` focused on wiring reactivity to the template.
 
+**Ownership**: Payload builders and validation helpers used by sub-components can live in the parent page's logic file (e.g. `buildUpdateMenuPayload` in `Detail.logic.ts` used by `MenuEditForm.vue`). This keeps all testable pure logic for a page consolidated in one place, regardless of which sub-component calls it.
+
 ### Composables: Stateful and Networking Logic
 
 When a component has **stateful logic involving networking** — TanStack mutations, multi-step flows, state machines, or complex error handling — extract it into a composable (`useComponentFlow.ts`).
@@ -156,6 +160,8 @@ export function useEvalCreateFlow(callbacks: {
   return { createStep, createName, handleCreate, handleSaveExpected, ... };
 }
 ```
+
+**When not to extract**: A single mutation with local UI state (e.g. an edit form with one save call, or a delete button with a redirect) can stay in the component. Composables are for multi-step flows, shared stateful logic, or complex error handling — not every use of a TanStack mutation.
 
 **Scoping note**: Each component that calls a composable gets its own instance with its own local state. This is usually what you want — each sub-component manages its own editing/uploading state independently. However, when multiple siblings need **coordinated state** (e.g. "only one note in edit mode at a time"), the parent should own that coordination state and pass it as a simple prop (like `isEditing: boolean`), while the sub-component still calls its own composable for mutations and other stateful flows.
 

--- a/vue/workflows/add-view.ts
+++ b/vue/workflows/add-view.ts
@@ -221,6 +221,7 @@ Run \`npm run typecheck\` in ${context.cwd} to verify the code is type-safe.
   Don't add interaction tests here — Playwright covers that. Focus deeper tests on the extracted
   logic files and composables.
 * **Deciding What to Test**: Don't extract simple logic just to test it. We already have tests for each tanstack query, so there's no need to pull that into a separate composable either. Save testing for more complex logic, for example when multiple or tanstack queries are used together.
+* **When NOT to extract a composable**: A single mutation + local UI state (e.g. edit form + one save, delete + redirect) can stay in the component. Composables are for multi-step or shared flows.
 
 For more information, see ${context.docFiles?.components}`,
     })),


### PR DESCRIPTION
Some updates:
* some changes to auth and vue packages to enable better mocking and error handling
* add the ability to specify only admins may sign up in the identity service
* properly return 401 when getSafContextWithAuth finds no auth
* add some guidance to http codes (mainly to encourage 422 when appropriate)
* some other minor doc updates