### PR TITLE
Support Kratos

### DIFF
--- a/backup/backup-http/routes/backups/create.ts
+++ b/backup/backup-http/routes/backups/create.ts
@@ -25,7 +25,7 @@ export const createCreateHandler = (
   return createHandler(async (req, res) => {
     const { auth } = getSafContextWithAuth();
 
-    if (!auth.userScopes.includes("*")) {
+    if (!auth.userScopes?.includes("*")) {
       const errorResponse: BackupServiceResponseBody["createBackup"][403] = {
         message: "Forbidden - admin access required",
         code: "FORBIDDEN",

--- a/backup/backup-http/routes/backups/delete.ts
+++ b/backup/backup-http/routes/backups/delete.ts
@@ -13,7 +13,7 @@ export const createDeleteHandler = (objectStore: ObjectStore) => {
   return createHandler(async (req, res) => {
     const { auth } = getSafContextWithAuth();
 
-    if (!auth.userScopes.includes("*")) {
+    if (!auth.userScopes?.includes("*")) {
       const errorResponse: BackupServiceResponseBody["deleteBackup"][403] = {
         message: "Forbidden - admin access required",
         code: "FORBIDDEN",

--- a/backup/backup-http/routes/backups/list.ts
+++ b/backup/backup-http/routes/backups/list.ts
@@ -9,7 +9,7 @@ export const createListHandler = (objectStore: ObjectStore) => {
   return createHandler(async (_req, res) => {
     const { auth } = getSafContextWithAuth();
 
-    if (!auth.userScopes.includes("*")) {
+    if (!auth.userScopes?.includes("*")) {
       const errorResponse: BackupServiceResponseBody["listBackups"][403] = {
         message: "Forbidden - admin access required",
         code: "FORBIDDEN",

--- a/backup/backup-http/routes/backups/restore.ts
+++ b/backup/backup-http/routes/backups/restore.ts
@@ -20,7 +20,7 @@ export const createRestoreHandler = (
   return createHandler(async (req, res) => {
     const { auth } = getSafContextWithAuth();
 
-    if (!auth.userScopes.includes("*")) {
+    if (!auth.userScopes?.includes("*")) {
       const errorResponse: BackupServiceResponseBody["restoreBackup"][403] = {
         message: "Forbidden - admin access required",
         code: "FORBIDDEN",

--- a/email/email-spec/dist/openapi.d.ts
+++ b/email/email-spec/dist/openapi.d.ts
@@ -4,88 +4,142 @@
  */
 
 export interface paths {
-  "/email/sent": {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
+    "/email/sent": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /** List all sent emails */
+        get: operations["listSentEmails"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
     };
-    /** List all sent emails */
-    get: operations["listSentEmails"];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
+    "/email/kratos-courier": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Receive email dispatch from Ory Kratos HTTP courier */
+        post: operations["postKratosCourier"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
 }
 export type webhooks = Record<string, never>;
 export interface components {
-  schemas: {
-    SentEmail: components["schemas"]["sent-email"];
-    "sent-email": {
-      to: string[];
-      cc?: string[];
-      bcc?: string[];
-      subject: string;
-      text?: string;
-      html?: string;
-      attachments?: string[];
-      from: string;
-      timeSent?: number;
-      replyTo?: string[];
+    schemas: {
+        SentEmail: components["schemas"]["sent-email"];
+        "sent-email": {
+            to: string[];
+            cc?: string[];
+            bcc?: string[];
+            subject: string;
+            text?: string;
+            html?: string;
+            attachments?: string[];
+            from: string;
+            timeSent?: number;
+            replyTo?: string[];
+        };
+        error: {
+            /** @description A short, machine-readable error code, for when HTTP status codes are not sufficient. */
+            code?: string;
+            /**
+             * @description A human-readable description of the error.
+             * @example The requested resource could not be found.
+             */
+            message?: string;
+        };
     };
-    error: {
-      /** @description A short, machine-readable error code, for when HTTP status codes are not sufficient. */
-      code?: string;
-      /**
-       * @description A human-readable description of the error.
-       * @example The requested resource could not be found.
-       */
-      message?: string;
-    };
-  };
-  responses: never;
-  parameters: never;
-  requestBodies: never;
-  headers: never;
-  pathItems: never;
+    responses: never;
+    parameters: never;
+    requestBodies: never;
+    headers: never;
+    pathItems: never;
 }
 export type $defs = Record<string, never>;
 export interface operations {
-  listSentEmails: {
-    parameters: {
-      query?: {
-        /** @description The email address of the user to get sent emails to or from */
-        userEmail?: string;
-      };
-      header?: never;
-      path?: never;
-      cookie?: never;
+    listSentEmails: {
+        parameters: {
+            query?: {
+                /** @description The email address of the user to get sent emails to or from */
+                userEmail?: string;
+            };
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description A list of sent emails. */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["sent-email"][];
+                };
+            };
+            /** @description Forbidden - server is not mocking email sends */
+            403: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
+        };
     };
-    requestBody?: never;
-    responses: {
-      /** @description A list of sent emails. */
-      200: {
-        headers: {
-          [name: string]: unknown;
+    postKratosCourier: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
         };
-        content: {
-          "application/json": components["schemas"]["sent-email"][];
+        requestBody: {
+            content: {
+                "application/json": {
+                    recipient: string;
+                    template_type: string;
+                    template_data?: {
+                        [key: string]: unknown;
+                    };
+                };
+            };
         };
-      };
-      /** @description Forbidden - server is not mocking email sends */
-      403: {
-        headers: {
-          [name: string]: unknown;
+        responses: {
+            /** @description Email accepted for delivery */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Failed to send email */
+            500: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
+                };
+            };
         };
-        content: {
-          "application/json": components["schemas"]["error"];
-        };
-      };
     };
-  };
 }

--- a/email/email-spec/dist/openapi.json
+++ b/email/email-spec/dist/openapi.json
@@ -10,7 +10,9 @@
       "get": {
         "summary": "List all sent emails",
         "operationId": "listSentEmails",
-        "tags": ["email"],
+        "tags": [
+          "email"
+        ],
         "parameters": [
           {
             "name": "userEmail",
@@ -37,6 +39,57 @@
           },
           "403": {
             "description": "Forbidden - server is not mocking email sends",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/email/kratos-courier": {
+      "post": {
+        "summary": "Receive email dispatch from Ory Kratos HTTP courier",
+        "operationId": "postKratosCourier",
+        "tags": [
+          "no-auth",
+          "email"
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "recipient",
+                  "template_type"
+                ],
+                "properties": {
+                  "recipient": {
+                    "type": "string"
+                  },
+                  "template_type": {
+                    "type": "string"
+                  },
+                  "template_data": {
+                    "type": "object",
+                    "additionalProperties": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "204": {
+            "description": "Email accepted for delivery"
+          },
+          "500": {
+            "description": "Failed to send email",
             "content": {
               "application/json": {
                 "schema": {
@@ -103,7 +156,11 @@
             }
           }
         },
-        "required": ["to", "subject", "from"]
+        "required": [
+          "to",
+          "subject",
+          "from"
+        ]
       },
       "error": {
         "type": "object",

--- a/email/email-spec/openapi.yaml
+++ b/email/email-spec/openapi.yaml
@@ -13,3 +13,6 @@ paths:
   /email/sent:
     get:
       $ref: "./routes/email_routes.yaml#/get"
+  /email/kratos-courier:
+    post:
+      $ref: "./routes/kratos_courier.yaml#/post"

--- a/email/email-spec/routes/kratos_courier.yaml
+++ b/email/email-spec/routes/kratos_courier.yaml
@@ -1,0 +1,33 @@
+# POST /email/kratos-courier
+post:
+  summary: Receive email dispatch from Ory Kratos HTTP courier
+  operationId: postKratosCourier
+  tags:
+    - no-auth
+    - email
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          required:
+            - recipient
+            - template_type
+          properties:
+            recipient:
+              type: string
+            template_type:
+              type: string
+            template_data:
+              type: object
+              additionalProperties: true
+  responses:
+    "204":
+      description: Email accepted for delivery
+    "500":
+      description: Failed to send email
+      content:
+        application/json:
+          schema:
+            $ref: "../schemas/error.yaml"

--- a/email/email/routes/emails/index.ts
+++ b/email/email/routes/emails/index.ts
@@ -1,5 +1,6 @@
 import express from "express";
 import { getSentEmails } from "./get-sent-emails.ts";
+import { postKratosCourier } from "./post-kratos-courier.ts";
 import { createScopedMiddleware } from "@saflib/express";
 import { jsonSpec } from "@saflib/email-spec";
 
@@ -21,6 +22,7 @@ export function createEmailsRouter(options: EmailsRouterOptions = {}) {
 
   router.use("/email", scopedMiddleware);
   router.get("/email/sent", getSentEmails);
+  router.post("/email/kratos-courier", postKratosCourier);
 
   return router;
 }

--- a/email/email/routes/emails/post-kratos-courier.ts
+++ b/email/email/routes/emails/post-kratos-courier.ts
@@ -1,0 +1,84 @@
+import createError from "http-errors";
+import { createHandler } from "@saflib/express";
+import { getSafReporters } from "@saflib/node";
+import { emailClient } from "../../client/email-client.ts";
+
+export interface KratosCourierBody {
+  recipient: string;
+  template_type: string;
+  template_data?: Record<string, unknown>;
+}
+
+function buildMessage(body: KratosCourierBody): {
+  subject: string;
+  text: string;
+  html?: string;
+} {
+  const { template_type, template_data: td = {} } = body;
+  const verificationUrl = td.verification_url as string | undefined;
+  const recoveryUrl = td.recovery_url as string | undefined;
+  const verificationCode = td.verification_code as string | undefined;
+  const recoveryCode = td.recovery_code as string | undefined;
+
+  if (template_type.includes("verification")) {
+    const lines = [
+      verificationCode ? `Code: ${verificationCode}` : null,
+      verificationUrl ? `Link: ${verificationUrl}` : null,
+    ].filter(Boolean);
+    return {
+      subject: "Verify your email",
+      text: lines.join("\n") || JSON.stringify(td),
+      html: verificationUrl
+        ? `<p><a href="${verificationUrl}">Verify your email</a></p>`
+        : undefined,
+    };
+  }
+
+  if (template_type.includes("recovery")) {
+    const lines = [
+      recoveryCode ? `Code: ${recoveryCode}` : null,
+      recoveryUrl ? `Link: ${recoveryUrl}` : null,
+    ].filter(Boolean);
+    return {
+      subject: "Account recovery",
+      text: lines.join("\n") || JSON.stringify(td),
+      html: recoveryUrl
+        ? `<p><a href="${recoveryUrl}">Reset your password</a></p>`
+        : undefined,
+    };
+  }
+
+  return {
+    subject: `Kratos: ${template_type}`,
+    text: JSON.stringify(
+      { template_type, template_data: td },
+      null,
+      2,
+    ),
+  };
+}
+
+export const postKratosCourier = createHandler(async (req, res) => {
+  const { log } = getSafReporters();
+  const body = req.body as KratosCourierBody;
+
+  if (!body?.recipient || !body?.template_type) {
+    throw createError(400, "Invalid Kratos courier payload");
+  }
+
+  log.info("Kratos courier email", {
+    template_type: body.template_type,
+    recipient: body.recipient,
+  });
+
+  const { subject, text, html } = buildMessage(body);
+
+  await emailClient.sendEmail({
+    to: body.recipient,
+    subject,
+    text,
+    html,
+  });
+
+  res.status(204).end();
+});

--- a/express/src/index.ts
+++ b/express/src/index.ts
@@ -16,6 +16,7 @@ export {
 } from "./middleware/composition.ts";
 export { makeContextMiddleware } from "./middleware/context.ts";
 export { makeAuthMiddleware, drainRequest } from "./middleware/auth.ts";
+export { makeCsrfMiddleware } from "./middleware/csrf.ts";
 
 // multer options
 export * from "./middleware/multer.ts";

--- a/express/src/middleware/auth.ts
+++ b/express/src/middleware/auth.ts
@@ -46,7 +46,7 @@ export const makeAuthMiddleware = (
       return;
     }
 
-    if (adminRequired && !auth.userScopes.includes("*")) {
+    if (adminRequired && !auth.userScopes?.includes("*")) {
       drainRequest(req).then(() => {
         if (!res.headersSent) {
           res.status(403).json({

--- a/express/src/middleware/composition.ts
+++ b/express/src/middleware/composition.ts
@@ -12,6 +12,7 @@ import { blockHtml } from "./blockHtml.ts";
 import { createScopeValidator } from "./scopes.ts";
 import { metricsMiddleware } from "./metrics.ts";
 import { makeAuthMiddleware } from "./auth.ts";
+import { makeCsrfMiddleware } from "./csrf.ts";
 import multer from "multer";
 
 /**
@@ -87,6 +88,7 @@ export const createScopedMiddleware = (
 
   return [
     ...openApiValidatorMiddleware,
+    makeCsrfMiddleware(),
     makeContextMiddleware(),
     unsafeRequestLogger,
     ...authMiddleware,

--- a/express/src/middleware/context.ts
+++ b/express/src/middleware/context.ts
@@ -17,7 +17,8 @@ interface KratosAdminIdentity {
 }
 
 function defaultKratosAdminUrl(): string {
-  return process.env.KRATOS_ADMIN_URL ?? "http://kratos:4434";
+  // TODO: use env var?
+  return "http://kratos:4434";
 }
 
 async function resolveKratosAuth(identityId: string): Promise<Auth> {

--- a/express/src/middleware/context.ts
+++ b/express/src/middleware/context.ts
@@ -8,7 +8,83 @@ import {
   defaultErrorReporter,
   getServiceName,
 } from "@saflib/node";
-import type { Handler } from "express";
+import type { Handler, Request } from "express";
+import createError from "http-errors";
+
+interface KratosAdminIdentity {
+  traits?: { email?: string };
+  verifiable_addresses?: Array<{ verified?: boolean }>;
+}
+
+function defaultKratosAdminUrl(): string {
+  return process.env.KRATOS_ADMIN_URL ?? "http://kratos:4434";
+}
+
+async function resolveKratosAuth(identityId: string): Promise<Auth> {
+  const baseUrl = defaultKratosAdminUrl().replace(/\/$/, "");
+  const res = await fetch(`${baseUrl}/admin/identities/${identityId}`);
+  if (!res.ok) {
+    throw createError(
+      502,
+      `Kratos admin identity lookup failed: ${res.status}`,
+    );
+  }
+  const identity = (await res.json()) as KratosAdminIdentity;
+  const userEmail = identity.traits?.email;
+  if (!userEmail) {
+    throw createError(500, "Kratos identity missing email trait");
+  }
+  const emailVerified = identity.verifiable_addresses?.[0]?.verified ?? false;
+
+  const adminRaw = process.env.IDENTITY_SERVICE_ADMIN_EMAILS ?? "";
+  const adminEmails = new Set(
+    adminRaw
+      .split(",")
+      .map((e) => e.trim())
+      .filter(Boolean),
+  );
+
+  const userScopes: string[] = [];
+  if (adminEmails.has(userEmail) && emailVerified) {
+    userScopes.push("*");
+  } else {
+    userScopes.push("none");
+  }
+
+  return {
+    userId: identityId,
+    userEmail,
+    userScopes,
+    emailVerified,
+  };
+}
+
+function resolveIdentityServerAuth(req: Request): Auth | undefined {
+  const userId = req.headers["x-user-id"];
+  const userEmail = req.headers["x-user-email"];
+  const userScopesHeader = req.headers["x-user-scopes"];
+  const emailVerified = req.headers["x-user-email-verified"];
+  if (userId && userEmail) {
+    const scopes = userScopesHeader
+      ? (userScopesHeader as string).split(",")
+      : [];
+    return {
+      userId: userId as string,
+      userEmail: userEmail as string,
+      userScopes: scopes,
+      emailVerified: emailVerified === "true",
+    };
+  }
+  return undefined;
+}
+
+async function resolveAuth(req: Request): Promise<Auth | undefined> {
+  const kratosId = req.headers["x-kratos-authenticated-identity-id"];
+  if (typeof kratosId === "string" && kratosId.length > 0) {
+    return await resolveKratosAuth(kratosId);
+  }
+  return resolveIdentityServerAuth(req);
+}
 
 export const makeContextMiddleware = () => {
   const contextMiddleware: Handler = (req, _res, next) => {
@@ -21,39 +97,28 @@ export const makeContextMiddleware = () => {
       reqId = req.headers["x-request-id"] as string;
     }
 
-    let auth: Auth | undefined;
-    const userId = req.headers["x-user-id"];
-    const userEmail = req.headers["x-user-email"];
-    const userScopes = req.headers["x-user-scopes"];
-    const emailVerified = req.headers["x-user-email-verified"];
-    const scopes = userScopes ? (userScopes as string).split(",") : [];
-    if (userId && userEmail && scopes) {
-      auth = {
-        userId: userId as string,
-        userEmail: userEmail as string,
-        userScopes: scopes,
-        emailVerified: emailVerified === "true",
-      };
-    }
+    resolveAuth(req)
+      .then((auth) => {
+        const context: SafContext = {
+          requestId: reqId,
+          serviceName: getServiceName(),
+          subsystemName: "http",
+          operationName,
+          auth,
+        };
 
-    const context: SafContext = {
-      requestId: reqId,
-      serviceName: getServiceName(),
-      subsystemName: "http",
-      operationName,
-      auth,
-    };
+        const reporters: SafReporters = {
+          log: createLogger(context),
+          logError: defaultErrorReporter,
+        };
 
-    const reporters: SafReporters = {
-      log: createLogger(context),
-      logError: defaultErrorReporter,
-    };
-
-    safContextStorage.run(context, () => {
-      safReportersStorage.run(reporters, () => {
-        next();
-      });
-    });
+        safContextStorage.run(context, () => {
+          safReportersStorage.run(reporters, () => {
+            next();
+          });
+        });
+      })
+      .catch(next);
   };
   return contextMiddleware;
 };

--- a/express/src/middleware/csrf.ts
+++ b/express/src/middleware/csrf.ts
@@ -1,0 +1,42 @@
+import type { Handler } from "express";
+import { typedEnv } from "@saflib/env";
+
+const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+/**
+ * Require a non-simple header on state-changing requests so cross-site form POSTs
+ * cannot mutate state (browser same-origin policy blocks setting custom headers).
+ * Skips routes tagged `no-auth` (same convention as auth middleware).
+ */
+export const makeCsrfMiddleware = (): Handler => {
+  return (req, res, next): void => {
+    if (typedEnv.NODE_ENV === "test") {
+      return next();
+    }
+
+    if (req.openapi?.schema?.tags?.includes("no-auth")) {
+      return next();
+    }
+
+    const method = req.method.toUpperCase();
+    if (SAFE_METHODS.has(method)) {
+      return next();
+    }
+
+    const xrw = req.headers["x-requested-with"];
+    const ok =
+      typeof xrw === "string" && xrw.toLowerCase() === "xmlhttprequest";
+
+    if (!ok) {
+      if (!res.headersSent) {
+        res.status(403).json({
+          error: "Forbidden",
+          message: "CSRF validation failed",
+        });
+      }
+      return;
+    }
+
+    return next();
+  };
+};

--- a/express/src/middleware/scopes.ts
+++ b/express/src/middleware/scopes.ts
@@ -38,7 +38,7 @@ export const createScopeValidator = (): Handler => {
       return;
     }
 
-    const userScopes = new Set(auth.userScopes);
+    const userScopes = new Set(auth.userScopes ?? []);
 
     if (userScopes.has("*")) {
       return next();

--- a/express/src/vitest-helpers.ts
+++ b/express/src/vitest-helpers.ts
@@ -9,6 +9,7 @@ export function makeUserHeaders(
     "x-user-email": email,
     "x-user-email-verified": "true",
     "x-user-scopes": "none",
+    "x-requested-with": "XMLHttpRequest",
   };
 }
 
@@ -21,5 +22,6 @@ export function makeAdminHeaders(
     "x-user-email": email,
     "x-user-email-verified": "true",
     "x-user-scopes": "*",
+    "x-requested-with": "XMLHttpRequest",
   };
 }

--- a/node/src/types.ts
+++ b/node/src/types.ts
@@ -5,9 +5,9 @@ import { Logger } from "winston";
  */
 export interface Auth {
   userId: string;
-  userEmail: string;
-  userScopes: string[];
-  emailVerified: boolean;
+  userEmail?: string;
+  userScopes?: string[];
+  emailVerified?: boolean;
 }
 
 /**

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -30,6 +30,10 @@ export const createSafClient = <Q extends {}>(
       if (csrfToken) {
         request.headers.set("X-CSRF-Token", csrfToken);
       }
+      const method = request.method.toUpperCase();
+      if (!["GET", "HEAD", "OPTIONS"].includes(method)) {
+        request.headers.set("X-Requested-With", "XMLHttpRequest");
+      }
       return fetch(request);
     },
   });

--- a/secrets/secrets-http/routes/secrets/create.ts
+++ b/secrets/secrets-http/routes/secrets/create.ts
@@ -30,7 +30,7 @@ export const createSecretHandler = createHandler(async (req, res) => {
     name: data.name,
     description: data.description || null,
     valueEncrypted: encryptedValue,
-    createdBy: auth.userEmail,
+    createdBy: auth.userId,
     isActive: true,
   });
 

--- a/sentry/index.ts
+++ b/sentry/index.ts
@@ -3,7 +3,7 @@ import { addErrorCollector } from "@saflib/node";
 import { typedEnv } from "./env.ts";
 
 export const initSentry = () => {
-  if (typedEnv.MOCK_INTEGRATIONS === "true" && !typedEnv.SENTRY_DSN) {
+  if (typedEnv.MOCK_INTEGRATIONS === "true" || typedEnv.SENTRY_DSN === "mock") {
     return;
   }
 


### PR DESCRIPTION
I'm finally moving away from my bespoke identity server and switching to Ory Kratos. I built the prototype in https://github.com/sderickson/home-2026/pull/40, and this PR is necessary changes to support that prototype:
* Only expect a user id given by the identity server via headers. So I had to make some adjustments in usages for other properties on the Auth object. Honestly I think I'll bring my identity server in line with the kratos behavior; seems wiser.
* Add an email endpoint for kratos to send emails to. I haven't really tested that yet because I haven't tested email verification but I don't think that's too risky.
* Update express middleware to use kratos header, and handle csrf rather than having that be handled by identity. Again, something I'll bring the identity server in alignment with kratos.

I'm liking kratos a fair bit though... It's pretty lean which is nice. I may just get rid of my bespoke identity server entirely.