### PR TITLE
Update Kratos SPA

### DIFF
--- a/ory-kratos-spa/README.md
+++ b/ory-kratos-spa/README.md
@@ -93,6 +93,8 @@ The `#fieldset` slot receives:
 
 When `#fieldset` is provided, `#node` is not used (the fieldset consumer renders `KratosFlowUiNodeAt` directly and controls the full structure).
 
+**Default node order** is whatever Kratos returns in `flow.ui.nodes`. Flows that need a different order should pass a sorted copy via the **`nodes`** prop (see `RegistrationFlowForm.vue`, which uses `sortRegistrationFlowNodes` in `kratosRegistrationNodeOrder.logic.ts` for first → last → email → phone → password).
+
 ### KratosFlowUiNodeAt
 
 `common/KratosFlowUiNodeAt.vue` is the default per-node renderer. It receives context from `KratosFlowUi` via Vue `provide`/`inject` (see `kratosFlowUiInject.ts`). It can also be used directly by consumers who override `#fieldset`.
@@ -124,7 +126,7 @@ Submit-body construction is a pure function in the flow's `.logic.ts` file (e.g.
 - **MFA tabs**: Overrides `#fieldset` to split non-default groups into `v-tabs` / `v-window` for AAL2 login. Tab logic lives in `useKratosMfaGroupTabs.ts`.
 - **Passkey-specific CSS**: The `.kratos-flow-form__identifier-with-passkey` style lives in `LoginFlowForm.vue`'s `<style scoped>`, not in the shared component.
 
-Other flow forms (registration, recovery, verification, settings) use `KratosFlowUi` with just props — no slots needed.
+Other flow forms (recovery, verification, settings) use `KratosFlowUi` with just props — no slots needed. Registration passes **`nodes`** to fix field order without using slots.
 
 ## Ory WebAuthn / passkey integration
 

--- a/ory-kratos-spa/authFallbackInject.ts
+++ b/ory-kratos-spa/authFallbackInject.ts
@@ -1,11 +1,4 @@
-import {
-  computed,
-  inject,
-  ref,
-  type Ref,
-  type ComputedRef,
-  type InjectionKey,
-} from "vue";
+import { computed, inject, type ComputedRef, type InjectionKey } from "vue";
 import { useRoute } from "vue-router";
 
 // really gotta figure out some better way to handle client-side links
@@ -13,80 +6,123 @@ import { useRoute } from "vue-router";
 import { linkToHref } from "@saflib/links";
 const domain = document.location.host.replace("auth.", "");
 
-/** Default post-auth URL when the shell does not pass `postAuthFallbackHref` to {@link configureAuthApp}. */
+/** Default post-auth URL when the shell does not set `postAuthOverrideHref` in `configureAuthApp`. */
 export const defaultPostAuthFallbackHref = computed(() =>
   linkToHref({ subdomain: "app", path: "/" }, { domain }),
 );
 
-/** Default logged-out root URL when the shell does not pass `rootHomeFallbackHref` to {@link configureAuthApp}. */
+/** Default logged-out root URL when the shell does not set `rootHomeOverrideHref` in `configureAuthApp`. */
 export const defaultRootHomeFallbackHref = computed(() =>
   linkToHref({ subdomain: "root", path: "/" }, { domain }),
 );
 
-/** Default URL after a successful **registration** when the shell does not pass `postRegisterFallbackHref` to {@link configureAuthApp}. Matches post-login default unless the host overrides it. */
+/** Default URL after registration when the shell does not set `postRegisterOverrideHref` in `configureAuthApp`. */
 export const defaultPostRegisterFallbackHref = computed(() =>
   linkToHref({ subdomain: "app", path: "/" }, { domain }),
 );
 
 /**
- * Full URL for the hub **app** home (`app.`…`/`), used when `?return_to=` is absent: Kratos
- * `return_to`, post-login / post-verification navigation, verify-wall fallback, etc.
- * {@link configureAuthApp} provides this (or use inject defaults when the shell does not call it).
+ * Resolved post-auth URL from {@link configureAuthApp} (override value or library default).
+ * {@link AUTH_POST_AUTH_URL_IS_OVERRIDE} indicates whether the shell set an override.
  */
 export const AUTH_POST_AUTH_FALLBACK_HREF: InjectionKey<ComputedRef<string>> =
   Symbol("authPostAuthFallbackHref");
 
+/** True when {@link configureAuthApp} was given `postAuthOverrideHref` (that URL wins over `?return_to=`). */
+export const AUTH_POST_AUTH_URL_IS_OVERRIDE: InjectionKey<ComputedRef<boolean>> =
+  Symbol("authPostAuthUrlIsOverride");
+
 /**
- * Full URL for the hub **root** home (`/` on the root domain), used when logging out without
- * `?return_to=` so the browser lands on the logged-out marketing site.
- * {@link configureAuthApp} provides this (or use inject defaults when the shell does not call it).
+ * Resolved logged-out root URL from {@link configureAuthApp} (override or default).
  */
 export const AUTH_ROOT_HOME_FALLBACK_HREF: InjectionKey<ComputedRef<string>> =
   Symbol("authRootHomeFallbackHref");
 
+/** True when {@link configureAuthApp} was given `rootHomeOverrideHref`. */
+export const AUTH_ROOT_HOME_URL_IS_OVERRIDE: InjectionKey<ComputedRef<boolean>> =
+  Symbol("authRootHomeUrlIsOverride");
+
 /**
- * Landing URL after **registration** completes (session or auto-login), when `?return_to=` is absent.
- * Login flows use {@link AUTH_POST_AUTH_FALLBACK_HREF} instead.
+ * Resolved post-register URL from {@link configureAuthApp} (override or default).
  */
 export const AUTH_POST_REGISTER_FALLBACK_HREF: InjectionKey<ComputedRef<string>> =
   Symbol("authPostRegisterFallbackHref");
 
