### PR TITLE
Add goto workflow command

### DIFF
--- a/workflows/bin/saf-workflow/goto.ts
+++ b/workflows/bin/saf-workflow/goto.ts
@@ -1,0 +1,75 @@
+import {
+  loadPlanStatusContents,
+  loadWorkflow,
+  saveWorkflow,
+} from "./shared/file-io.ts";
+import { addNewLinesToString } from "../../strings.ts";
+import {
+  createWorkflowLogger,
+  setupWorkflowContext,
+} from "../../core/store.ts";
+import type { WorkflowBlob, WorkflowCommandOptions } from "./shared/types.ts";
+
+export const addGotoCommand = (commandOptions: WorkflowCommandOptions) => {
+  commandOptions.program
+    .command("goto [step]")
+    .description(
+      addNewLinesToString(
+        "Jump to a specific step of the current workflow by step number. If no step is given, lists available steps.",
+      ),
+    )
+    .action(async (step?: string) => {
+      const contents = loadPlanStatusContents();
+      if (!contents) {
+        console.error("No workflow status found");
+        process.exit(1);
+      }
+      const blob = JSON.parse(contents) as WorkflowBlob;
+      if (!blob.snapshotState?.context) {
+        console.error("No context found in workflow status");
+        process.exit(1);
+      }
+      const log = createWorkflowLogger({});
+      setupWorkflowContext({
+        logger: log,
+        getSourceUrl: commandOptions.getSourceUrl,
+      });
+
+      const workflow = await loadWorkflow(commandOptions.workflows);
+      if (!workflow) {
+        log.error("No workflow found");
+        process.exit(1);
+      }
+
+      const steps = workflow.listSteps();
+
+      if (step === undefined) {
+        console.log("\nWorkflow steps:");
+        steps.forEach(({ index, name }) => {
+          console.log(`  ${index}: ${name}`);
+        });
+        console.log(
+          "\nRun with a step number to jump to that step, e.g.: saf-workflow goto 2",
+        );
+        return;
+      }
+
+      const stepIndex = parseInt(step, 10);
+      if (isNaN(stepIndex) || stepIndex < 0 || stepIndex >= steps.length) {
+        log.error(
+          `Invalid step "${step}". Must be a number between 0 and ${steps.length - 1}.`,
+        );
+        console.log("\nAvailable steps:");
+        steps.forEach(({ index, name }) => {
+          console.log(`  ${index}: ${name}`);
+        });
+        process.exit(1);
+      }
+
+      const target = steps[stepIndex];
+      log.info(`Jumping to step ${target.index}: ${target.name}`);
+      await workflow.goToStep(stepIndex);
+      log.info(`Saving workflow after goto`);
+      saveWorkflow(workflow);
+    });
+};

--- a/workflows/bin/saf-workflow/index.ts
+++ b/workflows/bin/saf-workflow/index.ts
@@ -5,6 +5,7 @@ import { addKickoffCommand } from "./kickoff.ts";
 import { addChecklistCommand } from "./checklist.ts";
 import { addStatusCommand } from "./status.ts";
 import { addNextCommand } from "./next.ts";
+import { addGotoCommand } from "./goto.ts";
 import { addListCommand } from "./list.ts";
 import { addSourceCommand } from "./source.ts";
 import { addRunScriptsCommand } from "./run-scripts.ts";
