### PR TITLE
Support vite, mobile testing

### DIFF
--- a/backup/backup-sdk/typed-fake.ts
+++ b/backup/backup-sdk/typed-fake.ts
@@ -1,7 +1,4 @@
 import { typedCreateHandler } from "@saflib/sdk/testing";
 import type { paths } from "@saflib/backup-spec";
 
-export const { createHandler: backupHandler } =
-  typedCreateHandler<paths>({
-    subdomain: "backup",
-  });
+export const { createHandler: backupHandler } = typedCreateHandler<paths>();

--- a/ory-kratos-sdk/kratos-client.ts
+++ b/ory-kratos-sdk/kratos-client.ts
@@ -1,18 +1,12 @@
 import { Configuration, FrontendApi } from "@ory/client";
-import { getProtocol, getHost } from "@saflib/links";
+import { getBaseUrl } from "@saflib/sdk";
 
 let frontendApi: FrontendApi | undefined;
 
 /** Shared Ory Frontend API client (axios + cookies for browser flows). */
 export function getKratosFrontendApi(): FrontendApi {
   if (!frontendApi) {
-    let protocol = "http";
-    let host = "localhost:3000";
-    if (typeof document !== "undefined") {
-      protocol = getProtocol();
-      host = getHost();
-    }
-    const baseUrl = `${protocol}//kratos.${host}`;
+    const baseUrl = getBaseUrl("kratos");
     frontendApi = new FrontendApi(
       new Configuration({
         basePath: baseUrl,

--- a/sdk/src/client.ts
+++ b/sdk/src/client.ts
@@ -5,19 +5,28 @@ import { getProtocol, getHost } from "@saflib/links";
 import { TanstackError } from "./errors.ts";
 import type { ClientResult } from "./types.ts";
 
-/**
- * Given a "paths" openapi generated type and a subdomain, creates a typed `openapi-fetch` client which queries the given subdomain. Uses the current domain and protocol. Handles CSRF token injection, and works in tests.
- */
-export const createSafClient = <Q extends {}>(
-  serviceSubdomain: string,
-): ReturnType<typeof createClient<Q>> => {
+const simpleIpv4Regex = /^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+:[0-9]+$/;
+
+export const getBaseUrl = (serviceSubdomain: string) => {
   let protocol = "http";
   let host = "localhost:3000";
   if (typeof document !== "undefined") {
     protocol = getProtocol();
     host = getHost();
   }
-  const baseUrl = `${protocol}//${serviceSubdomain}.${host}`;
+  if (simpleIpv4Regex.test(host)) {
+    return `${protocol}//${host}`;
+  }
+  return `${protocol}//${serviceSubdomain}.${host}`;
+};
+
+/**
+ * Given a "paths" openapi generated type and a subdomain, creates a typed `openapi-fetch` client which queries the given subdomain. Uses the current domain and protocol. Handles CSRF token injection, and works in tests.
+ */
+export const createSafClient = <Q extends {}>(
+  serviceSubdomain: string,
+): ReturnType<typeof createClient<Q>> => {
+  const baseUrl = getBaseUrl(serviceSubdomain);
   return createClient<Q>({
     baseUrl,
     credentials: "include",

--- a/sdk/testing/typed-msw.ts
+++ b/sdk/testing/typed-msw.ts
@@ -1,4 +1,3 @@
-import { getHost } from "@saflib/links";
 import { http, HttpResponse } from "msw";
 
 type ExtractRequestParams<Op extends Record<string, any>> =

--- a/sdk/testing/typed-msw.ts
+++ b/sdk/testing/typed-msw.ts
@@ -88,42 +88,38 @@ export const typedCreateHandler = <Paths extends Record<string, any>>({
     if (!http[v]) {
       throw new Error(`Invalid HTTP verb: ${v}`);
     }
-    return http[v](
-      `http://${subdomain}.${domain}${pathString}`,
-      async (request) => {
-        let body: any;
-        if (verb === "post" || verb === "put" || verb === "patch") {
-          try {
-            const contentType =
-              request.request.headers.get("content-type") || "";
-            if (contentType.startsWith("multipart/form-data")) {
-              // if you try to run json(), it doesn't crash... it just hangs. So don't parse it. Trying to call formData() also hangs.
-              body = undefined;
-            } else {
-              body = await request.request.json();
-            }
-          } catch (e) {
+    return http[v](`*${pathString}`, async (request) => {
+      let body: any;
+      if (verb === "post" || verb === "put" || verb === "patch") {
+        try {
+          const contentType = request.request.headers.get("content-type") || "";
+          if (contentType.startsWith("multipart/form-data")) {
+            // if you try to run json(), it doesn't crash... it just hangs. So don't parse it. Trying to call formData() also hangs.
             body = undefined;
+          } else {
+            body = await request.request.json();
           }
+        } catch (e) {
+          body = undefined;
         }
-        const query = request.request.url.split("?")[1];
-        let queryParams: query = {};
-        if (query) {
-          queryParams = Object.fromEntries(
-            new URLSearchParams(query).entries(),
-          ) as query;
-        }
-        const params = { ...request.params };
-        return HttpResponse.json(
-          await handler({
-            query: queryParams,
-            params,
-            body,
-          }),
-          { status },
-        );
-      },
-    );
+      }
+      const query = request.request.url.split("?")[1];
+      let queryParams: query = {};
+      if (query) {
+        queryParams = Object.fromEntries(
+          new URLSearchParams(query).entries(),
+        ) as query;
+      }
+      const params = { ...request.params };
+      return HttpResponse.json(
+        await handler({
+          query: queryParams,
+          params,
+          body,
+        }),
+        { status },
+      );
+    });
   };
   return { createHandler };
 };

--- a/sdk/testing/typed-msw.ts
+++ b/sdk/testing/typed-msw.ts
@@ -35,11 +35,7 @@ type ExtractRequestBody<Op extends Record<string, any>> =
 /**
  * Use to create a typed helper function for creating typesafe mock API handlers.
  */
-export const typedCreateHandler = <Paths extends Record<string, any>>({
-  subdomain,
-}: {
-  subdomain: string;
-}) => {
+export const typedCreateHandler = <Paths extends Record<string, any>>() => {
   const createHandler = <
     P extends keyof Paths,
     V extends keyof Paths[P],
@@ -74,10 +70,6 @@ export const typedCreateHandler = <Paths extends Record<string, any>>({
     type query = ExtractRequestQuery<
       Paths[P][V] extends Record<string, any> ? Paths[P][V] : never
     >;
-    let domain = "localhost:3000";
-    if (typeof document !== "undefined") {
-      domain = getHost();
-    }
     // translate instances of "{id}" (the openapi spec format) with ":id" (the msw format)
     const pathString = String(path).replace(/{(\w+)}/g, ":$1");
     let v = verb as keyof typeof http;

--- a/sdk/workflows/templates/typed-fake.ts
+++ b/sdk/workflows/templates/typed-fake.ts
@@ -2,6 +2,4 @@ import { typedCreateHandler } from "@saflib/sdk/testing";
 import type { paths } from "template-package-spec";
 
 export const { createHandler: __serviceName__Handler } =
-  typedCreateHandler<paths>({
-    subdomain: "__service-name__",
-  });
+  typedCreateHandler<paths>();

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -82,6 +82,14 @@ export interface MakeConfigProps {
    * The absolute path of the root of the monorepo, to ensure vite has access to saflib packages.
    */
   monorepoRoot?: string;
+  /**
+   * appType: "spa" | "mpa"
+   */
+  appType?: "spa" | "mpa";
+  /**
+   * Use subdomain proxy plugin
+   */
+  useSubdomainProxy?: boolean;
 }
 
 /**
@@ -89,9 +97,12 @@ export interface MakeConfigProps {
  */
 export function makeConfig(config: MakeConfigProps = {}) {
   const { plugins = [], vuetifyOverrides, monorepoRoot } = config;
+  if (config.useSubdomainProxy !== false) {
+    plugins.push(subDomainProxyPlugin);
+  }
   return defineConfig({
     base: "/",
-    appType: "mpa",
+    appType: config.appType ?? "mpa",
     plugins: [
       vue(),
       vueDevTools(),
@@ -99,7 +110,6 @@ export function makeConfig(config: MakeConfigProps = {}) {
         vuetifyOverrides ? { styles: { configFile: vuetifyOverrides } } : {},
       ),
       ...plugins,
-      subDomainProxyPlugin,
     ],
     build: {
       rollupOptions: {


### PR DESCRIPTION
Some changes while working on https://github.com/sderickson/home-2026/pull/62, to make development work on a single client directly through the vite server (for mobile testing):
* Remove domain logic from typedCreateHandler. 
* Make the kratos and sdk clients handle when the domain is an ip address
* Set up the vite config to run without the proxy plugin and special mpa setup