-/**
- * Returns a url to return to after authentication, either from the `?return_to=` query parameter or the default post-auth fallback URL.
- */
-export function useAuthPostAuthFallbackHref(): Ref<string> {
-  const route = useRoute();
-  const returnTo = route.query.return_to;
-  if (typeof returnTo === "string") {
-    return ref(returnTo.trim());
-  }
-  return inject(AUTH_POST_AUTH_FALLBACK_HREF, defaultPostAuthFallbackHref);
+/** True when {@link configureAuthApp} was given `postRegisterOverrideHref`. */
+export const AUTH_POST_REGISTER_URL_IS_OVERRIDE: InjectionKey<ComputedRef<boolean>> =
+  Symbol("authPostRegisterUrlIsOverride");
+
+/** Default for URL override flags when `configureAuthApp` was not used. */
+export const defaultAuthUrlNotOverride = computed(() => false);
+
+function mergeReturnToQuery(
+  route: ReturnType<typeof useRoute>,
+  resolvedHref: ComputedRef<string>,
+  isOverride: ComputedRef<boolean>,
+): ComputedRef<string> {
+  return computed(() => {
+    if (isOverride.value) return resolvedHref.value;
+    const q = route.query.return_to;
+    if (typeof q === "string" && q.trim()) return q.trim();
+    return resolvedHref.value;
+  });
 }
 
 /**
- * Returns a url to return to after logging out, either from the `?return_to=` query parameter or the default logged-out root home URL.
+ * After login / post-auth: when the shell set `postAuthOverrideHref`, that URL is used and `?return_to=` is ignored.
+ * Otherwise `?return_to=` wins, then the resolved default URL.
  */
-export function useAuthLoggedOutRootFallbackHref(): Ref<string> {
+export function useAuthPostAuthFallbackHref(): ComputedRef<string> {
   const route = useRoute();
-  const returnTo = route.query.return_to;
-  if (typeof returnTo === "string") {
-    return ref(returnTo.trim());
-  }
-  return inject(AUTH_ROOT_HOME_FALLBACK_HREF, defaultRootHomeFallbackHref);
+  const resolvedHref = inject(
+    AUTH_POST_AUTH_FALLBACK_HREF,
+    defaultPostAuthFallbackHref,
+  );
+  const isOverride = inject(
+    AUTH_POST_AUTH_URL_IS_OVERRIDE,
+    defaultAuthUrlNotOverride,
+  );
+  return mergeReturnToQuery(route, resolvedHref, isOverride);
 }
 
 /**
- * Returns a url to send the user to after **registration** succeeds, either from `?return_to=` or the
- * post-register fallback URL ({@link AUTH_POST_REGISTER_FALLBACK_HREF}).
+ * After logout: when the shell set `rootHomeOverrideHref`, that URL is used and `?return_to=` is ignored.
+ * Otherwise `?return_to=` wins, then the resolved default URL.
  */
-export function useAuthPostRegisterFallbackHref(): Ref<string> {
+export function useAuthLoggedOutRootFallbackHref(): ComputedRef<string> {
   const route = useRoute();
-  const returnTo = route.query.return_to;
-  if (typeof returnTo === "string") {
-    return ref(returnTo.trim());
-  }
-  return inject(
+  const resolvedHref = inject(
+    AUTH_ROOT_HOME_FALLBACK_HREF,
+    defaultRootHomeFallbackHref,
+  );
+  const isOverride = inject(
+    AUTH_ROOT_HOME_URL_IS_OVERRIDE,
+    defaultAuthUrlNotOverride,
+  );
+  return mergeReturnToQuery(route, resolvedHref, isOverride);
+}
+
+/**
+ * After registration: when the shell set `postRegisterOverrideHref`, that URL is used and `?return_to=` is ignored.
+ * Otherwise `?return_to=` wins, then the resolved default URL.
+ */
+export function useAuthPostRegisterFallbackHref(): ComputedRef<string> {
+  const route = useRoute();
+  const resolvedHref = inject(
     AUTH_POST_REGISTER_FALLBACK_HREF,
     defaultPostRegisterFallbackHref,
   );
+  const isOverride = inject(
+    AUTH_POST_REGISTER_URL_IS_OVERRIDE,
+    defaultAuthUrlNotOverride,
+  );
+  return mergeReturnToQuery(route, resolvedHref, isOverride);
+}
+
+export function useAuthPostAuthUrlIsOverride(): ComputedRef<boolean> {
+  return inject(AUTH_POST_AUTH_URL_IS_OVERRIDE, defaultAuthUrlNotOverride);
+}
+
+export function useAuthPostRegisterUrlIsOverride(): ComputedRef<boolean> {
+  return inject(AUTH_POST_REGISTER_URL_IS_OVERRIDE, defaultAuthUrlNotOverride);
 }

--- a/ory-kratos-spa/authFallbackInject.ts
+++ b/ory-kratos-spa/authFallbackInject.ts
@@ -23,6 +23,11 @@ export const defaultRootHomeFallbackHref = computed(() =>
   linkToHref({ subdomain: "root", path: "/" }, { domain }),
 );
 
+/** Default URL after a successful **registration** when the shell does not pass `postRegisterFallbackHref` to {@link configureAuthApp}. Matches post-login default unless the host overrides it. */
+export const defaultPostRegisterFallbackHref = computed(() =>
+  linkToHref({ subdomain: "app", path: "/" }, { domain }),
+);
+
 /**
  * Full URL for the hub **app** home (`app.`…`/`), used when `?return_to=` is absent: Kratos
  * `return_to`, post-login / post-verification navigation, verify-wall fallback, etc.
@@ -38,6 +43,13 @@ export const AUTH_POST_AUTH_FALLBACK_HREF: InjectionKey<ComputedRef<string>> =
  */
 export const AUTH_ROOT_HOME_FALLBACK_HREF: InjectionKey<ComputedRef<string>> =
   Symbol("authRootHomeFallbackHref");
+
+/**
+ * Landing URL after **registration** completes (session or auto-login), when `?return_to=` is absent.
+ * Login flows use {@link AUTH_POST_AUTH_FALLBACK_HREF} instead.
+ */
+export const AUTH_POST_REGISTER_FALLBACK_HREF: InjectionKey<ComputedRef<string>> =
+  Symbol("authPostRegisterFallbackHref");
 
 /**
  * Returns a url to return to after authentication, either from the `?return_to=` query parameter or the default post-auth fallback URL.
@@ -61,4 +73,20 @@ export function useAuthLoggedOutRootFallbackHref(): Ref<string> {
     return ref(returnTo.trim());
   }
   return inject(AUTH_ROOT_HOME_FALLBACK_HREF, defaultRootHomeFallbackHref);
+}
+
+/**
+ * Returns a url to send the user to after **registration** succeeds, either from `?return_to=` or the
+ * post-register fallback URL ({@link AUTH_POST_REGISTER_FALLBACK_HREF}).
+ */
+export function useAuthPostRegisterFallbackHref(): Ref<string> {
+  const route = useRoute();
+  const returnTo = route.query.return_to;
+  if (typeof returnTo === "string") {
+    return ref(returnTo.trim());
+  }
+  return inject(
+    AUTH_POST_REGISTER_FALLBACK_HREF,
+    defaultPostRegisterFallbackHref,
+  );
 }

--- a/ory-kratos-spa/authFallbackInject.ts
+++ b/ory-kratos-spa/authFallbackInject.ts
@@ -12,17 +12,21 @@ import { useRoute } from "vue-router";
 // perhaps set up something in @saflib/vue that is reactive?
 import { linkToHref } from "@saflib/links";
 const domain = document.location.host.replace("auth.", "");
-const defaultPostAuthFallbackHref = computed(() =>
+
+/** Default post-auth URL when the shell does not pass `postAuthFallbackHref` to {@link configureAuthApp}. */
+export const defaultPostAuthFallbackHref = computed(() =>
   linkToHref({ subdomain: "app", path: "/" }, { domain }),
 );
-const defaultRootHomeFallbackHref = computed(() =>
+
+/** Default logged-out root URL when the shell does not pass `rootHomeFallbackHref` to {@link configureAuthApp}. */
+export const defaultRootHomeFallbackHref = computed(() =>
   linkToHref({ subdomain: "root", path: "/" }, { domain }),
 );
 
 /**
  * Full URL for the hub **app** home (`app.`…`/`), used when `?return_to=` is absent: Kratos
  * `return_to`, post-login / post-verification navigation, verify-wall fallback, etc.
- * {@link AuthSpa.vue} provides this; composables fall back to the same hub-links resolution if missing.
+ * {@link configureAuthApp} provides this (or use inject defaults when the shell does not call it).
  */
 export const AUTH_POST_AUTH_FALLBACK_HREF: InjectionKey<ComputedRef<string>> =
   Symbol("authPostAuthFallbackHref");
@@ -30,6 +34,7 @@ export const AUTH_POST_AUTH_FALLBACK_HREF: InjectionKey<ComputedRef<string>> =
 /**
  * Full URL for the hub **root** home (`/` on the root domain), used when logging out without
  * `?return_to=` so the browser lands on the logged-out marketing site.
+ * {@link configureAuthApp} provides this (or use inject defaults when the shell does not call it).
  */
 export const AUTH_ROOT_HOME_FALLBACK_HREF: InjectionKey<ComputedRef<string>> =
   Symbol("authRootHomeFallbackHref");

--- a/ory-kratos-spa/configureAuthApp.ts
+++ b/ory-kratos-spa/configureAuthApp.ts
@@ -1,0 +1,47 @@
+import {
+  computed,
+  inject,
+  provide,
+  toValue,
+  type ComputedRef,
+  type InjectionKey,
+  type MaybeRefOrGetter,
+} from "vue";
+
+export interface AuthAppConfig {
+  /**
+   * When false, Kratos flow pages hide built-in H1 titles (e.g. "Create your account")
+   * so a host layout can supply its own headings.
+   */
+  showFlowHeaders: boolean;
+}
+
+const defaultAuthAppConfig: AuthAppConfig = {
+  showFlowHeaders: true,
+};
+
+export const AUTH_APP_CONFIG: InjectionKey<ComputedRef<AuthAppConfig>> =
+  Symbol("authAppConfig");
+
+const fallbackAuthAppConfig = computed<AuthAppConfig>(
+  () => defaultAuthAppConfig,
+);
+
+/**
+ * Call once from the auth shell (e.g. `AuthApp.vue`) to provide options for nested Kratos pages.
+ * Uses the same provide/inject pattern as {@link AUTH_POST_AUTH_FALLBACK_HREF}.
+ */
+export function configureAuthApp(
+  options: MaybeRefOrGetter<Partial<AuthAppConfig>> = {},
+): ComputedRef<AuthAppConfig> {
+  const config = computed<AuthAppConfig>(() => ({
+    ...defaultAuthAppConfig,
+    ...toValue(options),
+  }));
+  provide(AUTH_APP_CONFIG, config);
+  return config;
+}
+
+export function useAuthAppConfig(): ComputedRef<AuthAppConfig> {
+  return inject(AUTH_APP_CONFIG, fallbackAuthAppConfig);
+}

--- a/ory-kratos-spa/configureAuthApp.ts
+++ b/ory-kratos-spa/configureAuthApp.ts
@@ -7,6 +7,12 @@ import {
   type InjectionKey,
   type MaybeRefOrGetter,
 } from "vue";
+import {
+  AUTH_POST_AUTH_FALLBACK_HREF,
+  AUTH_ROOT_HOME_FALLBACK_HREF,
+  defaultPostAuthFallbackHref,
+  defaultRootHomeFallbackHref,
+} from "./authFallbackInject.ts";
 
 export interface AuthAppConfig {
   /**
@@ -20,6 +26,19 @@ const defaultAuthAppConfig: AuthAppConfig = {
   showFlowHeaders: true,
 };
 
+export interface ConfigureAuthAppOptions extends Partial<AuthAppConfig> {
+  /**
+   * Overrides the default post-auth landing URL (`app.`…`/`).
+   * See {@link AUTH_POST_AUTH_FALLBACK_HREF}.
+   */
+  postAuthFallbackHref?: MaybeRefOrGetter<string>;
+  /**
+   * Overrides the default logged-out root home URL (marketing site).
+   * See {@link AUTH_ROOT_HOME_FALLBACK_HREF}.
+   */
+  rootHomeFallbackHref?: MaybeRefOrGetter<string>;
+}
+
 export const AUTH_APP_CONFIG: InjectionKey<ComputedRef<AuthAppConfig>> =
   Symbol("authAppConfig");
 
@@ -28,17 +47,40 @@ const fallbackAuthAppConfig = computed<AuthAppConfig>(
 );
 
 /**
- * Call once from the auth shell (e.g. `AuthApp.vue`) to provide options for nested Kratos pages.
- * Uses the same provide/inject pattern as {@link AUTH_POST_AUTH_FALLBACK_HREF}.
+ * Call once from the auth shell (e.g. `AuthApp.vue`) to provide options for nested Kratos pages,
+ * including post-auth and logged-out root URLs ({@link AUTH_POST_AUTH_FALLBACK_HREF},
+ * {@link AUTH_ROOT_HOME_FALLBACK_HREF}).
  */
 export function configureAuthApp(
-  options: MaybeRefOrGetter<Partial<AuthAppConfig>> = {},
+  options: MaybeRefOrGetter<ConfigureAuthAppOptions> = {},
 ): ComputedRef<AuthAppConfig> {
-  const config = computed<AuthAppConfig>(() => ({
-    ...defaultAuthAppConfig,
-    ...toValue(options),
-  }));
+  const config = computed<AuthAppConfig>(() => {
+    const o = toValue(options);
+    return {
+      ...defaultAuthAppConfig,
+      showFlowHeaders: o.showFlowHeaders ?? defaultAuthAppConfig.showFlowHeaders,
+    };
+  });
   provide(AUTH_APP_CONFIG, config);
+
+  const postAuthHref = computed(() => {
+    const o = toValue(options);
+    if (o.postAuthFallbackHref !== undefined) {
+      return toValue(o.postAuthFallbackHref);
+    }
+    return defaultPostAuthFallbackHref.value;
+  });
+  provide(AUTH_POST_AUTH_FALLBACK_HREF, postAuthHref);
+
+  const rootHomeHref = computed(() => {
+    const o = toValue(options);
+    if (o.rootHomeFallbackHref !== undefined) {
+      return toValue(o.rootHomeFallbackHref);
+    }
+    return defaultRootHomeFallbackHref.value;
+  });
+  provide(AUTH_ROOT_HOME_FALLBACK_HREF, rootHomeHref);
+
   return config;
 }
 

--- a/ory-kratos-spa/configureAuthApp.ts
+++ b/ory-kratos-spa/configureAuthApp.ts
@@ -9,8 +9,11 @@ import {
 } from "vue";
 import {
   AUTH_POST_AUTH_FALLBACK_HREF,
+  AUTH_POST_AUTH_URL_IS_OVERRIDE,
   AUTH_POST_REGISTER_FALLBACK_HREF,
+  AUTH_POST_REGISTER_URL_IS_OVERRIDE,
   AUTH_ROOT_HOME_FALLBACK_HREF,
+  AUTH_ROOT_HOME_URL_IS_OVERRIDE,
   defaultPostAuthFallbackHref,
   defaultPostRegisterFallbackHref,
   defaultRootHomeFallbackHref,
@@ -30,21 +33,23 @@ const defaultAuthAppConfig: AuthAppConfig = {
 
 export interface ConfigureAuthAppOptions extends Partial<AuthAppConfig> {
   /**
-   * Overrides the default post-auth landing URL (`app.`…`/`).
+   * When set, this URL is used for post-login redirects and `?return_to=` is ignored.
+   * When omitted, `?return_to=` is honored, then the default app home URL.
    * See {@link AUTH_POST_AUTH_FALLBACK_HREF}.
    */
-  postAuthFallbackHref?: MaybeRefOrGetter<string>;
+  postAuthOverrideHref?: MaybeRefOrGetter<string>;
   /**
-   * Overrides the default logged-out root home URL (marketing site).
+   * When set, this URL is used after logout and `?return_to=` is ignored.
+   * When omitted, `?return_to=` is honored, then the default root home URL.
    * See {@link AUTH_ROOT_HOME_FALLBACK_HREF}.
    */
-  rootHomeFallbackHref?: MaybeRefOrGetter<string>;
+  rootHomeOverrideHref?: MaybeRefOrGetter<string>;
   /**
-   * Where to send users after **registration** completes (when `?return_to=` is absent).
-   * Login still uses {@link ConfigureAuthAppOptions.postAuthFallbackHref}.
+   * When set, this URL is used after registration (and on the verify wall) and `?return_to=` is ignored.
+   * When omitted, `?return_to=` is honored, then the default URL.
    * See {@link AUTH_POST_REGISTER_FALLBACK_HREF}.
    */
-  postRegisterFallbackHref?: MaybeRefOrGetter<string>;
+  postRegisterOverrideHref?: MaybeRefOrGetter<string>;
 }
 
 export const AUTH_APP_CONFIG: InjectionKey<ComputedRef<AuthAppConfig>> =
@@ -56,8 +61,7 @@ const fallbackAuthAppConfig = computed<AuthAppConfig>(
 
 /**
  * Call once from the auth shell (e.g. `AuthApp.vue`) to provide options for nested Kratos pages,
- * including post-auth, post-register, and logged-out root URLs ({@link AUTH_POST_AUTH_FALLBACK_HREF},
- * {@link AUTH_POST_REGISTER_FALLBACK_HREF}, {@link AUTH_ROOT_HOME_FALLBACK_HREF}).
+ * including post-auth, post-register, and logged-out root URLs.
  */
 export function configureAuthApp(
   options: MaybeRefOrGetter<ConfigureAuthAppOptions> = {},
@@ -72,28 +76,43 @@ export function configureAuthApp(
   });
   provide(AUTH_APP_CONFIG, config);
 
+  const postAuthOverride = computed(
+    () => toValue(options).postAuthOverrideHref !== undefined,
+  );
+  provide(AUTH_POST_AUTH_URL_IS_OVERRIDE, postAuthOverride);
+
   const postAuthHref = computed(() => {
     const o = toValue(options);
-    if (o.postAuthFallbackHref !== undefined) {
-      return toValue(o.postAuthFallbackHref);
+    if (o.postAuthOverrideHref !== undefined) {
+      return toValue(o.postAuthOverrideHref);
     }
     return defaultPostAuthFallbackHref.value;
   });
   provide(AUTH_POST_AUTH_FALLBACK_HREF, postAuthHref);
 
+  const postRegisterOverride = computed(
+    () => toValue(options).postRegisterOverrideHref !== undefined,
+  );
+  provide(AUTH_POST_REGISTER_URL_IS_OVERRIDE, postRegisterOverride);
+
   const postRegisterHref = computed(() => {
     const o = toValue(options);
-    if (o.postRegisterFallbackHref !== undefined) {
-      return toValue(o.postRegisterFallbackHref);
+    if (o.postRegisterOverrideHref !== undefined) {
+      return toValue(o.postRegisterOverrideHref);
     }
     return defaultPostRegisterFallbackHref.value;
   });
   provide(AUTH_POST_REGISTER_FALLBACK_HREF, postRegisterHref);
 
+  const rootHomeOverride = computed(
+    () => toValue(options).rootHomeOverrideHref !== undefined,
+  );
+  provide(AUTH_ROOT_HOME_URL_IS_OVERRIDE, rootHomeOverride);
+
   const rootHomeHref = computed(() => {
     const o = toValue(options);
-    if (o.rootHomeFallbackHref !== undefined) {
-      return toValue(o.rootHomeFallbackHref);
+    if (o.rootHomeOverrideHref !== undefined) {
+      return toValue(o.rootHomeOverrideHref);
     }
     return defaultRootHomeFallbackHref.value;
   });

--- a/ory-kratos-spa/configureAuthApp.ts
+++ b/ory-kratos-spa/configureAuthApp.ts
@@ -9,8 +9,10 @@ import {
 } from "vue";
 import {
   AUTH_POST_AUTH_FALLBACK_HREF,
+  AUTH_POST_REGISTER_FALLBACK_HREF,
   AUTH_ROOT_HOME_FALLBACK_HREF,
   defaultPostAuthFallbackHref,
+  defaultPostRegisterFallbackHref,
   defaultRootHomeFallbackHref,
 } from "./authFallbackInject.ts";
 
@@ -37,6 +39,12 @@ export interface ConfigureAuthAppOptions extends Partial<AuthAppConfig> {
    * See {@link AUTH_ROOT_HOME_FALLBACK_HREF}.
    */
   rootHomeFallbackHref?: MaybeRefOrGetter<string>;
+  /**
+   * Where to send users after **registration** completes (when `?return_to=` is absent).
+   * Login still uses {@link ConfigureAuthAppOptions.postAuthFallbackHref}.
+   * See {@link AUTH_POST_REGISTER_FALLBACK_HREF}.
+   */
+  postRegisterFallbackHref?: MaybeRefOrGetter<string>;
 }
 
 export const AUTH_APP_CONFIG: InjectionKey<ComputedRef<AuthAppConfig>> =
@@ -48,8 +56,8 @@ const fallbackAuthAppConfig = computed<AuthAppConfig>(
 
 /**
  * Call once from the auth shell (e.g. `AuthApp.vue`) to provide options for nested Kratos pages,
- * including post-auth and logged-out root URLs ({@link AUTH_POST_AUTH_FALLBACK_HREF},
- * {@link AUTH_ROOT_HOME_FALLBACK_HREF}).
+ * including post-auth, post-register, and logged-out root URLs ({@link AUTH_POST_AUTH_FALLBACK_HREF},
+ * {@link AUTH_POST_REGISTER_FALLBACK_HREF}, {@link AUTH_ROOT_HOME_FALLBACK_HREF}).
  */
 export function configureAuthApp(
   options: MaybeRefOrGetter<ConfigureAuthAppOptions> = {},
@@ -58,7 +66,8 @@ export function configureAuthApp(
     const o = toValue(options);
     return {
       ...defaultAuthAppConfig,
-      showFlowHeaders: o.showFlowHeaders ?? defaultAuthAppConfig.showFlowHeaders,
+      showFlowHeaders:
+        o.showFlowHeaders ?? defaultAuthAppConfig.showFlowHeaders,
     };
   });
   provide(AUTH_APP_CONFIG, config);
@@ -71,6 +80,15 @@ export function configureAuthApp(
     return defaultPostAuthFallbackHref.value;
   });
   provide(AUTH_POST_AUTH_FALLBACK_HREF, postAuthHref);
+
+  const postRegisterHref = computed(() => {
+    const o = toValue(options);
+    if (o.postRegisterFallbackHref !== undefined) {
+      return toValue(o.postRegisterFallbackHref);
+    }
+    return defaultPostRegisterFallbackHref.value;
+  });
+  provide(AUTH_POST_REGISTER_FALLBACK_HREF, postRegisterHref);
 
   const rootHomeHref = computed(() => {
     const o = toValue(options);

--- a/ory-kratos-spa/index.ts
+++ b/ory-kratos-spa/index.ts
@@ -1,1 +1,2 @@
 export * from "./authFallbackInject.ts";
+export * from "./configureAuthApp.ts";

--- a/ory-kratos-spa/pages/common/CsrfViolationPanel.vue
+++ b/ory-kratos-spa/pages/common/CsrfViolationPanel.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
-    <h1 class="text-h4 mb-2">{{ t(strings.title) }}</h1>
+    <h1 v-if="authApp.showFlowHeaders" class="text-h4 mb-2">
+      {{ t(strings.title) }}
+    </h1>
     <p class="text-body-1 mb-4">{{ t(strings.body) }}</p>
     <div class="d-flex flex-wrap ga-3">
       <v-btn
@@ -20,6 +22,7 @@
 import { useRouter } from "vue-router";
 import type { SecurityCsrfViolation } from "@saflib/ory-kratos-sdk";
 import { useReverseT } from "@saflib/ory-kratos-spa/i18n";
+import { useAuthAppConfig } from "../../configureAuthApp.ts";
 import { csrf_violation as strings } from "./csrf_violation.strings.ts";
 
 const props = defineProps<{
@@ -29,6 +32,7 @@ const props = defineProps<{
 }>();
 
 const { t } = useReverseT();
+const authApp = useAuthAppConfig();
 const router = useRouter();
 
 function restart() {

--- a/ory-kratos-spa/pages/common/FlowGonePanel.vue
+++ b/ory-kratos-spa/pages/common/FlowGonePanel.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
-    <h1 class="text-h4 mb-2">{{ t(strings.title) }}</h1>
+    <h1 v-if="authApp.showFlowHeaders" class="text-h4 mb-2">
+      {{ t(strings.title) }}
+    </h1>
     <p class="text-body-1 mb-4">{{ t(strings.body) }}</p>
     <p v-if="detailLine" class="text-body-2 text-medium-emphasis mb-4">
       {{ detailLine }}
@@ -24,6 +26,7 @@ import { computed } from "vue";
 import { useRouter } from "vue-router";
 import type { FlowGone } from "@saflib/ory-kratos-sdk";
 import { useReverseT } from "@saflib/ory-kratos-spa/i18n";
+import { useAuthAppConfig } from "../../configureAuthApp.ts";
 import { flow_gone as strings } from "./FlowGone.strings.ts";
 
 const props = withDefaults(
@@ -38,6 +41,7 @@ const props = withDefaults(
 );
 
 const { t } = useReverseT();
+const authApp = useAuthAppConfig();
 const router = useRouter();
 
 const detailLine = computed(() => {

--- a/ory-kratos-spa/pages/common/KratosFlowUi.vue
+++ b/ory-kratos-spa/pages/common/KratosFlowUi.vue
@@ -1,10 +1,5 @@
 <template>
-  <v-card
-    v-if="flow"
-    variant="outlined"
-    class="pa-4"
-    :class="{ 'opacity-60': submitting }"
-  >
+  <div v-if="flow" :class="{ 'opacity-60': submitting }">
     <form
       ref="formRef"
       class="kratos-flow-form"
@@ -25,7 +20,11 @@
       </v-alert>
 
       <fieldset class="kratos-flow-form__fieldset">
-        <slot name="fieldset" :display-nodes="displayNodes" :all-node-indices="allNodeIndices">
+        <slot
+          name="fieldset"
+          :display-nodes="displayNodes"
+          :all-node-indices="allNodeIndices"
+        >
           <template v-for="idx in allNodeIndices" :key="'node-' + idx">
             <slot name="node" :node="displayNodes[idx]!" :idx="idx">
               <KratosFlowUiNodeAt :idx="idx" />
@@ -34,7 +33,7 @@
         </slot>
       </fieldset>
     </form>
-  </v-card>
+  </div>
 </template>
 
 <script setup lang="ts">
@@ -144,7 +143,9 @@ const flowForFocus = computed(() => {
 const formRef = ref<HTMLFormElement | null>(null);
 
 /** When {@link SubmitEvent.submitter} is null (often with Vuetify `v-btn`), `FormData` loses the clicked control. */
-const lastPointerSubmitter = ref<HTMLButtonElement | HTMLInputElement | null>(null);
+const lastPointerSubmitter = ref<HTMLButtonElement | HTMLInputElement | null>(
+  null,
+);
 
 function onFormPointerDownCapture(ev: Event) {
   const t = ev.target;

--- a/ory-kratos-spa/pages/common/KratosFlowUiNodeAt.vue
+++ b/ory-kratos-spa/pages/common/KratosFlowUiNodeAt.vue
@@ -1,130 +1,153 @@
 <template>
   <template v-if="node && node.type === 'text'">
-    <v-alert
-      v-for="(nm, mi) in ctx.visibleNodeMessages(node, idx)"
-      :key="'text-nm-' + idx + '-' + mi"
-      :type="nm.type === 'error' ? 'error' : 'info'"
-      variant="tonal"
-      class="mb-2"
-      density="comfortable"
-    >
-      {{ nm.text }}
-    </v-alert>
-    <p class="text-body-2 mb-2">
-      {{ (node.attributes as { text?: { text: string } }).text?.text }}
-    </p>
+    <div class="mb-4">
+      <p class="text-body-2 mb-2">
+        {{ (node.attributes as { text?: { text: string } }).text?.text }}
+      </p>
+      <p
+        v-for="(nm, mi) in ctx.visibleNodeMessages(node, idx)"
+        :key="'text-nm-' + idx + '-' + mi"
+        class="text-body-2 mt-1"
+        :class="nm.type === 'error' ? 'text-error' : 'text-medium-emphasis'"
+      >
+        {{ nm.text }}
+      </p>
+    </div>
   </template>
 
   <template v-else-if="node && node.type === 'img'">
-    <v-alert
-      v-for="(nm, mi) in ctx.visibleNodeMessages(node, idx)"
-      :key="'img-nm-' + idx + '-' + mi"
-      :type="nm.type === 'error' ? 'error' : 'info'"
-      variant="tonal"
-      class="mb-2"
-      density="comfortable"
-    >
-      {{ nm.text }}
-    </v-alert>
-    <div class="mb-4 d-flex justify-center">
-      <img
-        :src="String((node.attributes as { src?: string }).src ?? '')"
-        :alt="node.meta?.label?.text ?? 'Authenticator QR code'"
-        class="kratos-flow-form__qr"
-      />
+    <div class="mb-4">
+      <div class="mb-2 d-flex justify-center">
+        <img
+          :src="String((node.attributes as { src?: string }).src ?? '')"
+          :alt="node.meta?.label?.text ?? 'Authenticator QR code'"
+          class="kratos-flow-form__qr"
+        />
+      </div>
+      <p
+        v-for="(nm, mi) in ctx.visibleNodeMessages(node, idx)"
+        :key="'img-nm-' + idx + '-' + mi"
+        class="text-body-2 mt-1"
+        :class="nm.type === 'error' ? 'text-error' : 'text-medium-emphasis'"
+      >
+        {{ nm.text }}
+      </p>
     </div>
   </template>
 
   <template
     v-else-if="node && isKratosInputNode(node) && !ctx.shouldHideSubmit(node)"
   >
-    <v-alert
-      v-for="(nm, mi) in ctx.visibleNodeMessages(node, idx)"
-      :key="'in-nm-' + idx + '-' + mi"
-      :type="nm.type === 'error' ? 'error' : 'info'"
-      variant="tonal"
-      class="mb-2"
-      density="comfortable"
-    >
-      {{ nm.text }}
-    </v-alert>
     <input
       v-if="node.attributes.type === 'hidden'"
       type="hidden"
       :name="node.attributes.name"
       :value="node.attributes.value ?? undefined"
     />
-    <v-btn
-      v-else-if="node.attributes.type === 'button'"
-      :id="ctx.elementId(idx)"
-      type="button"
-      color="primary"
-      block
-      size="large"
-      variant="tonal"
-      class="mb-4 mt-1"
-      :disabled="submitting"
-      @click="runKratosWebAuthnInputClick(node)"
-    >
-      {{ ctx.kratosSubmitLabel(node) }}
-    </v-btn>
-    <v-btn
-      v-else-if="node.attributes.type === 'submit'"
-      :id="ctx.elementId(idx)"
-      type="submit"
-      color="primary"
-      block
-      size="large"
-      variant="tonal"
-      class="mb-8 mt-1"
-      :name="node.attributes.name"
-      :value="(node.attributes as { value?: string }).value ?? undefined"
-      :loading="submitting"
-      :disabled="submitting"
-    >
-      {{ ctx.kratosSubmitLabel(node) }}
-    </v-btn>
+    <div v-else-if="node.attributes.type === 'button'" class="mb-4 mt-1">
+      <v-btn
+        :id="ctx.elementId(idx)"
+        type="button"
+        color="primary"
+        block
+        size="large"
+        variant="tonal"
+        :disabled="submitting"
+        @click="runKratosWebAuthnInputClick(node)"
+      >
+        {{ ctx.kratosSubmitLabel(node) }}
+      </v-btn>
+      <p
+        v-for="(nm, mi) in ctx.visibleNodeMessages(node, idx)"
+        :key="'btn-nm-' + idx + '-' + mi"
+        class="text-body-2 mt-2"
+        :class="nm.type === 'error' ? 'text-error' : 'text-medium-emphasis'"
+      >
+        {{ nm.text }}
+      </p>
+    </div>
+    <div v-else-if="node.attributes.type === 'submit'" class="mb-8 mt-1">
+      <v-btn
+        :id="ctx.elementId(idx)"
+        type="submit"
+        color="primary"
+        block
+        size="large"
+        variant="tonal"
+        :name="node.attributes.name"
+        :value="(node.attributes as { value?: string }).value ?? undefined"
+        :loading="submitting"
+        :disabled="submitting"
+      >
+        {{ ctx.kratosSubmitLabel(node) }}
+      </v-btn>
+      <p
+        v-for="(nm, mi) in ctx.visibleNodeMessages(node, idx)"
+        :key="'sub-nm-' + idx + '-' + mi"
+        class="text-body-2 mt-2"
+        :class="nm.type === 'error' ? 'text-error' : 'text-medium-emphasis'"
+      >
+        {{ nm.text }}
+      </p>
+    </div>
     <template v-else-if="isKratosTraitsPhoneInputNode(node)">
       <!--
         Visible field shows formatted digits; FormData must receive E.164 from the hidden input
         (see UsPhoneNumberInput update:modelValue).
       -->
-      <input
-        type="hidden"
-        :name="node.attributes.name"
-        :value="fieldModels[idx]"
-      />
-      <UsPhoneNumberInput
-        v-model="fieldModels[idx]"
-        :id="ctx.elementId(idx)"
-        :label="kratosPhoneFieldLabel(node)"
-        :required="!!node.attributes.required"
-        :disabled="submitting"
-        density="comfortable"
-        class="mb-4"
-        autocomplete="tel"
-      />
+      <div class="mb-4">
+        <input
+          type="hidden"
+          :name="node.attributes.name"
+          :value="fieldModels[idx]"
+        />
+        <UsPhoneNumberInput
+          v-model="fieldModels[idx]"
+          :id="ctx.elementId(idx)"
+          :label="kratosPhoneFieldLabel(node)"
+          :required="!!node.attributes.required"
+          :disabled="submitting"
+          :error-messages="nodeErrorMessages(node, idx)"
+          density="comfortable"
+          autocomplete="tel"
+        />
+        <p
+          v-for="(msg, mi) in nodeInfoMessages(node, idx)"
+          :key="'phone-info-' + idx + '-' + mi"
+          class="text-body-2 text-medium-emphasis mt-1"
+        >
+          {{ msg }}
+        </p>
+      </div>
     </template>
-    <v-text-field
-      v-else
-      :id="ctx.elementId(idx)"
-      v-model="fieldModels[idx]"
-      :name="node.attributes.name"
-      :type="ctx.effectiveInputType(node, idx)"
-      :label="
-        node.meta?.label?.text?.trim() ||
-        kratosFallbackLabelForInputName(node.attributes.name)
-      "
-      :required="node.attributes.required"
-      :prepend-inner-icon="ctx.prependIcon(node)"
-      :append-inner-icon="appendInnerIconForField(node, idx)"
-      :disabled="submitting"
-      density="comfortable"
-      class="mb-4"
-      :class="identifierPasskeyClass(node)"
-      autocomplete="off"
-      @click:append-inner="onAppendInnerForField(idx, node)"
-    />
+    <div v-else class="mb-4">
+      <v-text-field
+        :id="ctx.elementId(idx)"
+        v-model="fieldModels[idx]"
+        :name="node.attributes.name"
+        :type="ctx.effectiveInputType(node, idx)"
+        :label="
+          node.meta?.label?.text?.trim() ||
+          kratosFallbackLabelForInputName(node.attributes.name)
+        "
+        :required="node.attributes.required"
+        :prepend-inner-icon="ctx.prependIcon(node)"
+        :append-inner-icon="appendInnerIconForField(node, idx)"
+        :disabled="submitting"
+        :error-messages="nodeErrorMessages(node, idx)"
+        density="comfortable"
+        :class="identifierPasskeyClass(node)"
+        autocomplete="off"
+        @click:append-inner="onAppendInnerForField(idx, node)"
+      />
+      <p
+        v-for="(msg, mi) in nodeInfoMessages(node, idx)"
+        :key="'tf-info-' + idx + '-' + mi"
+        class="text-body-2 text-medium-emphasis mt-1"
+      >
+        {{ msg }}
+      </p>
+    </div>
   </template>
 </template>
 
@@ -203,6 +226,22 @@ function onAppendInnerForField(idx: number, node: UiNode) {
 function kratosPhoneFieldLabel(node: UiNode): string {
   if (!isKratosInputNode(node)) return "Phone";
   return node.meta?.label?.text?.trim() || "Phone";
+}
+
+/** Kratos server messages for `error-messages` / red outline on Vuetify fields. */
+function nodeErrorMessages(node: UiNode, idx: number): string[] {
+  return ctx
+    .visibleNodeMessages(node, idx)
+    .filter((m) => m.type === "error")
+    .map((m) => m.text);
+}
+
+/** Non-error node messages (shown as muted text below the field). */
+function nodeInfoMessages(node: UiNode, idx: number): string[] {
+  return ctx
+    .visibleNodeMessages(node, idx)
+    .filter((m) => m.type !== "error")
+    .map((m) => m.text);
 }
 </script>
 

--- a/ory-kratos-spa/pages/common/SessionAlreadyAvailable.vue
+++ b/ory-kratos-spa/pages/common/SessionAlreadyAvailable.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
-    <h1 class="text-h4 mb-2">{{ t(strings.title) }}</h1>
+    <h1 v-if="authApp.showFlowHeaders" class="text-h4 mb-2">
+      {{ t(strings.title) }}
+    </h1>
     <p class="text-body-1 mb-4">{{ t(strings.body) }}</p>
     <div class="d-flex flex-wrap ga-3">
       <v-btn
@@ -30,12 +32,14 @@
 import { computed } from "vue";
 import { useRoute } from "vue-router";
 import { useReverseT } from "@saflib/ory-kratos-spa/i18n";
+import { useAuthAppConfig } from "../../configureAuthApp.ts";
 import { session_already_available as strings } from "./SessionAlreadyAvailable.strings.ts";
 import { useAuthPostAuthFallbackHref } from "../../authFallbackInject.ts";
 import { useKratosBrowserLogout } from "../registration/useKratosBrowserLogout.ts";
 
 const route = useRoute();
 const { t } = useReverseT();
+const authApp = useAuthAppConfig();
 const postAuthFallbackHref = useAuthPostAuthFallbackHref();
 
 const afterLogoutReturnTo = computed(

--- a/ory-kratos-spa/pages/common/UnhandledResponsePanel.vue
+++ b/ory-kratos-spa/pages/common/UnhandledResponsePanel.vue
@@ -1,6 +1,8 @@
 <template>
   <div>
-    <h1 class="text-h6 mb-2">Unexpected response</h1>
+    <h1 v-if="authApp.showFlowHeaders" class="text-h6 mb-2">
+      Unexpected response
+    </h1>
     <template v-if="result instanceof UnhandledResponse">
       <p class="text-body-2 text-medium-emphasis mb-2">
         HTTP status: <code>{{ result.status }}</code>
@@ -24,6 +26,9 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { UnhandledResponse } from "@saflib/ory-kratos-sdk";
+import { useAuthAppConfig } from "../../configureAuthApp.ts";
+
+const authApp = useAuthAppConfig();
 
 const props = defineProps<{
   result: unknown;

--- a/ory-kratos-spa/pages/login/Login.vue
+++ b/ory-kratos-spa/pages/login/Login.vue
@@ -1,21 +1,19 @@
 <template>
-  <v-container class="py-8" max-width="720">
-    <LoginFlowForm
-      v-if="queryData instanceof LoginFlowFetched && flow"
-      :flow="flow"
-    />
-    <FlowGonePanel
-      v-else-if="queryData instanceof FlowGone"
-      restart-path="/new-login"
-      :result="queryData"
-    />
-    <CsrfViolationPanel
-      v-else-if="queryData instanceof SecurityCsrfViolation"
-      restart-path="/new-login"
-      :result="queryData"
-    />
-    <UnhandledResponsePanel v-else :result="queryData" />
-  </v-container>
+  <LoginFlowForm
+    v-if="queryData instanceof LoginFlowFetched && flow"
+    :flow="flow"
+  />
+  <FlowGonePanel
+    v-else-if="queryData instanceof FlowGone"
+    restart-path="/new-login"
+    :result="queryData"
+  />
+  <CsrfViolationPanel
+    v-else-if="queryData instanceof SecurityCsrfViolation"
+    restart-path="/new-login"
+    :result="queryData"
+  />
+  <UnhandledResponsePanel v-else :result="queryData" />
 </template>
 
 <script setup lang="ts">

--- a/ory-kratos-spa/pages/login/LoginFlowForm.strings.ts
+++ b/ory-kratos-spa/pages/login/LoginFlowForm.strings.ts
@@ -1,3 +1,5 @@
 export const kratos_login_flow = {
   login_failed: "Sign-in failed.",
+  no_account: "Don't have an account?",
+  link_sign_up: "Sign up",
 };

--- a/ory-kratos-spa/pages/login/LoginFlowForm.vue
+++ b/ory-kratos-spa/pages/login/LoginFlowForm.vue
@@ -68,17 +68,13 @@
         </template>
       </template>
     </KratosFlowUi>
-    <div
-      v-if="!isSecondFactorStep"
-      class="text-center mb-4 mt-8"
-    >
+    <div v-if="!isSecondFactorStep" class="text-center mb-4 mt-8">
       {{ t(strings.no_account) }}
       <a
         :href="registerHref"
         class="text-primary text-decoration-none d-inline-flex align-center ga-1"
       >
         {{ t(strings.link_sign_up) }}
-        <v-icon icon="mdi-chevron-right" size="small" />
       </a>
     </div>
   </div>

--- a/ory-kratos-spa/pages/login/LoginFlowForm.vue
+++ b/ory-kratos-spa/pages/login/LoginFlowForm.vue
@@ -68,12 +68,28 @@
         </template>
       </template>
     </KratosFlowUi>
+    <div
+      v-if="!isSecondFactorStep"
+      class="text-center mb-4 mt-8"
+    >
+      {{ t(strings.no_account) }}
+      <a
+        :href="registerHref"
+        class="text-primary text-decoration-none d-inline-flex align-center ga-1"
+      >
+        {{ t(strings.link_sign_up) }}
+        <v-icon icon="mdi-chevron-right" size="small" />
+      </a>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import type { LoginFlow, UiNode } from "@ory/client";
 import { computed, toRef } from "vue";
+import { useReverseT } from "@saflib/ory-kratos-spa/i18n";
+import { kratos_login_flow as strings } from "./LoginFlowForm.strings.ts";
+import { useAuthFlowCrossLinks } from "../common/useAuthFlowCrossLinks.ts";
 import KratosFlowUi from "../common/KratosFlowUi.vue";
 import KratosFlowUiNodeAt from "../common/KratosFlowUiNodeAt.vue";
 import {
@@ -90,6 +106,10 @@ import { useLoginFlow } from "./useLoginFlow.ts";
 const props = defineProps<{
   flow: LoginFlow;
 }>();
+
+const { t } = useReverseT();
+
+const { registerHref } = useAuthFlowCrossLinks(() => props.flow.return_to);
 
 const { submitting, submitError, clearSubmitError, submitLoginForm } =
   useLoginFlow(toRef(props, "flow"));

--- a/ory-kratos-spa/pages/login/LoginIntro.strings.ts
+++ b/ory-kratos-spa/pages/login/LoginIntro.strings.ts
@@ -1,7 +1,6 @@
 export const login_intro = {
   title: "Sign in",
   title_second_factor: "Second sign-in step",
-  link_register: "Create an account",
   link_recovery: "Forgot password?",
   mfa_tab_code: "Email code",
   mfa_tab_totp: "Authenticator app",

--- a/ory-kratos-spa/pages/login/LoginIntro.vue
+++ b/ory-kratos-spa/pages/login/LoginIntro.vue
@@ -1,15 +1,5 @@
 <template>
   <div v-if="!secondFactor">
-    <div class="float-right mb-4">
-      <a
-        :href="registerHref"
-        class="text-primary text-decoration-none d-inline-flex align-center ga-1"
-      >
-        {{ t(strings.link_register) }}
-        <v-icon icon="mdi-chevron-right" size="small" />
-      </a>
-    </div>
-    <div style="clear: both"></div>
     <h1 v-if="authApp.showFlowHeaders" class="text-h4 mb-2">
       {{ t(secondFactor ? strings.title_second_factor : strings.title) }}
     </h1>
@@ -43,7 +33,5 @@ const props = defineProps<{
 
 const { t } = useReverseT();
 const authApp = useAuthAppConfig();
-const { registerHref, recoveryHref } = useAuthFlowCrossLinks(
-  () => props.flowReturnTo,
-);
+const { recoveryHref } = useAuthFlowCrossLinks(() => props.flowReturnTo);
 </script>

--- a/ory-kratos-spa/pages/login/LoginIntro.vue
+++ b/ory-kratos-spa/pages/login/LoginIntro.vue
@@ -10,7 +10,7 @@
       </a>
     </div>
     <div style="clear: both"></div>
-    <h1 class="text-h4 mb-2">
+    <h1 v-if="authApp.showFlowHeaders" class="text-h4 mb-2">
       {{ t(secondFactor ? strings.title_second_factor : strings.title) }}
     </h1>
     <nav
@@ -31,6 +31,7 @@
 
 <script setup lang="ts">
 import { useReverseT } from "@saflib/ory-kratos-spa/i18n";
+import { useAuthAppConfig } from "../../configureAuthApp.ts";
 import { useAuthFlowCrossLinks } from "../common/useAuthFlowCrossLinks.ts";
 import { login_intro as strings } from "./LoginIntro.strings.ts";
 
@@ -41,6 +42,7 @@ const props = defineProps<{
 }>();
 
 const { t } = useReverseT();
+const authApp = useAuthAppConfig();
 const { registerHref, recoveryHref } = useAuthFlowCrossLinks(
   () => props.flowReturnTo,
 );

--- a/ory-kratos-spa/pages/login/useLoginFlow.ts
+++ b/ory-kratos-spa/pages/login/useLoginFlow.ts
@@ -1,5 +1,8 @@
 import { computed, ref, type Ref } from "vue";
-import { useAuthPostAuthFallbackHref } from "../../authFallbackInject.ts";
+import {
+  useAuthPostAuthFallbackHref,
+  useAuthPostAuthUrlIsOverride,
+} from "../../authFallbackInject.ts";
 import {
   BrowserRedirectRequired,
   LoginCompleted,
@@ -18,11 +21,14 @@ import type { LoginFlow } from "@ory/client";
  * (`Login.vue` + loader).
  */
 export function useLoginFlow(flow: Ref<LoginFlow>) {
-  const postAuthFallbackHref = useAuthPostAuthFallbackHref();
+  const postAuthHref = useAuthPostAuthFallbackHref();
+  const postAuthIsOverride = useAuthPostAuthUrlIsOverride();
   const updateLogin = useUpdateLoginFlowMutation();
 
-  const returnTo = computed(
-    () => flow.value.return_to ?? postAuthFallbackHref.value,
+  const returnTo = computed(() =>
+    postAuthIsOverride.value
+      ? postAuthHref.value
+      : (flow.value.return_to ?? postAuthHref.value),
   );
 
   const submitting = ref(false);

--- a/ory-kratos-spa/pages/new-login/NewLogin.vue
+++ b/ory-kratos-spa/pages/new-login/NewLogin.vue
@@ -1,14 +1,12 @@
 <template>
-  <v-container class="py-8" max-width="720">
-    <LoginFlowCreatedView
-      v-if="queryData instanceof LoginFlowCreatedResult"
-      :result="queryData"
-    />
-    <SessionAlreadyAvailableComponent
-      v-else-if="queryData instanceof SessionAlreadyAvailable"
-    />
-    <UnhandledResponsePanel v-else :result="queryData" />
-  </v-container>
+  <LoginFlowCreatedView
+    v-if="queryData instanceof LoginFlowCreatedResult"
+    :result="queryData"
+  />
+  <SessionAlreadyAvailableComponent
+    v-else-if="queryData instanceof SessionAlreadyAvailable"
+  />
+  <UnhandledResponsePanel v-else :result="queryData" />
 </template>
 
 <script setup lang="ts">

--- a/ory-kratos-spa/pages/new-recovery/NewRecovery.vue
+++ b/ory-kratos-spa/pages/new-recovery/NewRecovery.vue
@@ -1,14 +1,12 @@
 <template>
-  <v-container class="py-8" max-width="720">
-    <RecoveryFlowCreatedView
-      v-if="queryData instanceof RecoveryFlowCreatedResult"
-      :result="queryData"
-    />
-    <SessionAlreadyAvailableComponent
-      v-else-if="queryData instanceof SessionAlreadyAvailable"
-    />
-    <UnhandledResponsePanel v-else :result="queryData" />
-  </v-container>
+  <RecoveryFlowCreatedView
+    v-if="queryData instanceof RecoveryFlowCreatedResult"
+    :result="queryData"
+  />
+  <SessionAlreadyAvailableComponent
+    v-else-if="queryData instanceof SessionAlreadyAvailable"
+  />
+  <UnhandledResponsePanel v-else :result="queryData" />
 </template>
 
 <script setup lang="ts">

--- a/ory-kratos-spa/pages/new-registration/NewRegistration.vue
+++ b/ory-kratos-spa/pages/new-registration/NewRegistration.vue
@@ -1,14 +1,12 @@
 <template>
-  <v-container class="py-8" max-width="720">
-    <RegistrationFlowCreatedView
-      v-if="queryData instanceof RegistrationFlowCreatedResult"
-      :result="queryData"
-    />
-    <SessionAlreadyAvailableComponent
-      v-else-if="queryData instanceof SessionAlreadyAvailable"
-    />
-    <UnhandledResponsePanel v-else :result="queryData" />
-  </v-container>
+  <RegistrationFlowCreatedView
+    v-if="queryData instanceof RegistrationFlowCreatedResult"
+    :result="queryData"
+  />
+  <SessionAlreadyAvailableComponent
+    v-else-if="queryData instanceof SessionAlreadyAvailable"
+  />
+  <UnhandledResponsePanel v-else :result="queryData" />
 </template>
 
 <script setup lang="ts">

--- a/ory-kratos-spa/pages/new-settings/NewSettings.vue
+++ b/ory-kratos-spa/pages/new-settings/NewSettings.vue
@@ -1,15 +1,13 @@
 <template>
-  <v-container class="py-8" max-width="720">
-    <SettingsAalReauthRedirect
-      v-if="queryData instanceof BrowserRedirectRequiredResult"
-      :redirect-browser-to="queryData.payload.redirect_browser_to"
-    />
-    <SettingsFlowCreatedView
-      v-else-if="queryData instanceof SettingsFlowCreatedResult"
-      :result="queryData"
-    />
-    <UnhandledResponsePanel v-else :result="queryData" />
-  </v-container>
+  <SettingsAalReauthRedirect
+    v-if="queryData instanceof BrowserRedirectRequiredResult"
+    :redirect-browser-to="queryData.payload.redirect_browser_to"
+  />
+  <SettingsFlowCreatedView
+    v-else-if="queryData instanceof SettingsFlowCreatedResult"
+    :result="queryData"
+  />
+  <UnhandledResponsePanel v-else :result="queryData" />
 </template>
 
 <script setup lang="ts">

--- a/ory-kratos-spa/pages/new-verification/NewVerification.vue
+++ b/ory-kratos-spa/pages/new-verification/NewVerification.vue
@@ -1,11 +1,9 @@
 <template>
-  <v-container class="py-8" max-width="720">
-    <VerificationFlowCreatedView
-      v-if="queryData instanceof VerificationFlowCreatedResult"
-      :result="queryData"
-    />
-    <UnhandledResponsePanel v-else :result="queryData" />
-  </v-container>
+  <VerificationFlowCreatedView
+    v-if="queryData instanceof VerificationFlowCreatedResult"
+    :result="queryData"
+  />
+  <UnhandledResponsePanel v-else :result="queryData" />
 </template>
 
 <script setup lang="ts">

--- a/ory-kratos-spa/pages/recovery/Recovery.vue
+++ b/ory-kratos-spa/pages/recovery/Recovery.vue
@@ -1,21 +1,19 @@
 <template>
-  <v-container class="py-8" max-width="720">
-    <RecoveryFlowForm
-      v-if="queryData instanceof RecoveryFlowFetched && flow"
-      :flow="flow"
-    />
-    <FlowGonePanel
-      v-else-if="queryData instanceof FlowGone"
-      restart-path="/new-recovery"
-      :result="queryData"
-    />
-    <CsrfViolationPanel
-      v-else-if="queryData instanceof SecurityCsrfViolation"
-      restart-path="/new-recovery"
-      :result="queryData"
-    />
-    <UnhandledResponsePanel v-else :result="queryData" />
-  </v-container>
+  <RecoveryFlowForm
+    v-if="queryData instanceof RecoveryFlowFetched && flow"
+    :flow="flow"
+  />
+  <FlowGonePanel
+    v-else-if="queryData instanceof FlowGone"
+    restart-path="/new-recovery"
+    :result="queryData"
+  />
+  <CsrfViolationPanel
+    v-else-if="queryData instanceof SecurityCsrfViolation"
+    restart-path="/new-recovery"
+    :result="queryData"
+  />
+  <UnhandledResponsePanel v-else :result="queryData" />
 </template>
 
 <script setup lang="ts">

--- a/ory-kratos-spa/pages/recovery/RecoveryFlowForm.vue
+++ b/ory-kratos-spa/pages/recovery/RecoveryFlowForm.vue
@@ -1,21 +1,6 @@
 <template>
   <div>
     <RecoveryIntro :flow-return-to="flow.return_to" />
-    <div class="d-flex flex-column flex-sm-row align-sm-center ga-2 mb-4">
-      <span class="text-body-2 text-medium-emphasis">{{
-        t(strings.resend_help)
-      }}</span>
-      <v-btn
-        variant="tonal"
-        size="small"
-        tag="a"
-        :href="newRecoveryHref"
-        :disabled="submitting"
-        :aria-label="t(strings.cta_new_flow)"
-      >
-        {{ t(strings.cta_new_flow) }}
-      </v-btn>
-    </div>
 
     <v-alert
       v-if="submitError"
@@ -43,25 +28,19 @@
 import { computed } from "vue";
 import { useRoute } from "vue-router";
 import type { RecoveryFlow } from "@ory/client";
-import { useReverseT } from "@saflib/ory-kratos-spa/i18n";
 import KratosFlowUi from "../common/KratosFlowUi.vue";
 import RecoveryIntro from "./RecoveryIntro.vue";
-import { kratos_recovery_flow as strings } from "./RecoveryFlowForm.strings.ts";
 import { useRecoveryFlow } from "./useRecoveryFlow.ts";
-import { useNewRecoveryEntryHref } from "./useNewRecoveryEntryHref.ts";
 
 const props = defineProps<{
   flow: RecoveryFlow;
 }>();
 
-const { t } = useReverseT();
 const route = useRoute();
 
 const recoveryToken = computed(() =>
   typeof route.query.token === "string" ? route.query.token : undefined,
 );
-
-const newRecoveryHref = useNewRecoveryEntryHref(() => props.flow.return_to);
 
 const { submitting, submitError, clearSubmitError, submitRecoveryForm } =
   useRecoveryFlow(recoveryToken, () => props.flow.id);

--- a/ory-kratos-spa/pages/recovery/RecoveryIntro.vue
+++ b/ory-kratos-spa/pages/recovery/RecoveryIntro.vue
@@ -10,12 +10,15 @@
       </a>
     </div>
     <div style="clear: both"></div>
-    <h1 class="text-h4 mb-2">{{ t(strings.title) }}</h1>
+    <h1 v-if="authApp.showFlowHeaders" class="text-h4 mb-2">
+      {{ t(strings.title) }}
+    </h1>
   </div>
 </template>
 
 <script setup lang="ts">
 import { useReverseT } from "@saflib/ory-kratos-spa/i18n";
+import { useAuthAppConfig } from "../../configureAuthApp.ts";
 import { useAuthFlowCrossLinks } from "../common/useAuthFlowCrossLinks.ts";
 import { recovery_intro as strings } from "./RecoveryIntro.strings.ts";
 
@@ -24,5 +27,6 @@ const props = defineProps<{
 }>();
 
 const { t } = useReverseT();
+const authApp = useAuthAppConfig();
 const { loginHref } = useAuthFlowCrossLinks(() => props.flowReturnTo);
 </script>

--- a/ory-kratos-spa/pages/registration/Registration.vue
+++ b/ory-kratos-spa/pages/registration/Registration.vue
@@ -1,21 +1,19 @@
 <template>
-  <v-container class="py-8" max-width="720">
-    <RegistrationFlowForm
-      v-if="queryData instanceof RegistrationFlowFetched && flow"
-      :flow="flow"
-    />
-    <FlowGonePanel
-      v-else-if="queryData instanceof FlowGone"
-      restart-path="/new-registration"
-      :result="queryData"
-    />
-    <CsrfViolationPanel
-      v-else-if="queryData instanceof SecurityCsrfViolation"
-      restart-path="/new-registration"
-      :result="queryData"
-    />
-    <UnhandledResponsePanel v-else :result="queryData" />
-  </v-container>
+  <RegistrationFlowForm
+    v-if="queryData instanceof RegistrationFlowFetched && flow"
+    :flow="flow"
+  />
+  <FlowGonePanel
+    v-else-if="queryData instanceof FlowGone"
+    restart-path="/new-registration"
+    :result="queryData"
+  />
+  <CsrfViolationPanel
+    v-else-if="queryData instanceof SecurityCsrfViolation"
+    restart-path="/new-registration"
+    :result="queryData"
+  />
+  <UnhandledResponsePanel v-else :result="queryData" />
 </template>
 
 <script setup lang="ts">

--- a/ory-kratos-spa/pages/registration/RegistrationFlowForm.strings.ts
+++ b/ory-kratos-spa/pages/registration/RegistrationFlowForm.strings.ts
@@ -1,5 +1,7 @@
 export const kratos_registration_flow = {
+  link_login: "Log In",
   registration_failed: "Registration failed.",
   post_reg_login_failed:
     "Your account was created, but signing you in failed. Try logging in from the login page.",
+  already_registered: "Already have an account?",
 };

--- a/ory-kratos-spa/pages/registration/RegistrationFlowForm.vue
+++ b/ory-kratos-spa/pages/registration/RegistrationFlowForm.vue
@@ -15,6 +15,7 @@
     <KratosFlowUi
       v-if="flow"
       :flow="flow"
+      :nodes="registrationDisplayNodes"
       :submitting="submitting"
       id-prefix="kratos-login"
       :message-filter="registrationMessageFilter"
@@ -34,9 +35,10 @@
 </template>
 
 <script setup lang="ts">
-import { toRef } from "vue";
+import { computed, toRef } from "vue";
 import KratosFlowUi from "../common/KratosFlowUi.vue";
 import RegistrationIntro from "./RegistrationIntro.vue";
+import { sortRegistrationFlowNodes } from "./kratosRegistrationNodeOrder.logic.ts";
 import { useRegistrationFlow } from "./useRegistrationFlow.ts";
 import type { RegistrationFlow } from "@ory/client";
 import { useReverseT } from "@saflib/ory-kratos-spa/i18n";
@@ -46,6 +48,10 @@ const { t } = useReverseT();
 
 import { useAuthFlowCrossLinks } from "../common/useAuthFlowCrossLinks.ts";
 const props = defineProps<{ flow: RegistrationFlow }>();
+
+const registrationDisplayNodes = computed(() =>
+  sortRegistrationFlowNodes(props.flow.ui.nodes),
+);
 
 const { loginHref } = useAuthFlowCrossLinks();
 

--- a/ory-kratos-spa/pages/registration/RegistrationFlowForm.vue
+++ b/ory-kratos-spa/pages/registration/RegistrationFlowForm.vue
@@ -20,6 +20,16 @@
       :message-filter="registrationMessageFilter"
       @submit="submitRegistrationForm"
     />
+    <div class="text-center mb-4 mt-8">
+      {{ t(strings.already_registered) }}
+      <a
+        :href="loginHref"
+        class="text-primary text-decoration-none d-inline-flex align-center ga-1"
+      >
+        {{ t(strings.link_login) }}
+        <v-icon icon="mdi-chevron-right" size="small" />
+      </a>
+    </div>
   </div>
 </template>
 
@@ -29,8 +39,15 @@ import KratosFlowUi from "../common/KratosFlowUi.vue";
 import RegistrationIntro from "./RegistrationIntro.vue";
 import { useRegistrationFlow } from "./useRegistrationFlow.ts";
 import type { RegistrationFlow } from "@ory/client";
+import { useReverseT } from "@saflib/ory-kratos-spa/i18n";
+import { kratos_registration_flow as strings } from "./RegistrationFlowForm.strings.ts";
 
+const { t } = useReverseT();
+
+import { useAuthFlowCrossLinks } from "../common/useAuthFlowCrossLinks.ts";
 const props = defineProps<{ flow: RegistrationFlow }>();
+
+const { loginHref } = useAuthFlowCrossLinks();
 
 const {
   submitting,

--- a/ory-kratos-spa/pages/registration/RegistrationFlowForm.vue
+++ b/ory-kratos-spa/pages/registration/RegistrationFlowForm.vue
@@ -1,6 +1,6 @@
 <template>
   <div>
-    <RegistrationIntro :flow-return-to="flow.return_to" />
+    <RegistrationIntro />
     <v-alert
       v-if="submitError"
       type="error"
@@ -53,7 +53,7 @@ const registrationDisplayNodes = computed(() =>
   sortRegistrationFlowNodes(props.flow.ui.nodes),
 );
 
-const { loginHref } = useAuthFlowCrossLinks();
+const { loginHref } = useAuthFlowCrossLinks(() => props.flow.return_to);
 
 const {
   submitting,

--- a/ory-kratos-spa/pages/registration/RegistrationIntro.vue
+++ b/ory-kratos-spa/pages/registration/RegistrationIntro.vue
@@ -1,15 +1,5 @@
 <template>
   <div>
-    <div class="float-right mb-4">
-      <a
-        :href="loginHref"
-        class="text-primary text-decoration-none d-inline-flex align-center ga-1"
-      >
-        {{ t(strings.link_login) }}
-        <v-icon icon="mdi-chevron-right" size="small" />
-      </a>
-    </div>
-    <div style="clear: both"></div>
     <h1 v-if="authApp.showFlowHeaders" class="text-h4 mb-2">
       {{ t(strings.title) }}
     </h1>
@@ -19,14 +9,8 @@
 <script setup lang="ts">
 import { useReverseT } from "@saflib/ory-kratos-spa/i18n";
 import { useAuthAppConfig } from "../../configureAuthApp.ts";
-import { useAuthFlowCrossLinks } from "../common/useAuthFlowCrossLinks.ts";
 import { registration_intro as strings } from "./RegistrationIntro.strings.ts";
-
-const props = defineProps<{
-  flowReturnTo?: string | null;
-}>();
 
 const { t } = useReverseT();
 const authApp = useAuthAppConfig();
-const { loginHref } = useAuthFlowCrossLinks(() => props.flowReturnTo);
 </script>

--- a/ory-kratos-spa/pages/registration/RegistrationIntro.vue
+++ b/ory-kratos-spa/pages/registration/RegistrationIntro.vue
@@ -10,12 +10,15 @@
       </a>
     </div>
     <div style="clear: both"></div>
-    <h1 class="text-h4 mb-2">{{ t(strings.title) }}</h1>
+    <h1 v-if="authApp.showFlowHeaders" class="text-h4 mb-2">
+      {{ t(strings.title) }}
+    </h1>
   </div>
 </template>
 
 <script setup lang="ts">
 import { useReverseT } from "@saflib/ory-kratos-spa/i18n";
+import { useAuthAppConfig } from "../../configureAuthApp.ts";
 import { useAuthFlowCrossLinks } from "../common/useAuthFlowCrossLinks.ts";
 import { registration_intro as strings } from "./RegistrationIntro.strings.ts";
 
@@ -24,5 +27,6 @@ const props = defineProps<{
 }>();
 
 const { t } = useReverseT();
+const authApp = useAuthAppConfig();
 const { loginHref } = useAuthFlowCrossLinks(() => props.flowReturnTo);
 </script>

--- a/ory-kratos-spa/pages/registration/kratosRegistrationNodeOrder.logic.test.ts
+++ b/ory-kratos-spa/pages/registration/kratosRegistrationNodeOrder.logic.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from "vitest";
+import type { UiNode } from "@ory/client";
+import {
+  REGISTRATION_TRAIT_FIELD_ORDER,
+  sortRegistrationFlowNodes,
+} from "./kratosRegistrationNodeOrder.logic.ts";
+import { isKratosInputNode } from "../common/kratosNodeUtils.ts";
+
+function inputNode(
+  name: string,
+  extra: Partial<{ type: string; group: string }> = {},
+): UiNode {
+  return {
+    type: "input",
+    group: extra.group ?? "default",
+    attributes: {
+      node_type: "input",
+      name,
+      type: extra.type ?? (name === "password" ? "password" : "text"),
+      required: true,
+    },
+    meta: {},
+  } as UiNode;
+}
+
+describe("sortRegistrationFlowNodes", () => {
+  it("lists the expected canonical order constant", () => {
+    expect([...REGISTRATION_TRAIT_FIELD_ORDER]).toEqual([
+      "traits.name.first",
+      "traits.name.last",
+      "traits.email",
+      "traits.phone",
+      "password",
+    ]);
+  });
+
+  it("orders trait fields first, last, email, phone, password when Kratos sends a different order", () => {
+    const csrf = inputNode("csrf_token", { type: "hidden" });
+    const email = inputNode("traits.email", { type: "email" });
+    const first = inputNode("traits.name.first");
+    const last = inputNode("traits.name.last");
+    const phone = inputNode("traits.phone");
+    const password = inputNode("password", { type: "password", group: "password" });
+    const method = {
+      type: "input",
+      group: "password",
+      attributes: {
+        node_type: "input",
+        name: "method",
+        type: "submit",
+        value: "password",
+      },
+      meta: {},
+    } as UiNode;
+
+    const shuffled = [csrf, email, password, first, last, phone, method];
+    const sorted = sortRegistrationFlowNodes(shuffled);
+
+    const inputNames: string[] = [];
+    for (const n of sorted) {
+      if (isKratosInputNode(n)) inputNames.push(n.attributes.name);
+    }
+
+    expect(inputNames).toEqual([
+      "csrf_token",
+      "traits.name.first",
+      "traits.name.last",
+      "traits.email",
+      "traits.phone",
+      "password",
+      "method",
+    ]);
+  });
+
+  it("leaves email-before-password-only mocks unchanged aside from grouping", () => {
+    const csrf = inputNode("csrf_token", { type: "hidden" });
+    const email = inputNode("traits.email", { type: "email" });
+    const password = inputNode("password", { type: "password", group: "password" });
+    const method = {
+      type: "input",
+      group: "password",
+      attributes: {
+        node_type: "input",
+        name: "method",
+        type: "submit",
+        value: "password",
+      },
+      meta: {},
+    } as UiNode;
+
+    const nodes = [csrf, email, password, method];
+    const sorted = sortRegistrationFlowNodes(nodes);
+    expect(
+      sorted.map((n) =>
+        isKratosInputNode(n) ? (n.attributes.name as string) : "?",
+      ),
+    ).toEqual(["csrf_token", "traits.email", "password", "method"]);
+  });
+});

--- a/ory-kratos-spa/pages/registration/kratosRegistrationNodeOrder.logic.ts
+++ b/ory-kratos-spa/pages/registration/kratosRegistrationNodeOrder.logic.ts
@@ -1,0 +1,65 @@
+import type { UiNode } from "@ory/client";
+import { isKratosInputNode } from "../common/kratosNodeUtils.ts";
+
+/**
+ * Preferred visual order for registration trait fields and password.
+ * Kratos may send these in schema / JSON order; the UI normalizes for consistency.
+ */
+export const REGISTRATION_TRAIT_FIELD_ORDER = [
+  "traits.name.first",
+  "traits.name.last",
+  "traits.email",
+  "traits.phone",
+  "password",
+] as const;
+
+/**
+ * Returns a new array: same nodes as the flow, but any registration fields listed in
+ * {@link REGISTRATION_TRAIT_FIELD_ORDER} appear in that order (when present). CSRF, scripts,
+ * submit buttons, and other nodes keep their positions relative to the surrounding list, except
+ * that the ordered fields are grouped and sorted starting at where the first such field appeared.
+ */
+export function sortRegistrationFlowNodes(nodes: readonly UiNode[]): UiNode[] {
+  const order = REGISTRATION_TRAIT_FIELD_ORDER as readonly string[];
+  const orderedNameSet = new Set<string>(order);
+
+  const sequence: UiNode[] = [];
+  const seen = new Set<UiNode>();
+  for (const name of order) {
+    for (const n of nodes) {
+      if (seen.has(n)) continue;
+      if (
+        n.type === "input" &&
+        isKratosInputNode(n) &&
+        n.attributes.name === name
+      ) {
+        sequence.push(n);
+        seen.add(n);
+        break;
+      }
+    }
+  }
+
+  let placed = false;
+  const out: UiNode[] = [];
+  for (const n of nodes) {
+    if (
+      n.type === "input" &&
+      isKratosInputNode(n) &&
+      orderedNameSet.has(n.attributes.name)
+    ) {
+      if (!placed) {
+        out.push(...sequence);
+        placed = true;
+      }
+      continue;
+    }
+    out.push(n);
+  }
+
+  if (!placed && sequence.length > 0) {
+    out.push(...sequence);
+  }
+
+  return out;
+}

--- a/ory-kratos-spa/pages/registration/useRegistrationFlow.ts
+++ b/ory-kratos-spa/pages/registration/useRegistrationFlow.ts
@@ -16,7 +16,7 @@ import {
   SessionAlreadyAvailable,
   UnhandledResponse,
 } from "@saflib/ory-kratos-sdk";
-import { useAuthPostAuthFallbackHref } from "../../authFallbackInject.ts";
+import { useAuthPostRegisterFallbackHref } from "../../authFallbackInject.ts";
 import type { KratosFlowUiMessageFilterContext } from "../common/kratosUiMessages.ts";
 import { isKratosPropertyMissingMessage } from "../common/kratosUiMessages.ts";
 import {
@@ -42,7 +42,7 @@ export function useRegistrationFlow(flow: Ref<RegistrationFlow>) {
   function clearSubmitError() {
     submitError.value = null;
   }
-  const postAuthFallbackHref = useAuthPostAuthFallbackHref();
+  const postRegisterFallbackHref = useAuthPostRegisterFallbackHref();
 
   /**
    * Used to hide Kratos "Property password is missing" on the first response after submitting email
@@ -89,7 +89,7 @@ export function useRegistrationFlow(flow: Ref<RegistrationFlow>) {
         throw new Error("Unexpected result");
       }
 
-      const destination = flow.value.return_to ?? postAuthFallbackHref.value;
+      const destination = flow.value.return_to ?? postRegisterFallbackHref.value;
       const registrationSession = updated.result.session;
       if (registrationSession) {
         if (identityNeedsEmailVerification(registrationSession.identity)) {

--- a/ory-kratos-spa/pages/registration/useRegistrationFlow.ts
+++ b/ory-kratos-spa/pages/registration/useRegistrationFlow.ts
@@ -16,7 +16,10 @@ import {
   SessionAlreadyAvailable,
   UnhandledResponse,
 } from "@saflib/ory-kratos-sdk";
-import { useAuthPostRegisterFallbackHref } from "../../authFallbackInject.ts";
+import {
+  useAuthPostRegisterFallbackHref,
+  useAuthPostRegisterUrlIsOverride,
+} from "../../authFallbackInject.ts";
 import type { KratosFlowUiMessageFilterContext } from "../common/kratosUiMessages.ts";
 import { isKratosPropertyMissingMessage } from "../common/kratosUiMessages.ts";
 import {
@@ -42,7 +45,8 @@ export function useRegistrationFlow(flow: Ref<RegistrationFlow>) {
   function clearSubmitError() {
     submitError.value = null;
   }
-  const postRegisterFallbackHref = useAuthPostRegisterFallbackHref();
+  const postRegisterHref = useAuthPostRegisterFallbackHref();
+  const postRegisterIsOverride = useAuthPostRegisterUrlIsOverride();
 
   /**
    * Used to hide Kratos "Property password is missing" on the first response after submitting email
@@ -89,7 +93,9 @@ export function useRegistrationFlow(flow: Ref<RegistrationFlow>) {
         throw new Error("Unexpected result");
       }
 
-      const destination = flow.value.return_to ?? postRegisterFallbackHref.value;
+      const destination = postRegisterIsOverride.value
+        ? postRegisterHref.value
+        : (flow.value.return_to ?? postRegisterHref.value);
       const registrationSession = updated.result.session;
       if (registrationSession) {
         if (identityNeedsEmailVerification(registrationSession.identity)) {

--- a/ory-kratos-spa/pages/settings/Settings.vue
+++ b/ory-kratos-spa/pages/settings/Settings.vue
@@ -1,102 +1,100 @@
 <template>
-  <v-container class="py-8" max-width="720">
-    <template v-if="queryData instanceof SettingsFlowFetched && flow">
-      <SettingsIntro />
+  <template v-if="queryData instanceof SettingsFlowFetched && flow">
+    <SettingsIntro />
 
-      <v-alert
-        v-if="showPasswordRecoveryPrompt"
-        type="info"
-        variant="tonal"
-        class="mb-4"
-        density="comfortable"
-      >
-        {{ t(passwordRecoveryStrings.prompt) }}
-      </v-alert>
+    <v-alert
+      v-if="showPasswordRecoveryPrompt"
+      type="info"
+      variant="tonal"
+      class="mb-4"
+      density="comfortable"
+    >
+      {{ t(passwordRecoveryStrings.prompt) }}
+    </v-alert>
 
-      <v-alert
-        v-if="submitError"
-        type="error"
-        variant="tonal"
-        class="mb-4"
-        closable
-        @click:close="clearSubmitError"
-      >
-        {{ submitError }}
-      </v-alert>
+    <v-alert
+      v-if="submitError"
+      type="error"
+      variant="tonal"
+      class="mb-4"
+      closable
+      @click:close="clearSubmitError"
+    >
+      {{ submitError }}
+    </v-alert>
 
-      <v-tabs v-model="tab" class="mb-4" color="primary">
-        <v-tab value="email">{{ t(tabs.general) }}</v-tab>
-        <v-tab value="password">{{ t(tabs.password) }}</v-tab>
-        <v-tab v-if="hasTotpSettings" value="totp">{{ t(tabs.totp) }}</v-tab>
-        <v-tab v-if="hasPasskeySettings" value="passkey">{{
-          t(tabs.passkey)
-        }}</v-tab>
-      </v-tabs>
+    <v-tabs v-model="tab" class="mb-4" color="primary">
+      <v-tab value="email">{{ t(tabs.general) }}</v-tab>
+      <v-tab value="password">{{ t(tabs.password) }}</v-tab>
+      <v-tab v-if="hasTotpSettings" value="totp">{{ t(tabs.totp) }}</v-tab>
+      <v-tab v-if="hasPasskeySettings" value="passkey">{{
+        t(tabs.passkey)
+      }}</v-tab>
+    </v-tabs>
 
-      <v-window v-model="tab">
-        <v-window-item value="email">
-          <SettingsGroupUi
-            :flow="flow"
-            group="profile"
-            :submitting="submitting"
-            id-prefix="settings-profile"
-            :message-filter="settingsMessageFilter"
-            @submit="submitSettingsForm"
-          />
-        </v-window-item>
-        <v-window-item value="password">
-          <SettingsGroupUi
-            :flow="flow"
-            group="password"
-            :submitting="submitting"
-            id-prefix="settings-password"
-            :message-filter="settingsMessageFilter"
-            @submit="submitSettingsForm"
-          />
-        </v-window-item>
-        <v-window-item v-if="hasTotpSettings" value="totp">
-          <SettingsGroupUi
-            :flow="flow"
-            group="totp"
-            :submitting="submitting"
-            id-prefix="settings-totp"
-            :message-filter="settingsMessageFilter"
-            @submit="submitSettingsForm"
-          />
-        </v-window-item>
-        <v-window-item v-if="hasPasskeySettings" value="passkey">
-          <SettingsGroupUi
-            :flow="flow"
-            group="passkey"
-            :submitting="submitting"
-            id-prefix="settings-passkey"
-            :message-filter="settingsMessageFilter"
-            :identity-passkey-display-fallback="sessionEmail"
-            @submit="submitSettingsForm"
-          />
-        </v-window-item>
-      </v-window>
-    </template>
+    <v-window v-model="tab">
+      <v-window-item value="email">
+        <SettingsGroupUi
+          :flow="flow"
+          group="profile"
+          :submitting="submitting"
+          id-prefix="settings-profile"
+          :message-filter="settingsMessageFilter"
+          @submit="submitSettingsForm"
+        />
+      </v-window-item>
+      <v-window-item value="password">
+        <SettingsGroupUi
+          :flow="flow"
+          group="password"
+          :submitting="submitting"
+          id-prefix="settings-password"
+          :message-filter="settingsMessageFilter"
+          @submit="submitSettingsForm"
+        />
+      </v-window-item>
+      <v-window-item v-if="hasTotpSettings" value="totp">
+        <SettingsGroupUi
+          :flow="flow"
+          group="totp"
+          :submitting="submitting"
+          id-prefix="settings-totp"
+          :message-filter="settingsMessageFilter"
+          @submit="submitSettingsForm"
+        />
+      </v-window-item>
+      <v-window-item v-if="hasPasskeySettings" value="passkey">
+        <SettingsGroupUi
+          :flow="flow"
+          group="passkey"
+          :submitting="submitting"
+          id-prefix="settings-passkey"
+          :message-filter="settingsMessageFilter"
+          :identity-passkey-display-fallback="sessionEmail"
+          @submit="submitSettingsForm"
+        />
+      </v-window-item>
+    </v-window>
+  </template>
 
-    <SettingsAalReauthRedirect
-      v-else-if="queryData instanceof BrowserRedirectRequired"
-      :redirect-browser-to="queryData.payload.redirect_browser_to"
-    />
+  <SettingsAalReauthRedirect
+    v-else-if="queryData instanceof BrowserRedirectRequired"
+    :redirect-browser-to="queryData.payload.redirect_browser_to"
+  />
 
-    <FlowGonePanel
-      v-else-if="queryData instanceof FlowGone"
-      restart-path="/new-settings"
-      :restart-query="settingsRestartQuery"
-      :result="queryData"
-    />
-    <CsrfViolationPanel
-      v-else-if="queryData instanceof SecurityCsrfViolation"
-      restart-path="/new-settings"
-      :restart-query="settingsRestartQuery"
-      :result="queryData"
-    />
-    <UnhandledResponsePanel v-else :result="queryData" />
-  </v-container>
+  <FlowGonePanel
+    v-else-if="queryData instanceof FlowGone"
+    restart-path="/new-settings"
+    :restart-query="settingsRestartQuery"
+    :result="queryData"
+  />
+  <CsrfViolationPanel
+    v-else-if="queryData instanceof SecurityCsrfViolation"
+    restart-path="/new-settings"
+    :restart-query="settingsRestartQuery"
+    :result="queryData"
+  />
+  <UnhandledResponsePanel v-else :result="queryData" />
 </template>
 
 <script setup lang="ts">

--- a/ory-kratos-spa/pages/settings/SettingsIntro.vue
+++ b/ory-kratos-spa/pages/settings/SettingsIntro.vue
@@ -1,12 +1,16 @@
 <template>
   <div>
-    <h1 class="text-h4 mb-2">{{ t(strings.title) }}</h1>
+    <h1 v-if="authApp.showFlowHeaders" class="text-h4 mb-2">
+      {{ t(strings.title) }}
+    </h1>
   </div>
 </template>
 
 <script setup lang="ts">
 import { useReverseT } from "@saflib/ory-kratos-spa/i18n";
+import { useAuthAppConfig } from "../../configureAuthApp.ts";
 import { settings_intro as strings } from "./SettingsIntro.strings.ts";
 
 const { t } = useReverseT();
+const authApp = useAuthAppConfig();
 </script>

--- a/ory-kratos-spa/pages/verification/Verification.vue
+++ b/ory-kratos-spa/pages/verification/Verification.vue
@@ -1,21 +1,19 @@
 <template>
-  <v-container class="py-8" max-width="720">
-    <VerificationFlowForm
-      v-if="queryData instanceof VerificationFlowFetched && flow"
-      :flow="flow"
-    />
-    <FlowGonePanel
-      v-else-if="queryData instanceof FlowGone"
-      restart-path="/new-verification"
-      :result="queryData"
-    />
-    <CsrfViolationPanel
-      v-else-if="queryData instanceof SecurityCsrfViolation"
-      restart-path="/new-verification"
-      :result="queryData"
-    />
-    <UnhandledResponsePanel v-else :result="queryData" />
-  </v-container>
+  <VerificationFlowForm
+    v-if="queryData instanceof VerificationFlowFetched && flow"
+    :flow="flow"
+  />
+  <FlowGonePanel
+    v-else-if="queryData instanceof FlowGone"
+    restart-path="/new-verification"
+    :result="queryData"
+  />
+  <CsrfViolationPanel
+    v-else-if="queryData instanceof SecurityCsrfViolation"
+    restart-path="/new-verification"
+    :result="queryData"
+  />
+  <UnhandledResponsePanel v-else :result="queryData" />
 </template>
 
 <script setup lang="ts">

--- a/ory-kratos-spa/pages/verification/VerificationIntro.vue
+++ b/ory-kratos-spa/pages/verification/VerificationIntro.vue
@@ -10,12 +10,15 @@
       </a>
     </div>
     <div style="clear: both"></div>
-    <h1 class="text-h4 mb-2">{{ t(strings.title) }}</h1>
+    <h1 v-if="authApp.showFlowHeaders" class="text-h4 mb-2">
+      {{ t(strings.title) }}
+    </h1>
   </div>
 </template>
 
 <script setup lang="ts">
 import { useReverseT } from "@saflib/ory-kratos-spa/i18n";
+import { useAuthAppConfig } from "../../configureAuthApp.ts";
 import { useAuthFlowCrossLinks } from "../common/useAuthFlowCrossLinks.ts";
 import { verification_intro as strings } from "./VerificationIntro.strings.ts";
 
@@ -24,5 +27,6 @@ const props = defineProps<{
 }>();
 
 const { t } = useReverseT();
+const authApp = useAuthAppConfig();
 const { loginHref } = useAuthFlowCrossLinks(() => props.flowReturnTo);
 </script>

--- a/ory-kratos-spa/pages/verify-wall/VerifyWall.logic.test.ts
+++ b/ory-kratos-spa/pages/verify-wall/VerifyWall.logic.test.ts
@@ -1,27 +1,6 @@
 import type { Session } from "@ory/client";
 import { describe, expect, it } from "vitest";
-import {
-  resolveVerifyWallReturnToDestination,
-  sessionDisplayEmail,
-} from "./VerifyWall.logic.ts";
-
-describe("resolveVerifyWallReturnToDestination", () => {
-  it("uses the return_to query when it is a non-empty string", () => {
-    expect(resolveVerifyWallReturnToDestination("https://app.example/after", "https://fallback")).toBe(
-      "https://app.example/after",
-    );
-  });
-
-  it("trims the return_to query", () => {
-    expect(resolveVerifyWallReturnToDestination("  https://x  ", "https://fallback")).toBe("https://x");
-  });
-
-  it("uses the fallback when return_to is missing or blank", () => {
-    expect(resolveVerifyWallReturnToDestination(undefined, "https://fallback")).toBe("https://fallback");
-    expect(resolveVerifyWallReturnToDestination("", "https://fallback")).toBe("https://fallback");
-    expect(resolveVerifyWallReturnToDestination("   ", "https://fallback")).toBe("https://fallback");
-  });
-});
+import { sessionDisplayEmail } from "./VerifyWall.logic.ts";
 
 describe("sessionDisplayEmail", () => {
   it("prefers traits.email when present", () => {
@@ -32,7 +11,14 @@ describe("sessionDisplayEmail", () => {
           id: "i",
           schema_id: "x",
           traits: { email: "traits@example.com" },
-          verifiable_addresses: [{ value: "other@example.com", verified: false, via: "email", status: "pending" }],
+          verifiable_addresses: [
+            {
+              value: "other@example.com",
+              verified: false,
+              via: "email",
+              status: "pending",
+            },
+          ],
         },
       } as Session),
     ).toBe("traits@example.com");

--- a/ory-kratos-spa/pages/verify-wall/VerifyWall.logic.ts
+++ b/ory-kratos-spa/pages/verify-wall/VerifyWall.logic.ts
@@ -1,16 +1,5 @@
 import type { Session } from "@ory/client";
 
-/** Post-verification destination: `?return_to=` when set, otherwise the injected post-register fallback URL. */
-export function resolveVerifyWallReturnToDestination(
-  returnToQueryParam: unknown,
-  fallbackHref: string,
-): string {
-  if (typeof returnToQueryParam === "string" && returnToQueryParam.trim()) {
-    return returnToQueryParam.trim();
-  }
-  return fallbackHref;
-}
-
 /** Display email from traits or the first email verifiable address. */
 export function sessionDisplayEmail(session: Session): string {
   const traits = session.identity?.traits as { email?: string } | undefined;

--- a/ory-kratos-spa/pages/verify-wall/VerifyWall.logic.ts
+++ b/ory-kratos-spa/pages/verify-wall/VerifyWall.logic.ts
@@ -1,14 +1,14 @@
 import type { Session } from "@ory/client";
 
-/** Post-verification destination: `?return_to=` when set, otherwise the injected hub app fallback URL. */
+/** Post-verification destination: `?return_to=` when set, otherwise the injected post-register fallback URL. */
 export function resolveVerifyWallReturnToDestination(
   returnToQueryParam: unknown,
-  fallbackRecipesHomeHref: string,
+  fallbackHref: string,
 ): string {
   if (typeof returnToQueryParam === "string" && returnToQueryParam.trim()) {
     return returnToQueryParam.trim();
   }
-  return fallbackRecipesHomeHref;
+  return fallbackHref;
 }
 
 /** Display email from traits or the first email verifiable address. */

--- a/ory-kratos-spa/pages/verify-wall/VerifyWallIntro.vue
+++ b/ory-kratos-spa/pages/verify-wall/VerifyWallIntro.vue
@@ -3,7 +3,9 @@
     <div class="text-center mb-6">
       <v-icon size="64" color="primary" class="mb-4">mdi-email-check</v-icon>
     </div>
-    <h1 class="text-h4 text-center mb-2">{{ t(strings.title) }}</h1>
+    <h1 v-if="authApp.showFlowHeaders" class="text-h4 text-center mb-2">
+      {{ t(strings.title) }}
+    </h1>
     <i18n-t
       v-if="identityEmail"
       scope="global"
@@ -18,6 +20,7 @@
 
 <script setup lang="ts">
 import { useReverseT } from "@saflib/ory-kratos-spa/i18n";
+import { useAuthAppConfig } from "../../configureAuthApp.ts";
 import { verify_wall_intro as strings } from "./VerifyWallIntro.strings.ts";
 
 defineProps<{
@@ -26,4 +29,5 @@ defineProps<{
 }>();
 
 const { t, lookupTKey } = useReverseT();
+const authApp = useAuthAppConfig();
 </script>

--- a/ory-kratos-spa/pages/verify-wall/VerifyWallVerifiedIntro.vue
+++ b/ory-kratos-spa/pages/verify-wall/VerifyWallVerifiedIntro.vue
@@ -3,7 +3,10 @@
     <div class="text-center mb-6">
       <v-icon size="64" color="primary" class="mb-4">mdi-check-decagram</v-icon>
     </div>
-    <h1 class="text-h4 text-center font-weight-bold mb-2">
+    <h1
+      v-if="authApp.showFlowHeaders"
+      class="text-h4 text-center font-weight-bold mb-2"
+    >
       {{ t(strings.title) }}
     </h1>
     <p class="text-body-1 text-medium-emphasis text-center mb-6">
@@ -14,7 +17,9 @@
 
 <script setup lang="ts">
 import { useReverseT } from "@saflib/ory-kratos-spa/i18n";
+import { useAuthAppConfig } from "../../configureAuthApp.ts";
 import { verify_wall_verified_intro as strings } from "./VerifyWallVerifiedIntro.strings.ts";
 
 const { t } = useReverseT();
+const authApp = useAuthAppConfig();
 </script>

--- a/ory-kratos-spa/pages/verify-wall/useVerifyWallPage.ts
+++ b/ory-kratos-spa/pages/verify-wall/useVerifyWallPage.ts
@@ -4,7 +4,7 @@ import { computed, watch } from "vue";
 import { useRoute } from "vue-router";
 import { linkToHrefWithHost, navigateToLink } from "@saflib/links";
 import { authLinks } from "@saflib/ory-kratos-sdk/links";
-import { useAuthPostAuthFallbackHref } from "../../authFallbackInject.ts";
+import { useAuthPostRegisterFallbackHref } from "../../authFallbackInject.ts";
 import { identityNeedsEmailVerification } from "@saflib/ory-kratos-sdk";
 import {
   resolveVerifyWallReturnToDestination,
@@ -19,12 +19,12 @@ export function useVerifyWallPage(
   sessionQuery: UseQueryReturnType<Session | null, Error>,
 ) {
   const route = useRoute();
-  const postAuthFallbackHref = useAuthPostAuthFallbackHref();
+  const postRegisterFallbackHref = useAuthPostRegisterFallbackHref();
 
   const redirectAfter = computed(() =>
     resolveVerifyWallReturnToDestination(
       route.query.return_to,
-      postAuthFallbackHref.value,
+      postRegisterFallbackHref.value,
     ),
   );
 

--- a/ory-kratos-spa/pages/verify-wall/useVerifyWallPage.ts
+++ b/ory-kratos-spa/pages/verify-wall/useVerifyWallPage.ts
@@ -6,10 +6,7 @@ import { linkToHrefWithHost, navigateToLink } from "@saflib/links";
 import { authLinks } from "@saflib/ory-kratos-sdk/links";
 import { useAuthPostRegisterFallbackHref } from "../../authFallbackInject.ts";
 import { identityNeedsEmailVerification } from "@saflib/ory-kratos-sdk";
-import {
-  resolveVerifyWallReturnToDestination,
-  sessionDisplayEmail,
-} from "./VerifyWall.logic.ts";
+import { sessionDisplayEmail } from "./VerifyWall.logic.ts";
 
 /**
  * Route side effects and derived state for the verify wall: redirect unauthenticated users to login,
@@ -19,14 +16,7 @@ export function useVerifyWallPage(
   sessionQuery: UseQueryReturnType<Session | null, Error>,
 ) {
   const route = useRoute();
-  const postRegisterFallbackHref = useAuthPostRegisterFallbackHref();
-
-  const redirectAfter = computed(() =>
-    resolveVerifyWallReturnToDestination(
-      route.query.return_to,
-      postRegisterFallbackHref.value,
-    ),
-  );
+  const redirectAfter = useAuthPostRegisterFallbackHref();
 
   const verifyWallReturnHref = computed(() => {
     const r = route.query.return_to;

--- a/vue/components/TopLevelContainer.vue
+++ b/vue/components/TopLevelContainer.vue
@@ -1,11 +1,16 @@
 <template>
-  <v-container class="mt-8">
+  <v-container>
     <v-row>
-      <v-spacer />
-      <v-col cols="12" md="10" lg="6" xl="4">
+      <v-spacer v-if="smAndUp" />
+      <v-col cols="12" sm="10" md="8" lg="6" xl="4" xxl="3">
         <slot></slot>
       </v-col>
-      <v-spacer />
+      <v-spacer v-if="smAndUp" />
     </v-row>
   </v-container>
 </template>
+
+<script setup lang="ts">
+import { useDisplay } from "vuetify";
+const { smAndUp } = useDisplay();
+</script>


### PR DESCRIPTION
Doing some updates to support a usage of the auth spa.
* Refactor configuration into a composable, add more options for flow controls and whether to show headers.
* Remove card and container around the form. Up to the app to style here.
* Move input errors to below the input, as text instead of alerts.
* Move cross links to below the form.
* Remove the "send new recovery code" button from the recovery flow.
* Sort registration fields.