@@ -46,6 +47,7 @@ export async function runWorkflowCli(
   addDryRunCommand(commandOptions);
   addStatusCommand(commandOptions);
   addNextCommand(commandOptions);
+  addGotoCommand(commandOptions);
   addChecklistCommand(commandOptions);
   addListCommand(commandOptions);
   addSourceCommand(commandOptions);

--- a/workflows/bin/saf-workflow/kickoff.ts
+++ b/workflows/bin/saf-workflow/kickoff.ts
@@ -67,7 +67,7 @@ export const addKickoffCommand = (commandOptions: WorkflowCommandOptions) => {
         });
         if (givenRunMode === "run") {
           addPendingMessage(
-            "You are going through a well-defined developer workflow specific to this codebase and project. You will receive logs and prompts, please follow them to the best of your ability. If you need to halt the workflow because of a blocker, please include the --- HALT WORKFLOW --- string in your final response.\n",
+            "You are going through a well-defined developer workflow specific to this codebase and project. You will receive logs and prompts, please follow them to the best of your ability. If you need to halt the workflow because of a blocker, please include the --- HALT WORKFLOW --- string in your final response. If you mention that you don't need to halt the workflow, don't cite the string that halts the workflow though...\n",
           );
           if (commandOptions.systemPrompt) {
             addPendingMessage(`${commandOptions.systemPrompt}\n`);

--- a/workflows/bin/saf-workflow/shared/workflow.ts
+++ b/workflows/bin/saf-workflow/shared/workflow.ts
@@ -49,7 +49,7 @@ export abstract class AbstractWorkflowRunner {
   abstract getCurrentStateName(): string;
   abstract goToNextStep(options?: WorkflowRunOptions): Promise<void>;
   abstract listSteps(): WorkflowStepInfo[];
-  abstract goToStep(stepIndex: number, options?: WorkflowRunOptions): Promise<void>;
+  abstract goToStep(stepIndex: number): Promise<void>;
   abstract dehydrate(): WorkflowBlob;
   abstract hydrate(blob: WorkflowBlob): void;
   abstract done(): boolean;
@@ -86,6 +86,7 @@ export class XStateWorkflowRunner extends AbstractWorkflowRunner {
   };
   private args: string[];
   private actor: AnyActor | undefined;
+  private pendingBlob: WorkflowBlob | undefined;
   definition: WorkflowDefinition<any, any>;
 
   constructor(options: XStateWorkflowOptions<any, any>) {
@@ -146,6 +147,7 @@ export class XStateWorkflowRunner extends AbstractWorkflowRunner {
       log.error("Workflow not started");
       return;
     }
+    this.actor.start();
     if (this.actor.getSnapshot().status === "error") {
       log.error("Workflow has errored. And could not continue.");
       return;
@@ -179,6 +181,7 @@ export class XStateWorkflowRunner extends AbstractWorkflowRunner {
     if (!this.actor) {
       throw new Error("Workflow not started");
     }
+    this.actor.start();
     if (this.actor.getSnapshot().status === "error") {
       log.error("This workflow has errored. And could not continue.");
       return;
@@ -198,6 +201,9 @@ export class XStateWorkflowRunner extends AbstractWorkflowRunner {
   };
 
   dehydrate = (): WorkflowBlob => {
+    if (this.pendingBlob) {
+      return this.pendingBlob;
+    }
     return {
       workflowName: this.machine.id,
       workflowSourceUrl: this.definition.sourceUrl,
@@ -216,7 +222,6 @@ export class XStateWorkflowRunner extends AbstractWorkflowRunner {
         }
       },
     });
-    this.actor.start();
   };
 
   done = (): boolean => {
@@ -254,13 +259,7 @@ export class XStateWorkflowRunner extends AbstractWorkflowRunner {
     }));
   };
 
-  goToStep = async (
-    stepIndex: number,
-    options?: WorkflowRunOptions,
-  ): Promise<void> => {
-    if (!this.actor) {
-      throw new Error("Workflow not started");
-    }
+  goToStep = async (stepIndex: number): Promise<void> => {
     const step = this.definition.steps[stepIndex];
     if (!step) {
       throw new Error(
@@ -269,7 +268,7 @@ export class XStateWorkflowRunner extends AbstractWorkflowRunner {
     }
     const targetStateName = `step_${stepIndex}_${step.machine.id}`;
     const currentBlob = this.dehydrate();
-    const modifiedBlob: WorkflowBlob = {
+    this.pendingBlob = {
       ...currentBlob,
       snapshotState: {
         ...currentBlob.snapshotState,
@@ -278,8 +277,6 @@ export class XStateWorkflowRunner extends AbstractWorkflowRunner {
         children: {},
       },
     };
-    this.actor.stop();
-    this.hydrate(modifiedBlob, options);
   };
 
   getError = (): Error | undefined => {

--- a/workflows/bin/saf-workflow/shared/workflow.ts
+++ b/workflows/bin/saf-workflow/shared/workflow.ts
@@ -35,6 +35,11 @@ export interface WorkflowRunOptions {
   onSnapshot?: (snapshot: Snapshot<any>) => void;
 }
 
+export interface WorkflowStepInfo {
+  index: number;
+  name: string;
+}
+
 /**
  * Abstract superclass for XStateWorkflow. Can probably be removed since SimpleWorkflows are gone.
  */
@@ -43,6 +48,8 @@ export abstract class AbstractWorkflowRunner {
   abstract printStatus(): Promise<void>;
   abstract getCurrentStateName(): string;
   abstract goToNextStep(options?: WorkflowRunOptions): Promise<void>;
+  abstract listSteps(): WorkflowStepInfo[];
+  abstract goToStep(stepIndex: number, options?: WorkflowRunOptions): Promise<void>;
   abstract dehydrate(): WorkflowBlob;
   abstract hydrate(blob: WorkflowBlob): void;
   abstract done(): boolean;
@@ -238,6 +245,41 @@ export class XStateWorkflowRunner extends AbstractWorkflowRunner {
       return "not started";
     }
     return this.actor.getSnapshot().value;
+  };
+
+  listSteps = (): WorkflowStepInfo[] => {
+    return this.definition.steps.map((s, index) => ({
+      index,
+      name: s.machine.id,
+    }));
+  };
+
+  goToStep = async (
+    stepIndex: number,
+    options?: WorkflowRunOptions,
+  ): Promise<void> => {
+    if (!this.actor) {
+      throw new Error("Workflow not started");
+    }
+    const step = this.definition.steps[stepIndex];
+    if (!step) {
+      throw new Error(
+        `Step ${stepIndex} does not exist (workflow has ${this.definition.steps.length} steps)`,
+      );
+    }
+    const targetStateName = `step_${stepIndex}_${step.machine.id}`;
+    const currentBlob = this.dehydrate();
+    const modifiedBlob: WorkflowBlob = {
+      ...currentBlob,
+      snapshotState: {
+        ...currentBlob.snapshotState,
+        status: "active",
+        value: targetStateName,
+        children: {},
+      },
+    };
+    this.actor.stop();
+    this.hydrate(modifiedBlob, options);
   };
 
   getError = (): Error | undefined => {

--- a/workflows/core/agents/cursor-agent.ts
+++ b/workflows/core/agents/cursor-agent.ts
@@ -244,7 +244,6 @@ export const executePromptWithCursor = async ({
   } else {
     printLineSlowly("Starting new session");
     args.push("--model", "auto");
-    throw new Error("This shouldn't happen");
   }
   const agent = spawn("cursor-agent", args);
   agent.stdin.end(); // or it hangs

--- a/workflows/core/agents/cursor-agent.ts
+++ b/workflows/core/agents/cursor-agent.ts
@@ -244,6 +244,7 @@ export const executePromptWithCursor = async ({
   } else {
     printLineSlowly("Starting new session");
     args.push("--model", "auto");
+    throw new Error("This shouldn't happen");
   }
   const agent = spawn("cursor-agent", args);
   agent.stdin.end(); // or it hangs


### PR DESCRIPTION
I'm trying out a way to recover from a workflow that errors in the middle, or needs to be changed in the middle. This goto command works like the "next" command in that it continues to use the workflow context saved to disk, but it will also update the state of the workflow.

This is an experimental feature, so it's not thoroughly tested yet.