### PR TITLE
Update workflows, tweak auth

### DIFF
--- a/express/docs/02-middleware.md
+++ b/express/docs/02-middleware.md
@@ -28,9 +28,11 @@ The data passed in this way is limited. The only information the route is given 
 
 The auth middleware checks the OpenAPI schema for the requested route and the auth object provided through the `forward_auth` headers to return 401s where appropriate. As such, it depends on both the `context.ts` and `openapi.ts` middleware.
 
-If a route has a `no-auth` tag associated with it, it always passes the request through.
+If a route has a `no-auth` tag associated with it, it always passes the request through (no authentication or CSRF checks for that operation).
 
 Otherwise, if the request is unauthenticated, the middleware returns 401.
+
+If a route has an `email-verified` tag, or scoped middleware was created with `emailVerificationRequired: true`, the middleware returns 403 unless `auth.emailVerified` is true.
 
 When creating scoped middleware, `auth.ts` can be disabled, but it's on by default.
 

--- a/express/src/middleware/auth.test.ts
+++ b/express/src/middleware/auth.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 
 import express from "express";
+import type { OpenAPIV3 } from "express-openapi-validator/dist/framework/types.ts";
 import request from "supertest";
 import { createScopedMiddleware } from "./composition.ts";
 import { errorHandler } from "./errors.ts"; // Import errorHandler for a complete setup
