### PR TITLE
email-client, object-store, secret-store tweaks

### DIFF
--- a/email/email/client/email-client.ts
+++ b/email/email/client/email-client.ts
@@ -88,7 +88,11 @@ export { sentEmails };
  * A simplified client for sending emails, wrapping the shared {@link emailService}.
  */
 export class EmailClient {
-  constructor(private readonly service: EmailService = emailService) {}
+  private readonly service: EmailService;
+
+  constructor(service: EmailService = emailService) {
+    this.service = service;
+  }
 
   sendEmail(options: EmailOptions): Promise<EmailResult> {
     return this.service.sendEmail(options);

--- a/object-store/gcs/GcsObjectStore.test.ts
+++ b/object-store/gcs/GcsObjectStore.test.ts
@@ -8,24 +8,6 @@ describe("GcsObjectStore", () => {
     it("should initialize with bucket name", () => {
       const store = new GcsObjectStore({
         bucketName: "test-bucket",
-        accessLevel: "private",
-      });
-      expect(store).toBeInstanceOf(GcsObjectStore);
-    });
-
-    it("should initialize with location", () => {
-      const store = new GcsObjectStore({
-        bucketName: "test-bucket",
-        accessLevel: "private",
-        location: "europe-west1",
-      });
-      expect(store).toBeInstanceOf(GcsObjectStore);
-    });
-
-    it("should initialize with public access level", () => {
-      const store = new GcsObjectStore({
-        bucketName: "test-bucket",
-        accessLevel: "blob",
       });
       expect(store).toBeInstanceOf(GcsObjectStore);
     });
@@ -35,7 +17,6 @@ describe("GcsObjectStore", () => {
     it("should upload file successfully", async () => {
       const store = new GcsObjectStore({
         bucketName: "test-bucket",
-        accessLevel: "private",
       });
       const stream = Readable.from("test content");
 
@@ -51,7 +32,6 @@ describe("GcsObjectStore", () => {
     it("should upload file with metadata", async () => {
       const store = new GcsObjectStore({
         bucketName: "test-bucket",
-        accessLevel: "private",
       });
       const stream = Readable.from("test content");
 
@@ -70,7 +50,6 @@ describe("GcsObjectStore", () => {
     it("should include path in url", async () => {
       const store = new GcsObjectStore({
         bucketName: "test-bucket",
-        accessLevel: "private",
       });
       const stream = Readable.from("test content");
 
@@ -86,7 +65,6 @@ describe("GcsObjectStore", () => {
     it("should return StorageError for invalid paths", async () => {
       const store = new GcsObjectStore({
         bucketName: "test-bucket",
-        accessLevel: "private",
       });
       const stream = Readable.from("test content");
 
@@ -104,7 +82,6 @@ describe("GcsObjectStore", () => {
     it("should return empty array in test mode", async () => {
       const store = new GcsObjectStore({
         bucketName: "test-bucket",
-        accessLevel: "private",
       });
       const result = await store.listFiles();
 
@@ -117,7 +94,6 @@ describe("GcsObjectStore", () => {
     it("should accept prefix parameter", async () => {
       const store = new GcsObjectStore({
         bucketName: "test-bucket",
-        accessLevel: "private",
       });
       const result = await store.listFiles("subfolder");
 
@@ -132,7 +108,6 @@ describe("GcsObjectStore", () => {
     it("should delete file successfully", async () => {
       const store = new GcsObjectStore({
         bucketName: "test-bucket",
-        accessLevel: "private",
       });
       const result = await store.deleteFile("test.txt");
 
@@ -145,7 +120,6 @@ describe("GcsObjectStore", () => {
     it("should return StorageError for invalid paths", async () => {
       const store = new GcsObjectStore({
         bucketName: "test-bucket",
-        accessLevel: "private",
       });
 
       const result = await store.deleteFile("../file.txt");
@@ -162,7 +136,6 @@ describe("GcsObjectStore", () => {
     it("should return Readable stream in test mode", async () => {
       const store = new GcsObjectStore({
         bucketName: "test-bucket",
-        accessLevel: "private",
       });
       const result = await store.readFile("test.txt");
 
@@ -175,7 +148,6 @@ describe("GcsObjectStore", () => {
     it("should return StorageError for invalid paths", async () => {
       const store = new GcsObjectStore({
         bucketName: "test-bucket",
-        accessLevel: "private",
       });
 
       const result = await store.readFile("../file.txt");
@@ -192,7 +164,6 @@ describe("GcsObjectStore", () => {
     it("should use nested path in url", async () => {
       const store = new GcsObjectStore({
         bucketName: "test-bucket",
-        accessLevel: "private",
       });
       const stream = Readable.from("test");
 
@@ -202,52 +173,7 @@ describe("GcsObjectStore", () => {
       );
       expect("result" in uploadResult).toBe(true);
       if ("result" in uploadResult && uploadResult.result) {
-        expect(uploadResult.result.url).toContain(
-          "folder/subfolder/file.txt",
-        );
-      }
-    });
-  });
-
-  describe("upsertContainer", () => {
-    it("should upsert bucket successfully in test mode", async () => {
-      const store = new GcsObjectStore({
-        bucketName: "my-bucket",
-        accessLevel: "private",
-      });
-      const result = await store.upsertContainer();
-
-      expect("result" in result).toBe(true);
-      if ("result" in result && result.result) {
-        expect(result.result.success).toBe(true);
-        expect(result.result.created).toBe(true);
-        expect(result.result.url).toBe("https://storage.googleapis.com/my-bucket");
-      }
-    });
-
-    it("should use access level from constructor (blob)", async () => {
-      const store = new GcsObjectStore({
-        bucketName: "blob-bucket",
-        accessLevel: "blob",
-      });
-      const result = await store.upsertContainer();
-
-      expect("result" in result).toBe(true);
-      if ("result" in result && result.result) {
-        expect(result.result.success).toBe(true);
-      }
-    });
-
-    it("should use store bucket name in url", async () => {
-      const store = new GcsObjectStore({
-        bucketName: "custom-bucket-name",
-        accessLevel: "private",
-      });
-      const result = await store.upsertContainer();
-
-      expect("result" in result).toBe(true);
-      if ("result" in result && result.result) {
-        expect(result.result.url).toContain("custom-bucket-name");
+        expect(uploadResult.result.url).toContain("folder/subfolder/file.txt");
       }
     });
   });

--- a/object-store/gcs/GcsObjectStore.ts
+++ b/object-store/gcs/GcsObjectStore.ts
@@ -11,28 +11,16 @@ import { typedEnv } from "../env.ts";
 import type { ReturnsError } from "@saflib/monorepo";
 import { getSafReporters } from "@saflib/node";
 
-/** Aligns with Azure `ContainerAccessLevel`: private bucket vs public object access. */
-export type GcsBucketAccessLevel = "blob" | "container" | "private";
-
 export interface GcsObjectStoreOptions {
   bucketName: string;
-  accessLevel: GcsBucketAccessLevel;
-  /** Used when creating a new bucket; defaults to `US`. */
-  location?: string;
 }
-
-const bucketsUpserted = new Set<string>();
 
 export class GcsObjectStore extends ObjectStore {
   protected readonly bucketName: string;
-  protected readonly accessLevel: GcsBucketAccessLevel;
-  protected readonly location: string;
 
   constructor(options: GcsObjectStoreOptions) {
     super();
     this.bucketName = options.bucketName;
-    this.accessLevel = options.accessLevel;
-    this.location = options.location ?? "US";
   }
 
   async uploadFile(
@@ -270,68 +258,6 @@ export class GcsObjectStore extends ObjectStore {
       StorageError
     >
   > {
-    if (typedEnv.NODE_ENV === "test") {
-      return {
-        result: {
-          success: true,
-          created: true,
-          url: `https://storage.googleapis.com/${this.bucketName}`,
-        },
-      };
-    }
-
-    if (bucketsUpserted.has(this.bucketName)) {
-      return {
-        result: {
-          success: true,
-          skipped: true,
-        },
-      };
-    }
-
-    const { log, logError } = getSafReporters();
-    const wantsPublic =
-      this.accessLevel === "blob" || this.accessLevel === "container";
-
-    try {
-      const storage = getStorage();
-      const bucket = storage.bucket(this.bucketName);
-      const [exists] = await bucket.exists();
-
-      let created = false;
-      if (!exists) {
-        log.info(`Creating GCS bucket ${this.bucketName}`);
-        await storage.createBucket(this.bucketName, {
-          location: this.location,
-        });
-        created = true;
-      }
-
-      if (wantsPublic) {
-        log.info(`Setting GCS bucket ${this.bucketName} public read`);
-        await bucket.makePublic();
-      } else {
-        await bucket.makePrivate();
-      }
-
-      bucketsUpserted.add(this.bucketName);
-
-      return {
-        result: {
-          success: true,
-          created,
-          updated: !created,
-          url: `https://storage.googleapis.com/${this.bucketName}/`,
-        },
-      };
-    } catch (error) {
-      logError(error);
-      return {
-        error: new StorageError(
-          error instanceof Error ? error.message : "Error upserting bucket",
-          error instanceof Error ? error : undefined,
-        ),
-      };
-    }
+    throw new Error("Not implemented");
   }
 }

--- a/secret-store/infisical/InfisicalSecretStore.test.ts
+++ b/secret-store/infisical/InfisicalSecretStore.test.ts
@@ -16,7 +16,7 @@ describe("InfisicalSecretStore (mock token)", () => {
     });
     const { result, error } = await store.getSecretByName(key);
     expect(error).toBeUndefined();
-    expect(result).toBe("mock-secret-value");
+    expect(result).toBe("mock");
   });
 
   it("prefers process.env when set", async () => {

--- a/secret-store/infisical/mockGetSecretByName.ts
+++ b/secret-store/infisical/mockGetSecretByName.ts
@@ -1,7 +1,7 @@
 import type { ReturnsError } from "@saflib/monorepo";
 import type { InfisicalClientError } from "./errors.ts";
 
-const MOCK_SECRET_VALUE = "mock-secret-value";
+const MOCK_SECRET_VALUE = "mock";
 
 /**
  * Mock resolution when `accessToken` is `"mock"`: prefers `process.env[name]`, else a fixed placeholder.


### PR DESCRIPTION
I've been testing using google cloud store, and I got rid of the implementation for upserting a bucket. It seems more natural when working with GCP to create the buckets separately.

I also made the infisical mock store return "mock" strings for all secrets by default. Since that's the string I use for all my mock services.

For some reason, running the email client on node stopped working; it didn't support that particular ts syntax. Probably there's a node version discrepancy somewhere but I just made it work.