@@ -155,7 +156,7 @@ describe("Auth Middleware email verification", () => {
 
 describe("Auth Middleware email-verified OpenAPI tag", () => {
   /** Minimal spec with response bodies so express-openapi-validator accepts handler + auth errors. */
-  const specWithEmailVerifiedTag = {
+  const specWithEmailVerifiedTag: OpenAPIV3.DocumentV3 = {
     openapi: "3.0.0",
     info: { title: "test", version: "1.0.0" },
     paths: {
@@ -192,7 +193,7 @@ describe("Auth Middleware email-verified OpenAPI tag", () => {
         },
       },
     },
-  } as const;
+  };
 
   it("returns 403 when operation has email-verified tag and email is not verified", async () => {
     const app = express();

--- a/express/src/middleware/auth.test.ts
+++ b/express/src/middleware/auth.test.ts
@@ -152,3 +152,94 @@ describe("Auth Middleware email verification", () => {
     expect(response.body.authFromMiddleware?.emailVerified).toBe(true);
   });
 });
+
+describe("Auth Middleware email-verified OpenAPI tag", () => {
+  /** Minimal spec with response bodies so express-openapi-validator accepts handler + auth errors. */
+  const specWithEmailVerifiedTag = {
+    openapi: "3.0.0",
+    info: { title: "test", version: "1.0.0" },
+    paths: {
+      "/tagged": {
+        get: {
+          tags: ["email-verified"],
+          responses: {
+            "200": {
+              description: "ok",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: { ok: { type: "boolean" } },
+                  },
+                },
+              },
+            },
+            "403": {
+              description: "forbidden",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      error: { type: "string" },
+                      message: { type: "string" },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  } as const;
+
+  it("returns 403 when operation has email-verified tag and email is not verified", async () => {
+    const app = express();
+    app.use(
+      createScopedMiddleware({
+        enforceAuth: true,
+        apiSpec: specWithEmailVerifiedTag,
+      }),
+    );
+    app.get("/tagged", (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    app.use(errorHandler);
+
+    const response = await request(app).get("/tagged").set({
+      "x-user-id": "123",
+      "x-user-email": "test@example.com",
+      "x-user-email-verified": "false",
+    });
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      error: "Forbidden",
+      message: "Forbidden",
+    });
+  });
+
+  it("allows the request when operation has email-verified tag and email is verified", async () => {
+    const app = express();
+    app.use(
+      createScopedMiddleware({
+        enforceAuth: true,
+        apiSpec: specWithEmailVerifiedTag,
+      }),
+    );
+    app.get("/tagged", (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+    app.use(errorHandler);
+
+    const response = await request(app).get("/tagged").set({
+      "x-user-id": "123",
+      "x-user-email": "test@example.com",
+      "x-user-email-verified": "true",
+    });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+  });
+});

--- a/express/src/middleware/auth.ts
+++ b/express/src/middleware/auth.ts
@@ -31,12 +31,17 @@ export const makeAuthMiddleware = (
 
   return (req, res, next): void => {
     const { auth } = getSafContext();
+    const tags = req.openapi?.schema?.tags;
+    const routeRequiresVerifiedEmail =
+      Boolean(emailVerificationRequired) ||
+      tags?.includes("email-verified") === true;
 
-    if (req.openapi?.schema?.tags?.includes("no-auth")) {
+    if (tags?.includes("no-auth")) {
       return next();
     }
 
     if (!auth) {
+      console.log("Unauthorizedm returning so");
       drainRequest(req).then(() => {
         if (!res.headersSent) {
           res.status(401).json({
@@ -48,7 +53,7 @@ export const makeAuthMiddleware = (
       return;
     }
 
-    if (emailVerificationRequired && auth.emailVerified !== true) {
+    if (routeRequiresVerifiedEmail && auth.emailVerified !== true) {
       drainRequest(req).then(() => {
         if (!res.headersSent) {
           res.status(403).json({

--- a/express/src/middleware/context.ts
+++ b/express/src/middleware/context.ts
@@ -96,7 +96,8 @@ async function resolveAuth(req: Request): Promise<Auth | undefined> {
   if (typedEnv.NODE_ENV === "test") {
     return resolveTestAuth(req);
   }
-  throw createError(500, "No auth found");
+  // No Kratos identity header (e.g. Caddy whoami returned 401, or request bypassed edge auth): treat as anonymous.
+  return undefined;
 }
 
 export const makeContextMiddleware = () => {

--- a/express/workflows/test-workflows.ts
+++ b/express/workflows/test-workflows.ts
@@ -3,7 +3,7 @@ import { AddHandlerWorkflowDefinition } from "./add-handler.ts";
 
 import {
   OpenapiInitWorkflowDefinition,
-  AddSchemaWorkflowDefinition,
+  OpenApiSchemaWorkflowDefinition,
   AddRouteWorkflowDefinition,
 } from "@saflib/openapi/workflows";
 
@@ -57,7 +57,7 @@ const TestExpressWorkflowsDefinition = defineWorkflow<
     step(CdStepMachine, () => ({
       path: "test-spec",
     })),
-    step(makeWorkflowMachine(AddSchemaWorkflowDefinition), () => ({
+    step(makeWorkflowMachine(OpenApiSchemaWorkflowDefinition), () => ({
       name: "user",
     })),
 

--- a/express/workflows/test-workflows.ts
+++ b/express/workflows/test-workflows.ts
@@ -4,7 +4,7 @@ import { AddHandlerWorkflowDefinition } from "./add-handler.ts";
 import {
   OpenapiInitWorkflowDefinition,
   OpenApiSchemaWorkflowDefinition,
-  AddRouteWorkflowDefinition,
+  OpenApiRouteWorkflowDefinition,
 } from "@saflib/openapi/workflows";
 
 import {
@@ -62,7 +62,7 @@ const TestExpressWorkflowsDefinition = defineWorkflow<
     })),
 
     // Add a list users route to the spec
-    step(makeWorkflowMachine(AddRouteWorkflowDefinition), () => ({
+    step(makeWorkflowMachine(OpenApiRouteWorkflowDefinition), () => ({
       path: "routes/users/list.yaml",
       urlPath: "/users",
       method: "get",

--- a/openapi/docs/workflows/add-route.md
+++ b/openapi/docs/workflows/add-route.md
@@ -1,4 +1,4 @@
-# openapi/add-route
+# openapi/route
 
 ## Source
 
@@ -7,7 +7,7 @@
 ## Usage
 
 ```bash
-npm exec saf-workflow kickoff openapi/add-route <path>
+npm exec saf-workflow kickoff openapi/route <path>
 ```
 
 To run this workflow automatically, tell the agent to:
@@ -34,7 +34,7 @@ When run, the workflow will:
 ## Help Docs
 
 ```bash
-Usage: npm exec saf-workflow kickoff openapi/add-route <path>
+Usage: npm exec saf-workflow kickoff openapi/route <path>
 
 Add a new route to an existing OpenAPI specification package
 

--- a/openapi/docs/workflows/add-schema.md
+++ b/openapi/docs/workflows/add-schema.md
@@ -1,4 +1,4 @@
-# openapi/add-schema
+# openapi/schema
 
 ## Source
 
@@ -7,7 +7,7 @@
 ## Usage
 
 ```bash
-npm exec saf-workflow kickoff openapi/add-schema <name>
+npm exec saf-workflow kickoff openapi/schema <name>
 ```
 
 To run this workflow automatically, tell the agent to:
@@ -34,7 +34,7 @@ When run, the workflow will:
 ## Help Docs
 
 ```bash
-Usage: npm exec saf-workflow kickoff openapi/add-schema <name>
+Usage: npm exec saf-workflow kickoff openapi/schema <name>
 
 Add a new schema to an existing OpenAPI specification package
 

--- a/openapi/docs/workflows/index.md
+++ b/openapi/docs/workflows/index.md
@@ -3,6 +3,6 @@
 `@saflib/openapi` provides the following automated workflows for packages depending on it:
 
 - [openapi/add-event](./add-event.md)
-- [openapi/add-route](./add-route.md)
-- [openapi/add-schema](./add-schema.md)
+- [openapi/route](./add-route.md)
+- [openapi/schema](./add-schema.md)
 - [openapi/init](./init.md)

--- a/openapi/workflows/add-route.test.ts
+++ b/openapi/workflows/add-route.test.ts
@@ -16,7 +16,7 @@ describe("add-route", () => {
 });
 
 describe("mergeOpenApiRoute", () => {
-  const beginMarker = "BEGIN WORKFLOW AREA route-paths FOR openapi/add-route";
+  const beginMarker = "BEGIN WORKFLOW AREA route-paths FOR openapi/route";
   const endMarker = "END WORKFLOW AREA";
 
   it("returns content unchanged when no workflow area markers exist", () => {

--- a/openapi/workflows/add-route.test.ts
+++ b/openapi/workflows/add-route.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import {
-  AddRouteWorkflowDefinition,
+  OpenApiRouteWorkflowDefinition,
   mergeOpenApiRoute,
 } from "./add-route.ts";
 import { runWorkflow } from "@saflib/workflows";
@@ -8,7 +8,7 @@ import { runWorkflow } from "@saflib/workflows";
 describe("add-route", () => {
   it("should successfully dry run", async () => {
     const result = await runWorkflow({
-      definition: AddRouteWorkflowDefinition,
+      definition: OpenApiRouteWorkflowDefinition,
       runMode: "checklist",
     });
     expect(result.output?.checklist).toBeDefined();
@@ -16,8 +16,7 @@ describe("add-route", () => {
 });
 
 describe("mergeOpenApiRoute", () => {
-  const beginMarker =
-    "BEGIN WORKFLOW AREA route-paths FOR openapi/add-route";
+  const beginMarker = "BEGIN WORKFLOW AREA route-paths FOR openapi/add-route";
   const endMarker = "END WORKFLOW AREA";
 
   it("returns content unchanged when no workflow area markers exist", () => {
@@ -54,7 +53,7 @@ describe("mergeOpenApiRoute", () => {
     // Single path key for /recipes (no duplicate "  /recipes:" line before post)
     const recipesSection = result.slice(
       result.indexOf("  /recipes:"),
-      result.indexOf("  /other:")
+      result.indexOf("  /other:"),
     );
     expect(recipesSection.match(/^\s{2}\/recipes:/gm)).toHaveLength(1);
   });

--- a/openapi/workflows/add-route.ts
+++ b/openapi/workflows/add-route.ts
@@ -153,7 +153,7 @@ export const OpenApiRouteWorkflowDefinition = defineWorkflow<
 export function mergeOpenApiRoute(content: string): string {
   const lines = content.split("\n");
   const areaStart = lines.findIndex((l) =>
-    l.includes("BEGIN WORKFLOW AREA route-paths FOR openapi/add-route"),
+    l.includes("BEGIN WORKFLOW AREA route-paths FOR openapi/route"),
   );
   const areaEnd = lines.findIndex(
     (l) => l.includes("END WORKFLOW AREA") && lines.indexOf(l) > areaStart,

--- a/openapi/workflows/add-route.ts
+++ b/openapi/workflows/add-route.ts
@@ -40,11 +40,12 @@ const input = [
   {
     name: "download",
     type: "flag" as const,
-    description: "Route returns binary (e.g. application/octet-stream or specific type)",
+    description:
+      "Route returns binary (e.g. application/octet-stream or specific type)",
   },
 ] as const;
 
-interface AddRouteWorkflowContext extends ParsePathOutput {
+interface OpenApiRouteWorkflowContext extends ParsePathOutput {
   operationId: string;
   upload: boolean;
   download: boolean;
@@ -52,16 +53,16 @@ interface AddRouteWorkflowContext extends ParsePathOutput {
   method: string;
 }
 
-export const AddRouteWorkflowDefinition = defineWorkflow<
+export const OpenApiRouteWorkflowDefinition = defineWorkflow<
   typeof input,
-  AddRouteWorkflowContext
+  OpenApiRouteWorkflowContext
 >({
-  id: "openapi/add-route",
+  id: "openapi/route",
 
-  description: "Add a new route to an existing OpenAPI specification package",
+  description: "Work on an OpenAPI route",
 
   checklistDescription: ({ groupName, targetName }) =>
-    `Add a new ${targetName} route for ${groupName} resource to the OpenAPI specification.`,
+    `Work on the ${targetName} route for ${groupName} resource.`,
 
   input,
 
@@ -112,15 +113,11 @@ export const AddRouteWorkflowDefinition = defineWorkflow<
 
     step(UpdateStepMachine, ({ context }) => ({
       fileId: "route",
-      promptMessage: `Update **${path.basename(context.copiedFiles!.route)}**. Resolve all TODOs.
-      
-      Replace the template properties with actual route definition:
-      - Define request parameters and body schemas using $ref to existing schemas
-      - Define response schemas using $ref to existing schemas (including error.yaml for error responses)
+      promptMessage: `Update **${path.basename(context.copiedFiles!.route)}**.
+      - Request parameters and body schemas, and response schemas should $ref existing schemas
       - Remove any unused sections (parameters, requestBody) if not needed
       - Do not specify a 400 response when the only 400s would come from OpenAPI request validation (e.g. missing required, wrong type). Do specify 400 for dynamic or business-rule failures (e.g. duplicate id, id not URL-safe, cannot remove creator).
       - If this is a list route, do not include a sort parameter unless explicitly requested.
-      - For a route that is public, specify and enforce it with a "no-auth" tag.
       ${context.download ? "- For download routes the 200 response content is already set to application/octet-stream (or adjust to a specific media type e.g. application/pdf)." : ""}
       `,
     })),

--- a/openapi/workflows/add-schema.test.ts
+++ b/openapi/workflows/add-schema.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import { OpenApiSchemaWorkflowDefinition } from "./add-schema.ts";
 import { runWorkflow } from "@saflib/workflows";
 
-describe("openapi/add-schema", () => {
+describe("openapi/schema", () => {
   it("should successfully dry run", async () => {
     const result = await runWorkflow({
       definition: OpenApiSchemaWorkflowDefinition,

--- a/openapi/workflows/add-schema.test.ts
+++ b/openapi/workflows/add-schema.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { AddSchemaWorkflowDefinition } from "./add-schema.ts";
+import { OpenApiSchemaWorkflowDefinition } from "./add-schema.ts";
 import { runWorkflow } from "@saflib/workflows";
 
 describe("openapi/add-schema", () => {
   it("should successfully dry run", async () => {
     const result = await runWorkflow({
-      definition: AddSchemaWorkflowDefinition,
+      definition: OpenApiSchemaWorkflowDefinition,
       runMode: "checklist",
     });
     expect(result.output?.checklist).toBeDefined();

--- a/openapi/workflows/add-schema.ts
+++ b/openapi/workflows/add-schema.ts
@@ -19,7 +19,7 @@ const sourceDir = path.join(import.meta.dirname, "templates");
 const input = [
   {
     name: "name",
-    description: "The name of the schema to create (e.g., 'user' or 'product')",
+    description: "The name of the schema (e.g., 'user' or 'product')",
     exampleValue: "example",
   },
 ] as const;
@@ -33,10 +33,9 @@ export const OpenApiSchemaWorkflowDefinition = defineWorkflow<
 >({
   id: "openapi/schema",
 
-  description: "Add a new schema to an existing OpenAPI specification package",
+  description: "Work on an OpenAPI schema",
 
-  checklistDescription: ({ groupName }) =>
-    `Add a new ${groupName} schema to the OpenAPI specification.`,
+  checklistDescription: ({ targetName }) => `Work on the ${targetName} schema.`,
 
   input,
 

--- a/openapi/workflows/add-schema.ts
+++ b/openapi/workflows/add-schema.ts
@@ -24,15 +24,14 @@ const input = [
   },
 ] as const;
 
-interface AddSchemaWorkflowContext
-  extends ParsePackageNameOutput,
-    ParsePathOutput {}
+interface OpenApiSchemaWorkflowContext
+  extends ParsePackageNameOutput, ParsePathOutput {}
 
-export const AddSchemaWorkflowDefinition = defineWorkflow<
+export const OpenApiSchemaWorkflowDefinition = defineWorkflow<
   typeof input,
-  AddSchemaWorkflowContext
+  OpenApiSchemaWorkflowContext
 >({
-  id: "openapi/add-schema",
+  id: "openapi/schema",
 
   description: "Add a new schema to an existing OpenAPI specification package",
 
@@ -82,14 +81,11 @@ export const AddSchemaWorkflowDefinition = defineWorkflow<
 
     step(UpdateStepMachine, ({ context }) => ({
       fileId: "schema",
-      promptMessage: `Update **${context.targetName}** to define the schema for the ${context.groupName} resource.
-      
-      Replace the template properties with actual properties for your schema:
-      - Define the object properties and their types
-      - Add appropriate descriptions and examples
-      - Set required fields
+      promptMessage: `Update **${context.targetName}**
+      - Add or update object properties and their types
+      - Include appropriate descriptions and examples with new or updated properties
+      - Update the required property as necessary
       - Use type: string for id and reference fields (do not use format: uuid; we use short ids from generateShortId)
-      - Consider validation rules and constraints
       - For nullable enums, make sure to include null in the enum list otherwise the validator will disallow null values.`,
     })),
 

--- a/openapi/workflows/index.ts
+++ b/openapi/workflows/index.ts
@@ -1,20 +1,20 @@
 import { OpenapiInitWorkflowDefinition } from "./init.ts";
 import { OpenApiSchemaWorkflowDefinition } from "./add-schema.ts";
-import { AddRouteWorkflowDefinition } from "./add-route.ts";
+import { OpenApiRouteWorkflowDefinition } from "./add-route.ts";
 import { AddEventWorkflowDefinition } from "./add-event.ts";
 import type { WorkflowDefinition } from "@saflib/workflows";
 
 export {
   OpenapiInitWorkflowDefinition,
   OpenApiSchemaWorkflowDefinition,
-  AddRouteWorkflowDefinition,
+  OpenApiRouteWorkflowDefinition,
   AddEventWorkflowDefinition,
 };
 
 const workflowDefinitions: WorkflowDefinition[] = [
   OpenapiInitWorkflowDefinition,
   OpenApiSchemaWorkflowDefinition,
-  AddRouteWorkflowDefinition,
+  OpenApiRouteWorkflowDefinition,
   AddEventWorkflowDefinition,
 ];
 

--- a/openapi/workflows/index.ts
+++ b/openapi/workflows/index.ts
@@ -1,19 +1,19 @@
 import { OpenapiInitWorkflowDefinition } from "./init.ts";
-import { AddSchemaWorkflowDefinition } from "./add-schema.ts";
+import { OpenApiSchemaWorkflowDefinition } from "./add-schema.ts";
 import { AddRouteWorkflowDefinition } from "./add-route.ts";
 import { AddEventWorkflowDefinition } from "./add-event.ts";
 import type { WorkflowDefinition } from "@saflib/workflows";
 
 export {
   OpenapiInitWorkflowDefinition,
-  AddSchemaWorkflowDefinition,
+  OpenApiSchemaWorkflowDefinition,
   AddRouteWorkflowDefinition,
   AddEventWorkflowDefinition,
 };
 
 const workflowDefinitions: WorkflowDefinition[] = [
   OpenapiInitWorkflowDefinition,
-  AddSchemaWorkflowDefinition,
+  OpenApiSchemaWorkflowDefinition,
   AddRouteWorkflowDefinition,
   AddEventWorkflowDefinition,
 ];

--- a/openapi/workflows/templates/index.ts
+++ b/openapi/workflows/templates/index.ts
@@ -14,7 +14,7 @@ export type __ServiceName__ServiceRequestBody = ExtractRequestBody<operations>;
 export type Error = components["schemas"]["Error"];
 export type ProductEvent = components["schemas"]["ProductEvent"];
 
-// BEGIN SORTED WORKFLOW AREA schema-exports FOR openapi/add-schema
+// BEGIN SORTED WORKFLOW AREA schema-exports FOR openapi/schema
 export type __TargetName__ = components["schemas"]["__TargetName__"];
 // END WORKFLOW AREA
 

--- a/openapi/workflows/templates/openapi.yaml
+++ b/openapi/workflows/templates/openapi.yaml
@@ -5,7 +5,7 @@ info:
   description: API specification for the __service-name__ service
 
 paths:
-  # BEGIN WORKFLOW AREA route-paths FOR openapi/add-route
+  # BEGIN WORKFLOW AREA route-paths FOR openapi/route
   __url-path__:
     __method__:
       $ref: "./routes/__group-name__/__target-name__.yaml#/__operationId__"
@@ -17,7 +17,7 @@ components:
       $ref: "./schemas/error.yaml"
     ProductEvent:
       $ref: "./events/index.yaml"
-    # BEGIN WORKFLOW AREA schema-components FOR openapi/add-schema
+    # BEGIN WORKFLOW AREA schema-components FOR openapi/schema
     __TargetName__:
       $ref: "./schemas/__target-name__.yaml"
     # END WORKFLOW AREA

--- a/openapi/workflows/templates/routes/__group-name__/__target-name__.yaml
+++ b/openapi/workflows/templates/routes/__group-name__/__target-name__.yaml
@@ -18,7 +18,7 @@ __operationId__:
   requestBody:
     required: true
     content:
-      # BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/add-route IF upload
+      # BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/route IF upload
       multipart/form-data:
         schema:
           type: object
@@ -43,7 +43,7 @@ __operationId__:
     "200":
       description: "todo"
       content:
-        # BEGIN ONCE WORKFLOW AREA responseContent FOR openapi/add-route IF download
+        # BEGIN ONCE WORKFLOW AREA responseContent FOR openapi/route IF download
         application/octet-stream:
           schema:
             type: string

--- a/ory-kratos-spa/authFallbackInject.ts
+++ b/ory-kratos-spa/authFallbackInject.ts
@@ -6,7 +6,7 @@ import { useRoute } from "vue-router";
 import { linkToHref } from "@saflib/links";
 const domain = document.location.host.replace("auth.", "");
 
-/** Default post-auth URL when the shell does not set `postAuthOverrideHref` in `configureAuthApp`. */
+/** Default post-auth URL when the shell does not set `postAuthFallbackHref` or `postAuthOverrideHref` in `configureAuthApp`. */
 export const defaultPostAuthFallbackHref = computed(() =>
   linkToHref({ subdomain: "app", path: "/" }, { domain }),
 );
@@ -22,13 +22,13 @@ export const defaultPostRegisterFallbackHref = computed(() =>
 );
 
 /**
- * Resolved post-auth URL from {@link configureAuthApp} (override value or library default).
- * {@link AUTH_POST_AUTH_URL_IS_OVERRIDE} indicates whether the shell set an override.
+ * Resolved post-auth fallback base URL from {@link configureAuthApp} (override, explicit fallback, or library default).
+ * {@link AUTH_POST_AUTH_URL_IS_OVERRIDE} is true only when the shell set `postAuthOverrideHref` (then `?return_to=` is ignored).
  */
 export const AUTH_POST_AUTH_FALLBACK_HREF: InjectionKey<ComputedRef<string>> =
   Symbol("authPostAuthFallbackHref");
 
-/** True when {@link configureAuthApp} was given `postAuthOverrideHref` (that URL wins over `?return_to=`). */
+/** True when {@link configureAuthApp} was given `postAuthOverrideHref` (that URL wins; `?return_to=` is ignored). */
 export const AUTH_POST_AUTH_URL_IS_OVERRIDE: InjectionKey<ComputedRef<boolean>> =
   Symbol("authPostAuthUrlIsOverride");
 
@@ -70,7 +70,7 @@ function mergeReturnToQuery(
 
 /**
  * After login / post-auth: when the shell set `postAuthOverrideHref`, that URL is used and `?return_to=` is ignored.
- * Otherwise `?return_to=` wins, then the resolved default URL.
+ * Otherwise `?return_to=` wins when present, then the resolved fallback URL (`postAuthFallbackHref`, else library default).
  */
 export function useAuthPostAuthFallbackHref(): ComputedRef<string> {
   const route = useRoute();

--- a/ory-kratos-spa/configureAuthApp.ts
+++ b/ory-kratos-spa/configureAuthApp.ts
@@ -33,9 +33,14 @@ const defaultAuthAppConfig: AuthAppConfig = {
 
 export interface ConfigureAuthAppOptions extends Partial<AuthAppConfig> {
   /**
-   * When set, this URL is used for post-login redirects and `?return_to=` is ignored.
-   * When omitted, `?return_to=` is honored, then the default app home URL.
-   * See {@link AUTH_POST_AUTH_FALLBACK_HREF}.
+   * Default URL after login when `?return_to=` is absent. When set, `?return_to=` is still honored when present.
+   * Prefer this over `postAuthOverrideHref` when deep links (e.g. “sell a part” with `return_to`) should win.
+   * When omitted, the library default app home URL is used as that fallback.
+   */
+  postAuthFallbackHref?: MaybeRefOrGetter<string>;
+  /**
+   * When set, post-login redirects always use this URL and `?return_to=` is ignored.
+   * If both this and `postAuthFallbackHref` are set, this wins.
    */
   postAuthOverrideHref?: MaybeRefOrGetter<string>;
   /**
@@ -76,15 +81,19 @@ export function configureAuthApp(
   });
   provide(AUTH_APP_CONFIG, config);
 
-  const postAuthOverride = computed(
-    () => toValue(options).postAuthOverrideHref !== undefined,
-  );
+  const postAuthOverride = computed(() => {
+    const o = toValue(options);
+    return o.postAuthOverrideHref !== undefined;
+  });
   provide(AUTH_POST_AUTH_URL_IS_OVERRIDE, postAuthOverride);
 
   const postAuthHref = computed(() => {
     const o = toValue(options);
     if (o.postAuthOverrideHref !== undefined) {
       return toValue(o.postAuthOverrideHref);
+    }
+    if (o.postAuthFallbackHref !== undefined) {
+      return toValue(o.postAuthFallbackHref);
     }
     return defaultPostAuthFallbackHref.value;
   });

--- a/processes/workflows/spec-project.ts
+++ b/processes/workflows/spec-project.ts
@@ -95,8 +95,8 @@ export const SpecProjectWorkflowDefinition = defineWorkflow<
       The most common workflow... flow is:
       
       Backend:
-      * openapi/add-schema - to add business objects
-      * openapi/add-route - to add API routes (takes path, urlPath, method, and prompt; urlPath uses OpenAPI {param} syntax, method is lowercase e.g. get, post, put, delete)
+      * openapi/schema - to add business objects
+      * openapi/route - to add API routes (takes path, urlPath, method, and prompt; urlPath uses OpenAPI {param} syntax, method is lowercase e.g. get, post, put, delete)
       * drizzle/update-schema - to add database tables
       * drizzle/add-query - to add database queries
       * express/add-handler - to add API handlers

--- a/product/workflows/templates/deploy/remote-assets/config/common.Caddyfile
+++ b/product/workflows/templates/deploy/remote-assets/config/common.Caddyfile
@@ -89,7 +89,7 @@ http://caddy:2020 {
 	}
 }
 
-# Recipes API (and similar): forward_auth to Kratos whoami; Express resolves identity via admin API.
+# Recipes API (and similar): probe Kratos /sessions/whoami; copy identity on 2xx, but never short-circuit the client on 401.
 # args[0]: target service host (e.g. monolith:3002)
 (kratos-api-proxy) {
 	handle /health {
@@ -99,10 +99,21 @@ http://caddy:2020 {
 	}
 
 	handle {
-		forward_auth kratos:4433 {
-			uri /sessions/whoami
+		reverse_proxy kratos:4433 {
+			method GET
+			rewrite /sessions/whoami
 			header_up X-Request-ID {http.request.uuid}
-			copy_headers X-Kratos-Authenticated-Identity-Id
+			header_up X-Forwarded-Method {http.request.method}
+			header_up X-Forwarded-Uri {http.request.uri}
+
+			@kratos_session_ok status 2xx
+			handle_response @kratos_session_ok {
+				request_header X-Kratos-Authenticated-Identity-Id {rp.header.X-Kratos-Authenticated-Identity-Id}
+			}
+
+			@kratos_session_unauthorized status 401
+			handle_response @kratos_session_unauthorized {
+			}
 		}
 		reverse_proxy {args[0]} {
 			import reverse_proxy_common

--- a/sdk/components/address-form/AddressForm.vue
+++ b/sdk/components/address-form/AddressForm.vue
@@ -8,7 +8,7 @@
       :rules="[streetAddressRule]"
     />
 
-    <v-row class="ma-0" dense>
+    <v-row class="ma-0" density="comfortable">
       <v-col cols="12" sm="6" class="py-0 ps-0">
         <v-text-field
           v-model="locality"
@@ -29,7 +29,7 @@
       </v-col>
     </v-row>
 
-    <v-row class="ma-0" dense>
+    <v-row class="ma-0" density="comfortable">
       <v-col cols="12" sm="6" class="py-0 ps-0">
         <v-text-field
           v-model="country"

--- a/vue/workflows/template/__static-subdomain-name__/.vitepress/theme/components/__SubdomainName__HomePage.vue
+++ b/vue/workflows/template/__static-subdomain-name__/.vitepress/theme/components/__SubdomainName__HomePage.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="__subdomain-name__-home py-8">
-    <v-row class="align-center mb-10" dense>
+    <v-row class="align-center mb-10" density="comfortable">
       <v-col cols="12" md="6" class="order-2 order-md-1">
         <h1 class="text-h3 text-md-h2 font-weight-medium my-8">
           __Product Name__
@@ -13,8 +13,7 @@
   </div>
 </template>
 
-<script setup lang="ts">
-</script>
+<script setup lang="ts"></script>
 
 <style scoped>
 .__subdomain-name__-home :deep(a.text-primary) {

--- a/workflows-cli/test-all-workflows.ts
+++ b/workflows-cli/test-all-workflows.ts
@@ -2,7 +2,7 @@ import { defineWorkflow, makeWorkflowMachine, step } from "@saflib/workflows";
 import { InitProductWorkflowDefinition } from "@saflib/product/workflows";
 import { CdStepMachine } from "@saflib/workflows";
 import {
-  AddSchemaWorkflowDefinition,
+  OpenApiSchemaWorkflowDefinition,
   AddRouteWorkflowDefinition,
   AddEventWorkflowDefinition,
 } from "@saflib/openapi/workflows";
@@ -89,11 +89,11 @@ export const TestAllWorkflowsDefinition = defineWorkflow<
     step(CdStepMachine, () => ({
       path: "./tmp/service/spec",
     })),
-    step(makeWorkflowMachine(AddSchemaWorkflowDefinition), () => ({
+    step(makeWorkflowMachine(OpenApiSchemaWorkflowDefinition), () => ({
       name: "user",
     })),
     // Route template references schemas/todo.yaml; add it so saf-specs generate succeeds in script mode
-    step(makeWorkflowMachine(AddSchemaWorkflowDefinition), () => ({
+    step(makeWorkflowMachine(OpenApiSchemaWorkflowDefinition), () => ({
       name: "todo",
     })),
     step(makeWorkflowMachine(AddRouteWorkflowDefinition), () => ({

--- a/workflows-cli/test-all-workflows.ts
+++ b/workflows-cli/test-all-workflows.ts
@@ -3,7 +3,7 @@ import { InitProductWorkflowDefinition } from "@saflib/product/workflows";
 import { CdStepMachine } from "@saflib/workflows";
 import {
   OpenApiSchemaWorkflowDefinition,
-  AddRouteWorkflowDefinition,
+  OpenApiRouteWorkflowDefinition,
   AddEventWorkflowDefinition,
 } from "@saflib/openapi/workflows";
 import {
@@ -96,12 +96,12 @@ export const TestAllWorkflowsDefinition = defineWorkflow<
     step(makeWorkflowMachine(OpenApiSchemaWorkflowDefinition), () => ({
       name: "todo",
     })),
-    step(makeWorkflowMachine(AddRouteWorkflowDefinition), () => ({
+    step(makeWorkflowMachine(OpenApiRouteWorkflowDefinition), () => ({
       path: "./routes/users/list.yaml",
       urlPath: "/users",
       method: "get",
     })),
-    step(makeWorkflowMachine(AddRouteWorkflowDefinition), () => ({
+    step(makeWorkflowMachine(OpenApiRouteWorkflowDefinition), () => ({
       path: "./routes/users/create.yaml",
       urlPath: "/users",
       method: "post",

--- a/workflows/core/steps/copy/inline/parse.test.ts
+++ b/workflows/core/steps/copy/inline/parse.test.ts
@@ -11,7 +11,9 @@ describe("parseWorkflowAreaStart", () => {
   it("returns null for non-matching lines", () => {
     expect(parseWorkflowAreaStart("  const x = 1;")).toBeNull();
     expect(parseWorkflowAreaStart("")).toBeNull();
-    expect(parseWorkflowAreaStart("// BEGIN WORKFLOW ZONE foo FOR w1")).toBeNull();
+    expect(
+      parseWorkflowAreaStart("// BEGIN WORKFLOW ZONE foo FOR w1"),
+    ).toBeNull();
   });
 
   it("parses basic BEGIN WORKFLOW AREA", () => {
@@ -41,11 +43,11 @@ describe("parseWorkflowAreaStart", () => {
   });
 
   it("parses ONCE WORKFLOW AREA", () => {
-    const line = "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/add-route";
+    const line = "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/route";
     const parsed = parseWorkflowAreaStart(line);
     expect(parsed).toEqual({
       areaName: "requestBody",
-      workflowIds: ["openapi/add-route"],
+      workflowIds: ["openapi/route"],
       isSorted: false,
       isOnce: true,
       ifFlag: undefined,
@@ -55,11 +57,11 @@ describe("parseWorkflowAreaStart", () => {
 
   it("parses IF flag at end", () => {
     const line =
-      "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/add-route IF upload";
+      "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/route IF upload";
     const parsed = parseWorkflowAreaStart(line);
     expect(parsed).toEqual({
       areaName: "requestBody",
-      workflowIds: ["openapi/add-route"],
+      workflowIds: ["openapi/route"],
       isSorted: false,
       isOnce: true,
       ifFlag: "upload",
@@ -156,9 +158,9 @@ describe("resolveConditionalBlocks", () => {
 
   it("returns ifBlock when flag is true", () => {
     const lines = ["  ifLine", "# ELSE", "  elseLine"];
-    expect(
-      resolveConditionalBlocks(lines, "upload", { upload: true }),
-    ).toEqual(["  ifLine"]);
+    expect(resolveConditionalBlocks(lines, "upload", { upload: true })).toEqual(
+      ["  ifLine"],
+    );
   });
 
   it("returns elseBlock when flag is false", () => {

--- a/workflows/core/steps/copy/inline/update.test.ts
+++ b/workflows/core/steps/copy/inline/update.test.ts
@@ -125,7 +125,7 @@ describe("updateWorkflowAreas", () => {
   it("ONCE: replaces entire area with resolved content only (no markers)", () => {
     const result = updateWorkflowAreas({
       targetLines: [
-        "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/add-route IF upload",
+        "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/route IF upload",
         "  multipart/content",
         "# ELSE",
         "  application/json",
@@ -133,7 +133,7 @@ describe("updateWorkflowAreas", () => {
       ],
       targetPath: "test.yaml",
       sourceLines: [
-        "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/add-route IF upload",
+        "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/route IF upload",
         "  multipart/form-data:",
         "    schema: {}",
         "# ELSE",
@@ -141,33 +141,30 @@ describe("updateWorkflowAreas", () => {
         "    schema: {}",
         "# END WORKFLOW AREA",
       ],
-      workflowId: "openapi/add-route",
+      workflowId: "openapi/route",
       lineReplace: (line) => line,
       flags: { upload: true },
     });
 
-    expect(result).toEqual([
-      "  multipart/form-data:",
-      "    schema: {}",
-    ]);
+    expect(result).toEqual(["  multipart/form-data:", "    schema: {}"]);
   });
 
   it("ONCE with IF false: replaces with else-block only", () => {
     const result = updateWorkflowAreas({
       targetLines: [
-        "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/add-route IF upload",
+        "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/route IF upload",
         "# ELSE",
         "# END WORKFLOW AREA",
       ],
       targetPath: "test.yaml",
       sourceLines: [
-        "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/add-route IF upload",
+        "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/route IF upload",
         "  multipart",
         "# ELSE",
         "  application/json",
         "# END WORKFLOW AREA",
       ],
-      workflowId: "openapi/add-route",
+      workflowId: "openapi/route",
       lineReplace: (line) => line,
       flags: { upload: false },
     });

--- a/workflows/core/steps/copy/inline/validate.test.ts
+++ b/workflows/core/steps/copy/inline/validate.test.ts
@@ -30,7 +30,7 @@ describe("extractWorkflowAreas", () => {
 
   it("extracts area with ONCE and IF", () => {
     const lines = [
-      "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/add-route IF upload",
+      "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/route IF upload",
       "  content",
       "# END WORKFLOW AREA",
     ];
@@ -38,7 +38,7 @@ describe("extractWorkflowAreas", () => {
     expect(areas).toHaveLength(1);
     expect(areas[0]).toMatchObject({
       areaName: "requestBody",
-      workflowIds: ["openapi/add-route"],
+      workflowIds: ["openapi/route"],
       isSorted: false,
       isOnce: true,
       ifFlag: "upload",
@@ -65,10 +65,7 @@ describe("extractWorkflowAreas", () => {
   });
 
   it("records endLine null when area has no END", () => {
-    const lines = [
-      "// BEGIN WORKFLOW AREA myArea FOR workflow1",
-      "  code",
-    ];
+    const lines = ["// BEGIN WORKFLOW AREA myArea FOR workflow1", "  code"];
     const areas = extractWorkflowAreas(lines);
     expect(areas).toHaveLength(1);
     expect(areas[0].endLine).toBeNull();
@@ -117,8 +114,16 @@ describe("getAreaKey", () => {
       startLine: "// BEGIN WORKFLOW AREA x FOR w1",
       endLine: "// END" as string | null,
     };
-    const withOnce = { ...normal, isOnce: true, startLine: "// BEGIN ONCE WORKFLOW AREA x FOR w1" };
-    const withIf = { ...normal, ifFlag: "upload", startLine: "// BEGIN WORKFLOW AREA x FOR w1 IF upload" };
+    const withOnce = {
+      ...normal,
+      isOnce: true,
+      startLine: "// BEGIN ONCE WORKFLOW AREA x FOR w1",
+    };
+    const withIf = {
+      ...normal,
+      ifFlag: "upload",
+      startLine: "// BEGIN WORKFLOW AREA x FOR w1 IF upload",
+    };
     expect(getAreaKey(normal)).not.toBe(getAreaKey(withOnce));
     expect(getAreaKey(normal)).not.toBe(getAreaKey(withIf));
   });
@@ -173,7 +178,11 @@ describe("validateWorkflowAreas", () => {
       "    // END WORKFLOW AREA",
     ];
     expect(() =>
-      validateWorkflowAreas({ sourceLines: source, targetLines: target, ...ctx }),
+      validateWorkflowAreas({
+        sourceLines: source,
+        targetLines: target,
+        ...ctx,
+      }),
     ).not.toThrow();
   });
 
@@ -189,7 +198,11 @@ describe("validateWorkflowAreas", () => {
       "// END WORKFLOW AREA",
     ];
     expect(() =>
-      validateWorkflowAreas({ sourceLines: source, targetLines: target, ...ctx }),
+      validateWorkflowAreas({
+        sourceLines: source,
+        targetLines: target,
+        ...ctx,
+      }),
     ).not.toThrow();
   });
 
@@ -205,23 +218,31 @@ describe("validateWorkflowAreas", () => {
       "// END WORKFLOW AREA",
     ];
     expect(() =>
-      validateWorkflowAreas({ sourceLines: source, targetLines: target, ...ctx }),
+      validateWorkflowAreas({
+        sourceLines: source,
+        targetLines: target,
+        ...ctx,
+      }),
     ).not.toThrow();
   });
 
   it("does not throw when matching ONCE IF areas", () => {
     const source = [
-      "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/add-route IF upload",
+      "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/route IF upload",
       "  content",
       "# END WORKFLOW AREA",
     ];
     const target = [
-      "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/add-route IF upload",
+      "# BEGIN ONCE WORKFLOW AREA requestBody FOR openapi/route IF upload",
       "  resolved",
       "# END WORKFLOW AREA",
     ];
     expect(() =>
-      validateWorkflowAreas({ sourceLines: source, targetLines: target, ...ctx }),
+      validateWorkflowAreas({
+        sourceLines: source,
+        targetLines: target,
+        ...ctx,
+      }),
     ).not.toThrow();
   });
 
@@ -233,7 +254,11 @@ describe("validateWorkflowAreas", () => {
     ];
     const target: string[] = [];
     expect(() =>
-      validateWorkflowAreas({ sourceLines: source, targetLines: target, ...ctx }),
+      validateWorkflowAreas({
+        sourceLines: source,
+        targetLines: target,
+        ...ctx,
+      }),
     ).not.toThrow();
   });
 
@@ -268,17 +293,18 @@ describe("validateWorkflowAreas", () => {
   });
 
   it("throws when source area is missing END marker", () => {
-    const source = [
-      "// BEGIN WORKFLOW AREA myArea FOR workflow1",
-      "  code",
-    ];
+    const source = ["// BEGIN WORKFLOW AREA myArea FOR workflow1", "  code"];
     const target = [
       "// BEGIN WORKFLOW AREA myArea FOR workflow1",
       "  existing",
       "// END WORKFLOW AREA",
     ];
     expect(() =>
-      validateWorkflowAreas({ sourceLines: source, targetLines: target, ...ctx }),
+      validateWorkflowAreas({
+        sourceLines: source,
+        targetLines: target,
+        ...ctx,
+      }),
     ).toThrow(/without matching END marker/);
   });
 
@@ -293,7 +319,11 @@ describe("validateWorkflowAreas", () => {
       "  existing",
     ];
     expect(() =>
-      validateWorkflowAreas({ sourceLines: source, targetLines: target, ...ctx }),
+      validateWorkflowAreas({
+        sourceLines: source,
+        targetLines: target,
+        ...ctx,
+      }),
     ).toThrow(/without matching END marker/);
   });
 
@@ -309,7 +339,11 @@ describe("validateWorkflowAreas", () => {
       "// END WORKFLOW AREA",
     ];
     expect(() =>
-      validateWorkflowAreas({ sourceLines: source, targetLines: target, ...ctx }),
+      validateWorkflowAreas({
+        sourceLines: source,
+        targetLines: target,
+        ...ctx,
+      }),
     ).toThrow();
   });
 
@@ -325,7 +359,11 @@ describe("validateWorkflowAreas", () => {
       "// END WORKFLOW AREA",
     ];
     expect(() =>
-      validateWorkflowAreas({ sourceLines: source, targetLines: target, ...ctx }),
+      validateWorkflowAreas({
+        sourceLines: source,
+        targetLines: target,
+        ...ctx,
+      }),
     ).toThrow();
   });
 
@@ -341,7 +379,11 @@ describe("validateWorkflowAreas", () => {
       "// END WORKFLOW AREA",
     ];
     expect(() =>
-      validateWorkflowAreas({ sourceLines: source, targetLines: target, ...ctx }),
+      validateWorkflowAreas({
+        sourceLines: source,
+        targetLines: target,
+        ...ctx,
+      }),
     ).toThrow();
   });
 
@@ -360,7 +402,11 @@ describe("validateWorkflowAreas", () => {
       "// END WORKFLOW AREA",
     ];
     expect(() =>
-      validateWorkflowAreas({ sourceLines: source, targetLines: target, ...ctx }),
+      validateWorkflowAreas({
+        sourceLines: source,
+        targetLines: target,
+        ...ctx,
+      }),
     ).toThrow(/duplicate/);
   });
 
@@ -379,7 +425,11 @@ describe("validateWorkflowAreas", () => {
       "// END WORKFLOW AREA",
     ];
     expect(() =>
-      validateWorkflowAreas({ sourceLines: source, targetLines: target, ...ctx }),
+      validateWorkflowAreas({
+        sourceLines: source,
+        targetLines: target,
+        ...ctx,
+      }),
     ).toThrow(/duplicate/);
   });
 
@@ -395,7 +445,11 @@ describe("validateWorkflowAreas", () => {
       "# END WORKFLOW AREA",
     ];
     expect(() =>
-      validateWorkflowAreas({ sourceLines: source, targetLines: target, ...ctx }),
+      validateWorkflowAreas({
+        sourceLines: source,
+        targetLines: target,
+        ...ctx,
+      }),
     ).toThrow();
   });
 
@@ -411,7 +465,11 @@ describe("validateWorkflowAreas", () => {
       "// END WORKFLOW AREA",
     ];
     expect(() =>
-      validateWorkflowAreas({ sourceLines: source, targetLines: target, ...ctx }),
+      validateWorkflowAreas({
+        sourceLines: source,
+        targetLines: target,
+        ...ctx,
+      }),
     ).toThrow(/Target has workflow area/);
   });
 });


### PR DESCRIPTION
A handful of changes while working on other stuff:
* I'm starting to use workflows for updating things as well as adding them. I'm going to start making that more explicit so at the very least I can keep track of which ones have been updated.
* Made some auth changes, where kratos no longer blocks unauthenticated requests (that's express's job) as well as adding a new tag "email-verified" to api schemas with enforcement on the express side.
* Made some fixes to the kratos auth app configuration. Made it so you could use the fallback instead of the override for after authentication.
* Fixed some vuetify warnings in tests.