### PR TITLE
Remove sorted workflow usages

### DIFF
--- a/cron/cron-vue/package.json
+++ b/cron/cron-vue/package.json
@@ -10,7 +10,9 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@saflib/cron-spec": "*",
+    "@saflib/sdk": "*",
     "@saflib/vue": "*",
-    "@saflib/cron-spec": "*"
+    "@tanstack/vue-query": "*"
   }
 }

--- a/cron/cron/workflows/init.ts
+++ b/cron/cron/workflows/init.ts
@@ -90,8 +90,8 @@ export const CronInitWorkflowDefinition = defineWorkflow<
 
 **HTTP API (cron job admin / status endpoints)**  
 - In the service's main HTTP app (Express or similar), mount \`createCronRouter\` from \`@saflib/cron\`.
-- Pass \`{ jobs }\` from this \`*-cron\` package, and a \`dbKey\` from \`cronDb.connect({ onDisk: <absolute sqlite path> })\` in \`@saflib/cron-db\` (job settings use the cron schema only). **Do not** pass your main application Drizzle key unless it is the same manager as \`cronDb\`—otherwise \`cronDbManager.get(dbKey)\` is undefined and routes will crash.
-- Reuse one shared \`cronDb.connect(...)\` result for both \`createCronRouter\` and \`runCron\` in the same process. Prefer storing the SQLite file under this \`*-cron\` package (e.g. \`<package>/data/db-\${DEPLOYMENT_NAME}.sqlite\`) via \`onDisk\` as a string path; \`onDisk: true\` alone stores under \`saflib/cron/cron-db/data\`.
+- Pass \`{ jobs: ...Jobs, dbKey: get...CronDbKey() }\` from this \`*-cron\` package (\`get*CronDbKey\` wraps \`cronDb.connect({ onDisk: ... })\` for the job-settings schema). **Do not** pass your main application Drizzle key—\`cronDbManager.get(dbKey)\` would be undefined and routes will crash.
+- The generated \`cron.ts\` template exposes \`get*CronSqlitePath\` / \`get*CronDbKey\` and stores SQLite under this package's \`data/cron-db-\${DEPLOYMENT_NAME}.sqlite\` unless you change it. Reuse the same \`get*CronDbKey()\` for both \`createCronRouter\` and \`runCron\`.
 - Place the router with other API routes, before the global error middleware.
 
 **Admin SPA (optional but typical)**  

--- a/cron/cron/workflows/init.ts
+++ b/cron/cron/workflows/init.ts
@@ -90,7 +90,8 @@ export const CronInitWorkflowDefinition = defineWorkflow<
 
 **HTTP API (cron job admin / status endpoints)**  
 - In the service's main HTTP app (Express or similar), mount \`createCronRouter\` from \`@saflib/cron\`.
-- Pass \`{ dbKey, jobs }\` where \`jobs\` is the exported \`JobsMap\` from this new \`*-cron\` package (same \`dbKey\` the app already uses for persistence if job settings live on that DB).
+- Pass \`{ jobs }\` from this \`*-cron\` package, and a \`dbKey\` that comes from \`cronDb.connect()\` in \`@saflib/cron-db\` (job settings use the cron schema only). **Do not** pass your main application Drizzle key unless it is the same manager as \`cronDb\`—otherwise \`cronDbManager.get(dbKey)\` is undefined and routes will crash.
+- Reuse one shared \`cronDb.connect()\` result for both \`createCronRouter\` and \`runCron\` in the same process.
 - Place the router with other API routes, before the global error middleware.
 
 **Admin SPA (optional but typical)**  
@@ -100,7 +101,7 @@ export const CronInitWorkflowDefinition = defineWorkflow<
 - Add a sidebar / nav link (e.g. next to other admin pages).
 
 **Process entry (monolith vs standalone service)**  
-- Ensure something actually **starts** the cron scheduler: call the package's \`run*Cron(context)\` (or equivalent) with the same \`context\` / \`dbKey\` / storage pattern the HTTP layer uses.
+- Ensure something actually **starts** the cron scheduler: call the package's \`run*Cron(context)\` (or equivalent). Use the same cron \`dbKey\` for \`runCron\` as for \`createCronRouter\`; use the app's AsyncLocalStorage / context only for job handlers that need it, not as the cron settings DB key unless you have wired that intentionally.
 - In a **monolith**, that is usually after DB + shared deps are initialized and alongside or before HTTP listen.
 - In a **separate cron/worker service**, the service's \`main\` / entrypoint should call \`run*Cron\` instead of (or in addition to) HTTP—adapt to this repo's layout.
 - If the app uses \`initializeDependencies()\` or similar for secrets/integrations, ensure it runs before \`run*Cron\` when jobs need those clients.

--- a/cron/cron/workflows/init.ts
+++ b/cron/cron/workflows/init.ts
@@ -90,8 +90,8 @@ export const CronInitWorkflowDefinition = defineWorkflow<
 
 **HTTP API (cron job admin / status endpoints)**  
 - In the service's main HTTP app (Express or similar), mount \`createCronRouter\` from \`@saflib/cron\`.
-- Pass \`{ jobs }\` from this \`*-cron\` package, and a \`dbKey\` that comes from \`cronDb.connect()\` in \`@saflib/cron-db\` (job settings use the cron schema only). **Do not** pass your main application Drizzle key unless it is the same manager as \`cronDb\`—otherwise \`cronDbManager.get(dbKey)\` is undefined and routes will crash.
-- Reuse one shared \`cronDb.connect()\` result for both \`createCronRouter\` and \`runCron\` in the same process.
+- Pass \`{ jobs }\` from this \`*-cron\` package, and a \`dbKey\` from \`cronDb.connect({ onDisk: <absolute sqlite path> })\` in \`@saflib/cron-db\` (job settings use the cron schema only). **Do not** pass your main application Drizzle key unless it is the same manager as \`cronDb\`—otherwise \`cronDbManager.get(dbKey)\` is undefined and routes will crash.
+- Reuse one shared \`cronDb.connect(...)\` result for both \`createCronRouter\` and \`runCron\` in the same process. Prefer storing the SQLite file under this \`*-cron\` package (e.g. \`<package>/data/db-\${DEPLOYMENT_NAME}.sqlite\`) via \`onDisk\` as a string path; \`onDisk: true\` alone stores under \`saflib/cron/cron-db/data\`.
 - Place the router with other API routes, before the global error middleware.
 
 **Admin SPA (optional but typical)**  
@@ -105,6 +105,11 @@ export const CronInitWorkflowDefinition = defineWorkflow<
 - In a **monolith**, that is usually after DB + shared deps are initialized and alongside or before HTTP listen.
 - In a **separate cron/worker service**, the service's \`main\` / entrypoint should call \`run*Cron\` instead of (or in addition to) HTTP—adapt to this repo's layout.
 - If the app uses \`initializeDependencies()\` or similar for secrets/integrations, ensure it runs before \`run*Cron\` when jobs need those clients.
+
+**Docker / deploy (persistent cron job settings DB)**  
+- Persist the **directory containing** the SQLite file you pass to \`cronDb.connect({ onDisk: ".../file.sqlite" })\` (e.g. mount \`<repo>/daemon/service/cron/data:/app/daemon/service/cron/data\` when the file is under \`daemon/service/cron/data/\` in the image).
+- If you use \`onDisk: true\` without a path, SQLite defaults to \`saflib/cron/cron-db/data/\` in the image—mount that path instead.
+- Ensure first deploy can create the DB (migrations run on connect; align with \`ALLOW_DB_CREATION\` / ops conventions used for the main app DB when applicable).
 
 After changes: add any new workspace dependencies, run typecheck/tests for touched packages.`,
     })),

--- a/cron/cron/workflows/init.ts
+++ b/cron/cron/workflows/init.ts
@@ -7,6 +7,7 @@ import {
   type ParsePackageNameOutput,
   CommandStepMachine,
   CdStepMachine,
+  PromptStepMachine,
 } from "@saflib/workflows";
 import path from "node:path";
 
@@ -82,6 +83,29 @@ export const CronInitWorkflowDefinition = defineWorkflow<
     step(CommandStepMachine, () => ({
       command: "npm",
       args: ["test"],
+    })),
+
+    step(PromptStepMachine, () => ({
+      promptText: `Wire this cron package into the rest of the product (paths and package names will differ by repo).
+
+**HTTP API (cron job admin / status endpoints)**  
+- In the service's main HTTP app (Express or similar), mount \`createCronRouter\` from \`@saflib/cron\`.
+- Pass \`{ dbKey, jobs }\` where \`jobs\` is the exported \`JobsMap\` from this new \`*-cron\` package (same \`dbKey\` the app already uses for persistence if job settings live on that DB).
+- Place the router with other API routes, before the global error middleware.
+
+**Admin SPA (optional but typical)**  
+- Add \`@saflib/cron-vue\` to the admin client package if missing.
+- Register a route that renders \`CronJobsPage\` from \`@saflib/cron-vue\` (often via a thin wrapper component).
+- Pass the \`subdomain\` prop the same way other admin API clients do in this repo (often \`"api"\` when the daemon SDK uses \`createSafClient("api")\` so \`/cron/jobs\` hits the same host as the rest of the API).
+- Add a sidebar / nav link (e.g. next to other admin pages).
+
+**Process entry (monolith vs standalone service)**  
+- Ensure something actually **starts** the cron scheduler: call the package's \`run*Cron(context)\` (or equivalent) with the same \`context\` / \`dbKey\` / storage pattern the HTTP layer uses.
+- In a **monolith**, that is usually after DB + shared deps are initialized and alongside or before HTTP listen.
+- In a **separate cron/worker service**, the service's \`main\` / entrypoint should call \`run*Cron\` instead of (or in addition to) HTTP—adapt to this repo's layout.
+- If the app uses \`initializeDependencies()\` or similar for secrets/integrations, ensure it runs before \`run*Cron\` when jobs need those clients.
+
+After changes: add any new workspace dependencies, run typecheck/tests for touched packages.`,
     })),
   ],
 });

--- a/cron/cron/workflows/templates/cron.ts
+++ b/cron/cron/workflows/templates/cron.ts
@@ -1,13 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { cronDb } from "@saflib/cron-db";
 import { runCron, type JobsMap } from "@saflib/cron";
+import type { DbKey } from "@saflib/drizzle";
+import { typedEnv } from "@saflib/env";
 import {
   __serviceName__ServiceStorage,
   type __ServiceName__ServiceContext,
 } from "template-package-service-common";
 
-// TODO: Import and add jobs here
-export const __serviceName__Jobs: JobsMap = {
-  // Add more jobs as needed
-};
+// TODO: Import job groups and spread into this map (e.g. `...exampleGroupJobs`).
+export const __serviceName__Jobs: JobsMap = {};
+
+/** Absolute path to the cron job-settings SQLite file under this package's `data/`. */
+export function get__ServiceName__CronSqlitePath(): string {
+  return path.join(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "data",
+    `cron-db-${typedEnv.DEPLOYMENT_NAME}.sqlite`,
+  );
+}
+
+let cronJobSettingsDbKey: DbKey | undefined;
+
+/**
+ * Opaque key for `@saflib/cron-db` (not the main app DB key). Use this for
+ * `createCronRouter({ dbKey: get__ServiceName__CronDbKey(), jobs: __serviceName__Jobs })` and `runCron`.
+ */
+export function get__ServiceName__CronDbKey(): DbKey {
+  if (!cronJobSettingsDbKey) {
+    const sqlitePath = get__ServiceName__CronSqlitePath();
+    if (process.env.NODE_ENV !== "test") {
+      fs.mkdirSync(path.dirname(sqlitePath), { recursive: true });
+    }
+    cronJobSettingsDbKey = cronDb.connect({ onDisk: sqlitePath });
+  }
+  return cronJobSettingsDbKey;
+}
 
 export const run__ServiceName__Cron = (
   context: __ServiceName__ServiceContext,
@@ -15,7 +45,7 @@ export const run__ServiceName__Cron = (
   return __serviceName__ServiceStorage.run(context, () =>
     runCron({
       jobs: __serviceName__Jobs,
-      dbKey: context.__serviceName__DbKey,
+      dbKey: get__ServiceName__CronDbKey(),
     }),
   );
 };

--- a/cron/cron/workflows/templates/package.json
+++ b/cron/cron/workflows/templates/package.json
@@ -13,6 +13,8 @@
   },
   "dependencies": {
     "@saflib/cron": "*",
+    "@saflib/cron-db": "*",
+    "@saflib/drizzle": "*",
     "@saflib/env": "*",
     "@saflib/monorepo": "*",
     "@saflib/node": "*",

--- a/drizzle/workflows/add-query.ts
+++ b/drizzle/workflows/add-query.ts
@@ -26,8 +26,7 @@ const input = [
 ] as const;
 
 interface AddDrizzleQueryWorkflowContext
-  extends ParsePathOutput,
-    ParsePackageNameOutput {}
+  extends ParsePathOutput, ParsePackageNameOutput {}
 
 export const AddDrizzleQueryWorkflowDefinition = defineWorkflow<
   typeof input,
@@ -97,7 +96,7 @@ export const AddDrizzleQueryWorkflowDefinition = defineWorkflow<
 
         * As much as possible, types should be based on the types that drizzle provides.
         * A resource not being found by ID is an error.
-        * Errors should be simple, no special constructors or anything.
+        * Error subclasses should be simple, no special constructors or anything.
         * You don't need to export error types from the types.ts file.
         
         Please reference the documentation here for more information: ${context.docFiles?.refDoc}`,

--- a/drizzle/workflows/templates/index.ts
+++ b/drizzle/workflows/templates/index.ts
@@ -4,6 +4,6 @@ export * from "./errors.ts";
 import { __serviceName__DbManager } from "./instances.ts";
 export const __serviceName__Db = __serviceName__DbManager.publicInterface();
 
-// BEGIN SORTED WORKFLOW AREA query-exports FOR drizzle/add-query
+// BEGIN WORKFLOW AREA query-exports FOR drizzle/add-query
 export * from "./queries/__group-name__/index.ts";
 // END WORKFLOW AREA

--- a/drizzle/workflows/templates/queries/__group-name__/index.ts
+++ b/drizzle/workflows/templates/queries/__group-name__/index.ts
@@ -1,9 +1,9 @@
-// BEGIN SORTED WORKFLOW AREA query-exports FOR drizzle/add-query
+// BEGIN WORKFLOW AREA query-exports FOR drizzle/add-query
 import { __targetName____GroupName__ } from "./__target-name__.ts";
 // END WORKFLOW AREA
 
 export const __groupName__Queries = {
-  // BEGIN SORTED WORKFLOW AREA query-object FOR drizzle/add-query
+  // BEGIN WORKFLOW AREA query-object FOR drizzle/add-query
   __targetName____GroupName__,
   // END WORKFLOW AREA
 };

--- a/drizzle/workflows/templates/schema.ts
+++ b/drizzle/workflows/templates/schema.ts
@@ -1,3 +1,3 @@
-// BEGIN SORTED WORKFLOW AREA schema-exports FOR drizzle/update-schema
+// BEGIN WORKFLOW AREA schema-exports FOR drizzle/update-schema
 export * from "./schemas/__group-name__.ts";
 // END WORKFLOW AREA

--- a/express/workflows/templates/http.ts
+++ b/express/workflows/templates/http.ts
@@ -7,7 +7,7 @@ import {
   makeContext,
 } from "template-package-service-common";
 
-// BEGIN SORTED WORKFLOW AREA router-imports FOR express/add-handler
+// BEGIN WORKFLOW AREA router-imports FOR express/add-handler
 import { create__GroupName__Router } from "./routes/__group-name__/index.ts";
 // END WORKFLOW AREA
 

--- a/express/workflows/templates/routes/__group-name__/index.ts
+++ b/express/workflows/templates/routes/__group-name__/index.ts
@@ -3,7 +3,7 @@ import { createScopedMiddleware } from "@saflib/express";
 // TODO: import the appropriate spec package
 // import { jsonSpec } from "@saflib/cron-spec";
 
-// BEGIN SORTED WORKFLOW AREA handler-imports FOR express/add-handler
+// BEGIN WORKFLOW AREA handler-imports FOR express/add-handler
 // import { __targetName____GroupName__Handler } from "./__target-name__.ts";
 // END WORKFLOW AREA
 

--- a/integrations/workflows/index.ts
+++ b/integrations/workflows/index.ts
@@ -1,18 +1,18 @@
-// BEGIN SORTED WORKFLOW AREA workflow-imports FOR workflows/add-workflow
+// BEGIN WORKFLOW AREA workflow-imports FOR workflows/add-workflow
 import { AddCallWorkflowDefinition } from "./add-call.ts";
 import { InitIntegrationWorkflowDefinition } from "./init-integration.ts";
 // END WORKFLOW AREA
 import type { WorkflowDefinition } from "@saflib/workflows";
 
 export {
-  // BEGIN SORTED WORKFLOW AREA workflow-exports FOR workflows/add-workflow
+  // BEGIN WORKFLOW AREA workflow-exports FOR workflows/add-workflow
   AddCallWorkflowDefinition,
   InitIntegrationWorkflowDefinition,
   // END WORKFLOW AREA
 };
 
 const integrationsWorkflowDefinitions: WorkflowDefinition[] = [
-  // BEGIN SORTED WORKFLOW AREA workflow-array FOR workflows/add-workflow
+  // BEGIN WORKFLOW AREA workflow-array FOR workflows/add-workflow
   AddCallWorkflowDefinition,
   InitIntegrationWorkflowDefinition,
   // END WORKFLOW AREA

--- a/integrations/workflows/templates/index.ts
+++ b/integrations/workflows/templates/index.ts
@@ -5,6 +5,6 @@ export {
 } from "./client.ts";
 export type { Scoped__IntegrationName__Client } from "./client.ts";
 export { ping } from "./calls/ping.ts";
-// BEGIN SORTED WORKFLOW AREA call-exports FOR integrations/add-call
+// BEGIN WORKFLOW AREA call-exports FOR integrations/add-call
 export { __targetName__ } from "./calls/__target-name__.ts";
 // END WORKFLOW AREA

--- a/object-store/test/TestObjectStore.ts
+++ b/object-store/test/TestObjectStore.ts
@@ -2,7 +2,11 @@ import { Readable } from "stream";
 import { buffer as streamToBuffer } from "node:stream/consumers";
 import { ObjectStore } from "../ObjectStore.ts";
 import type { ReturnsError } from "@saflib/monorepo";
-import { StorageError, FileNotFoundError } from "../ObjectStore.ts";
+import {
+  PathTraversalError,
+  StorageError,
+  FileNotFoundError,
+} from "../ObjectStore.ts";
 
 export interface TestFile {
   path: string;
@@ -107,7 +111,18 @@ export class TestObjectStore extends ObjectStore {
 
   async readFile(
     path: string,
-  ): Promise<ReturnsError<Readable, StorageError | FileNotFoundError>> {
+  ): Promise<
+    ReturnsError<Readable, PathTraversalError | StorageError | FileNotFoundError>
+  > {
+    try {
+      this.getScopedPath(path);
+    } catch (error) {
+      if (error instanceof PathTraversalError) {
+        return { error };
+      }
+      throw error;
+    }
+
     const file = this.files.find((f) => f.path === path);
     if (!file) {
       return { error: new FileNotFoundError(path) };

--- a/openapi/docs/02-api-design.md
+++ b/openapi/docs/02-api-design.md
@@ -90,6 +90,80 @@ Resources should reference each other **by ID**, not by nesting. If a menu conta
 
 When a page needs to display resolved data (e.g. recipe titles inside a menu), the frontend fetches and joins them — or the API provides a dedicated endpoint that returns the resolved view (as a distinct schema, not by deeply nesting core resources).
 
+## Schema Layout: Inline Route Bodies, Named Business Objects
+
+Keep named schemas under `components.schemas` (or your spec's equivalent) reserved for **business objects** — the nouns your product talks about, like `Recipe`, `Menu`, `FileResource`. Don't promote per-route request or response envelopes to named schemas.
+
+### Define request and response bodies inline in the route
+
+Bodies that exist only to serve one endpoint should live **in that endpoint's route definition**, not as separate `CreateRecipeRequest` / `UpdateMenuRequest` / `ListRecipesResponse` schemas. Reuse named **business-object** schemas inside those inline definitions:
+
+```yaml
+# Good — inline request/response, referencing the Recipe business object
+createRecipe:
+  requestBody:
+    required: true
+    content:
+      application/json:
+        schema:
+          type: object
+          properties:
+            title: { type: string }
+            menuId: { type: string }
+          required: [title]
+  responses:
+    "201":
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              recipe:
+                $ref: "#/components/schemas/Recipe"
+            required: [recipe]
+```
+
+```yaml
+# Bad — two named schemas whose sole job is to wrap one endpoint
+components:
+  schemas:
+    CreateRecipeRequest: { ... }
+    CreateRecipeResponse: { ... }
+```
+
+Why:
+
+- **Named schemas become global vocabulary**. Every entry in `components.schemas` claims a name that now means something project-wide. Reserving that vocabulary for things the product actually reasons about (resources) keeps it meaningful.
+- **Route-specific envelopes change with the route**. Inlining puts the shape next to the handler/tests that enforce it, so edits don't ripple through a registry of one-off schemas.
+- **Response objects already tend to be thin wrappers** around a business object (`{ recipe: Recipe }`, `{ recipes: Recipe[] }`). Naming those wrappers is almost always noise.
+
+A **named** schema is the right call when:
+
+- It's a **business object** (a resource your app actually talks about — `Recipe`, `Menu`).
+- It's a **cross-route envelope** that multiple endpoints genuinely share (e.g. a common `Error` shape). If only two routes use it, it's probably still inline per route.
+
+A few specific patterns worth calling out:
+
+- **Response envelope of `{ resourceName: BusinessObject }`**: inline, `$ref` the business object.
+- **Per-route request body** with one or two fields: inline.
+- **Arrays/maps keyed by parent id** (batch-endpoint responses): inline the envelope, `$ref` the child business object.
+
+### Tolerate extra fields in requests to keep clients simple
+
+When a request body's shape overlaps with a business object (e.g. `PUT /packet-form-data/{id}` updates a few fields of `PacketFormData`), allow clients to send the **full business object** even when the endpoint only reads a subset. Fields the endpoint doesn't act on should be **silently ignored**, not rejected.
+
+This lets clients write straightforward code like:
+
+```ts
+await putPacketFormData(id, packetFormDataFromCache);
+```
+
+without having to manually project the object down to "only the fields the server actually writes." The server is still the authority on what gets persisted — it just doesn't make the client do bookkeeping to express that.
+
+Apply the same reasoning to agent-owned columns that share a shape with human-owned ones (e.g. `summary` vs `agentSummary`): if a PUT endpoint only writes the human field, it should accept — and ignore — the agent field when sent.
+
+Document the write-vs-ignore split in the route YAML's description so the intent is discoverable, but **don't** reject the request on the ignored fields.
+
 ## HTTP Status Codes
 
 Use status codes consistently so clients can distinguish **syntax errors** (bad request shape), **semantic/validation errors** (invalid references or business rules), **auth**, and **not found**.

--- a/openapi/workflows/templates/events/index.yaml
+++ b/openapi/workflows/templates/events/index.yaml
@@ -4,7 +4,7 @@ oneOf:
   - $ref: "./signup.yaml"
   - $ref: "./signup_view.yaml"
   - $ref: "./verify_email.yaml"
-  # BEGIN SORTED WORKFLOW AREA event-refs FOR openapi/add-event
+  # BEGIN WORKFLOW AREA event-refs FOR openapi/add-event
   - $ref: "./__target_name__.yaml"
   # END WORKFLOW AREA
 properties:

--- a/openapi/workflows/templates/index.ts
+++ b/openapi/workflows/templates/index.ts
@@ -14,7 +14,7 @@ export type __ServiceName__ServiceRequestBody = ExtractRequestBody<operations>;
 export type Error = components["schemas"]["Error"];
 export type ProductEvent = components["schemas"]["ProductEvent"];
 
-// BEGIN SORTED WORKFLOW AREA schema-exports FOR openapi/schema
+// BEGIN WORKFLOW AREA schema-exports FOR openapi/schema
 export type __TargetName__ = components["schemas"]["__TargetName__"];
 // END WORKFLOW AREA
 

--- a/ory-kratos-spa/fixtures.ts
+++ b/ory-kratos-spa/fixtures.ts
@@ -1,5 +1,5 @@
 // Re-export fixtures for each page here.
-// BEGIN SORTED WORKFLOW AREA fixture-exports FOR vue/add-view
+// BEGIN WORKFLOW AREA fixture-exports FOR vue/add-view
 export {
   LoginPageFixture,
   loginPageFixture,

--- a/ory-kratos-spa/pages/registration/registration.fixture.ts
+++ b/ory-kratos-spa/pages/registration/registration.fixture.ts
@@ -20,8 +20,16 @@ export class RegistrationPageFixture {
     return this.page.getByRole("textbox", { name: "E-Mail" });
   }
 
+  private get firstNameInput() {
+    return this.page.getByLabel("First name");
+  }
+
+  private get lastNameInput() {
+    return this.page.getByLabel("Last name");
+  }
+
   private get passwordInput() {
-    return this.page.locator("#kratos-login-2");
+    return this.page.getByRole("textbox", { name: "Password" });
   }
 
   private get signUpButton() {
@@ -42,6 +50,16 @@ export class RegistrationPageFixture {
     await this.passwordInput.fill(password);
   }
 
+  async fillFirstName(firstName: string): Promise<void> {
+    await this.firstNameInput.click();
+    await this.firstNameInput.fill(firstName);
+  }
+
+  async fillLastName(lastName: string): Promise<void> {
+    await this.lastNameInput.click();
+    await this.lastNameInput.fill(lastName);
+  }
+
   async submitPasswordStep(): Promise<void> {
     await this.signUpButton.click();
   }
@@ -52,6 +70,8 @@ export class RegistrationPageFixture {
   async completeRegistration(email: string, password: string): Promise<void> {
     await this.fillEmail(email);
     await this.submitEmailStep();
+    await this.fillFirstName("Test");
+    await this.fillLastName("User");
     await this.fillPassword(password);
     await this.submitPasswordStep();
   }

--- a/ory-kratos-spa/router.ts
+++ b/ory-kratos-spa/router.ts
@@ -3,7 +3,7 @@ import { createRouter, createWebHistory } from "vue-router";
 import { PageNotFound } from "@saflib/vue/components";
 import { authLinks } from "@saflib/ory-kratos-sdk/links";
 
-// BEGIN SORTED WORKFLOW AREA page-imports FOR vue/add-view
+// BEGIN WORKFLOW AREA page-imports FOR vue/add-view
 import loginAsync from "./pages/login/LoginAsync.vue";
 import newLoginAsync from "./pages/new-login/NewLoginAsync.vue";
 import settingsAsync from "./pages/settings/SettingsAsync.vue";

--- a/ory-kratos-spa/strings.ts
+++ b/ory-kratos-spa/strings.ts
@@ -1,4 +1,4 @@
-// BEGIN SORTED WORKFLOW AREA string-imports FOR vue/add-view sdk/add-component
+// BEGIN WORKFLOW AREA string-imports FOR vue/add-view sdk/add-component
 import { kratos_login_flow } from "./pages/login/LoginFlowForm.strings.ts";
 import { kratos_recovery_flow } from "./pages/recovery/RecoveryFlowForm.strings.ts";
 import { recovery_intro } from "./pages/recovery/RecoveryIntro.strings.ts";
@@ -26,7 +26,7 @@ import { verify_wall_verified_intro } from "./pages/verify-wall/VerifyWallVerifi
 // END WORKFLOW AREA
 
 export const auth_strings = {
-  // BEGIN SORTED WORKFLOW AREA string-object FOR vue/add-view sdk/add-component
+  // BEGIN WORKFLOW AREA string-object FOR vue/add-view sdk/add-component
   kratos_login_flow,
   kratos_recovery_flow,
   recovery_intro,

--- a/sdk/workflows/templates/fakes.ts
+++ b/sdk/workflows/templates/fakes.ts
@@ -1,24 +1,24 @@
-// BEGIN SORTED WORKFLOW AREA fake-group-imports FOR sdk/add-query sdk/add-mutation
+// BEGIN WORKFLOW AREA fake-group-imports FOR sdk/add-query sdk/add-mutation
 import { __groupName__FakeHandlers } from "./requests/__group-name__/index.fakes.ts";
 // END WORKFLOW AREA
 
-// BEGIN SORTED WORKFLOW AREA import-mocks FOR sdk/add-query sdk/add-mutation
+// BEGIN WORKFLOW AREA import-mocks FOR sdk/add-query sdk/add-mutation
 import { resetMocks as __groupName__ResetMocks } from "./requests/__group-name__/mocks.ts";
 // END WORKFLOW AREA
 
-// BEGIN SORTED WORKFLOW AREA mock-data-exports FOR sdk/add-query sdk/add-mutation
+// BEGIN WORKFLOW AREA mock-data-exports FOR sdk/add-query sdk/add-mutation
 export * from "./requests/__group-name__/mocks.ts";
 // END WORKFLOW AREA
 
 export const __serviceName__ServiceFakeHandlers = [
-  // BEGIN SORTED WORKFLOW AREA fake-group-handlers FOR sdk/add-query sdk/add-mutation
+  // BEGIN WORKFLOW AREA fake-group-handlers FOR sdk/add-query sdk/add-mutation
   ...__groupName__FakeHandlers,
   // END WORKFLOW AREA
 ];
 
 
 export const resetMocks = () => {
-  // BEGIN SORTED WORKFLOW AREA export-mocks FOR sdk/add-query sdk/add-mutation
+  // BEGIN WORKFLOW AREA export-mocks FOR sdk/add-query sdk/add-mutation
   __groupName__ResetMocks();
   // END WORKFLOW AREA
 };

--- a/sdk/workflows/templates/index.ts
+++ b/sdk/workflows/templates/index.ts
@@ -2,10 +2,10 @@
 // Since these packages can be large and shared, it's important to export everything independently,
 // rather than grouping them in an object and exporting that object, so they can be properly tree-shaken.
 
-// BEGIN SORTED WORKFLOW AREA query-group-exports FOR sdk/add-query sdk/add-mutation
+// BEGIN WORKFLOW AREA query-group-exports FOR sdk/add-query sdk/add-mutation
 export * from "./requests/__group-name__/index.ts";
 // END WORKFLOW AREA
 
-// BEGIN SORTED WORKFLOW AREA component-exports FOR sdk/add-component
+// BEGIN WORKFLOW AREA component-exports FOR sdk/add-component
 export * from "./__group-name__/__TargetName__.vue";
 // END WORKFLOW AREA

--- a/sdk/workflows/templates/requests/__group-name__/index.fakes.ts
+++ b/sdk/workflows/templates/requests/__group-name__/index.fakes.ts
@@ -1,18 +1,18 @@
-// BEGIN SORTED WORKFLOW AREA fake-handler-imports FOR sdk/add-query
+// BEGIN WORKFLOW AREA fake-handler-imports FOR sdk/add-query
 import { __queryName____GroupName__Handler } from "./__query-name__.fake.ts";
 // END WORKFLOW AREA
 
-// BEGIN SORTED WORKFLOW AREA mutation-handler-imports FOR sdk/add-mutation
+// BEGIN WORKFLOW AREA mutation-handler-imports FOR sdk/add-mutation
 import { __mutationName____GroupName__Handler } from "./__mutation-name__.fake.ts";
 // END WORKFLOW AREA
 
 // export all fake handlers for this group
 export const __groupName__FakeHandlers = [
-  // BEGIN SORTED WORKFLOW AREA fake-handler-array FOR sdk/add-query
+  // BEGIN WORKFLOW AREA fake-handler-array FOR sdk/add-query
   __queryName____GroupName__Handler,
   // END WORKFLOW AREA
 
-  // BEGIN SORTED WORKFLOW AREA mutation-handler-array FOR sdk/add-mutation
+  // BEGIN WORKFLOW AREA mutation-handler-array FOR sdk/add-mutation
   __mutationName____GroupName__Handler,
   // END WORKFLOW AREA
 ];

--- a/sdk/workflows/templates/requests/__group-name__/index.ts
+++ b/sdk/workflows/templates/requests/__group-name__/index.ts
@@ -1,6 +1,6 @@
-// BEGIN SORTED WORKFLOW AREA query-exports FOR sdk/add-query
+// BEGIN WORKFLOW AREA query-exports FOR sdk/add-query
 export * from "./__query-name__.ts";
 // END WORKFLOW AREA
-// BEGIN SORTED WORKFLOW AREA mutation-exports FOR sdk/add-mutation
+// BEGIN WORKFLOW AREA mutation-exports FOR sdk/add-mutation
 export * from "./__mutation-name__.ts";
 // END WORKFLOW AREA

--- a/sdk/workflows/templates/strings.ts
+++ b/sdk/workflows/templates/strings.ts
@@ -1,9 +1,9 @@
-// BEGIN SORTED WORKFLOW AREA string-imports FOR vue/add-view sdk/add-component
+// BEGIN WORKFLOW AREA string-imports FOR vue/add-view sdk/add-component
 import { __full_name___strings } from "./__group-name__/__TargetName__.strings.ts";
 // END WORKFLOW AREA
 
 export const __product_name___sdk_strings = {
-  // BEGIN SORTED WORKFLOW AREA string-object FOR vue/add-view sdk/add-component
+  // BEGIN WORKFLOW AREA string-object FOR vue/add-view sdk/add-component
   __full_name___strings,
   // END WORKFLOW AREA
 };

--- a/service/workflows/common-templates/context.ts
+++ b/service/workflows/common-templates/context.ts
@@ -1,14 +1,14 @@
 import { AsyncLocalStorage } from "async_hooks";
 import type { DbKey } from "@saflib/drizzle";
 import { __serviceName__Db } from "template-package-db";
-// BEGIN SORTED WORKFLOW AREA storeImports FOR service/add-store
+// BEGIN WORKFLOW AREA storeImports FOR service/add-store
 import { createObjectStore } from "@saflib/object-store";
 import type { ObjectStore } from "@saflib/object-store";
 // END WORKFLOW AREA
 
 export interface __ServiceName__ServiceContext {
   __serviceName__DbKey: DbKey;
-  // BEGIN SORTED WORKFLOW AREA storeProperties FOR service/add-store
+  // BEGIN WORKFLOW AREA storeProperties FOR service/add-store
   __storeName__: ObjectStore;
   // END WORKFLOW AREA
 }
@@ -18,7 +18,7 @@ export const __serviceName__ServiceStorage =
 
 export interface __ServiceName__ServiceContextOptions {
   __serviceName__DbKey?: DbKey;
-  // BEGIN SORTED WORKFLOW AREA storeOptions FOR service/add-store
+  // BEGIN WORKFLOW AREA storeOptions FOR service/add-store
   __storeName__?: ObjectStore;
   // END WORKFLOW AREA
 }
@@ -33,7 +33,7 @@ export const makeContext = (
   // END WORKFLOW AREA
   return {
     __serviceName__DbKey: dbKey,
-    // BEGIN SORTED WORKFLOW AREA storeReturn FOR service/add-store
+    // BEGIN WORKFLOW AREA storeReturn FOR service/add-store
     __storeName__,
     // END WORKFLOW AREA
   };

--- a/service/workflows/index.ts
+++ b/service/workflows/index.ts
@@ -1,4 +1,4 @@
-// BEGIN SORTED WORKFLOW AREA workflow-imports FOR workflows/add-workflow
+// BEGIN WORKFLOW AREA workflow-imports FOR workflows/add-workflow
 import { InitServiceWorkflowDefinition } from "./init.ts";
 import { ServiceAddStoreWorkflowDefinition } from "./add-store.ts";
 // END WORKFLOW AREA
@@ -6,14 +6,14 @@ import { ServiceAddStoreWorkflowDefinition } from "./add-store.ts";
 import type { WorkflowDefinition } from "@saflib/workflows";
 
 export {
-  // BEGIN SORTED WORKFLOW AREA workflow-exports FOR workflows/add-workflow
+  // BEGIN WORKFLOW AREA workflow-exports FOR workflows/add-workflow
   InitServiceWorkflowDefinition,
   ServiceAddStoreWorkflowDefinition,
   // END WORKFLOW AREA
 };
 
 const serviceWorkflowDefinitions: WorkflowDefinition[] = [
-  // BEGIN SORTED WORKFLOW AREA workflow-array FOR workflows/add-workflow
+  // BEGIN WORKFLOW AREA workflow-array FOR workflows/add-workflow
   InitServiceWorkflowDefinition,
   ServiceAddStoreWorkflowDefinition,
   // END WORKFLOW AREA

--- a/vue/docs/01-overview.md
+++ b/vue/docs/01-overview.md
@@ -77,7 +77,7 @@ _[Template file](../workflows/spa-template/i18n.ts)_
 
 Each page and component in this package should call `const { t } = useReverseT()` and use the `t` function to translate strings. Note that this is separate from `strings.ts` to avoid external packages that depend on `strings.ts` also depending on Vue I18n and co.
 
-For more information on using this in pages, and why it's set up this way, see [i18n](./03-i18n.md).
+For more information on using this in pages, and why it's set up this way, see [i18n](./03-i18n.md). For dynamic values in translated copy, follow [interpolation](./03-i18n.md#interpolation-dynamic-values-in-copy) (`{name}` in strings, `t(strings.key, { name: value })`, not Mustache `{{name}}` inside `t()` messages).
 
 ### `main.ts`
 

--- a/vue/docs/02-components.md
+++ b/vue/docs/02-components.md
@@ -104,7 +104,7 @@ By keeping them in separate files, they can be exported and used by processes wh
 
 **Duplication across components is fine.** If a create form and an edit form use the same labels, each should have its own strings file with its own copy. They get separate i18n keys (e.g. `create_menu_form.name_label` vs `menu_edit_form.name_label`), which means they can be translated independently per context — even if the English text is identical. Don't try to share strings across routes or components to reduce duplication; the added import complexity and path fragility isn't worth it.
 
-For localization, see [i18n](./03-i18n.md).
+For localization, see [i18n](./03-i18n.md), including [how to interpolate values](./03-i18n.md#interpolation-dynamic-values-in-copy) without breaking production message compilation.
 
 ### Logic Files: Pure Business Logic
 

--- a/vue/docs/02-components.md
+++ b/vue/docs/02-components.md
@@ -211,7 +211,11 @@ Sub-components should **not** have overly complicated prop/emit interfaces. Prop
 - **Loader data** — the data the view already loaded (passed as plain values or objects, not refs).
 - **Simple display state** — booleans, IDs, or other scalar values that control rendering.
 
-For everything else — mutations, multi-step flows, stateful editing/deleting/uploading — the sub-component should call the relevant **composable directly** in its own `<script setup>`. Do not pass flow objects, refs, or mutation callbacks through props.
+Do **not** pass query **loading** or **error** state down from the parent for data the page loader already owns. The `*Async.vue` wrapper’s `AsyncPage` blocks on the loader’s queries and surfaces fetch failures; by the time the page and its sub-components render, that data path is the happy path. (Optimizing for JIT loading of some loader queries is a separate decision—when in doubt, keep related queries in the page loader so sibling UI can reuse the same data without prop-drilling query objects.)
+
+Do **not** pass **mutations** through props either—the child calls TanStack mutation hooks (or a local composable) directly. Mutation **in-flight / error UI** for those actions (e.g. a submit button `:loading` or an inline alert on a failed create) stays in the component that owns the mutation; that is different from page-level query loading/errors above.
+
+For everything else — multi-step flows or orchestration that is not “fire this mutation with props I already have” — the sub-component should call the relevant **composable directly** in its own `<script setup>`. Do not pass flow objects, refs, or mutation callbacks through props.
 
 For example, if a `NoteCard` needs to edit and delete notes, it should call `useDetailNotesFlow()` itself rather than receiving an object with `editingNoteId`, `editBody`, `startEditNote`, `saveEditNote`, etc. as props. This avoids:
 

--- a/vue/docs/03-i18n.md
+++ b/vue/docs/03-i18n.md
@@ -34,6 +34,29 @@ Looking up strings by value provides a few key benefits:
 
 Because behind the scenes the lookups are still using vue-i18n's `t` function, you still get all the vue-i18n features.
 
+## Interpolation (dynamic values in copy)
+
+Messages are compiled with Vue I18n’s **message syntax** (ICU-style). Placeholders use **a single pair of braces** per name: `{count}`, `{email}`, `{userName}`.
+
+**Do not** use Mustache-style `{{name}}` inside strings that go through `t(...)`. Double braces are invalid for the message compiler and tend to fail in **production builds** (AOT compilation) while sometimes appearing to work in Vite dev mode.
+
+**Do** pass values as the second argument to `t`:
+
+```ts
+// strings.ts
+export const example = {
+  itemsFound: "{count} items found",
+};
+
+// Component
+const { t } = useReverseT();
+const caption = computed(() =>
+  t(example.itemsFound, { count: props.items.length }),
+);
+```
+
+For richer cases (pluralization, linked messages, HTML), see the [Vue I18n message syntax](https://vue-i18n.intlify.dev/guide/essentials/syntax.html) docs.
+
 The reverse-t function also handles flat objects, for seamless binding to HTML elements.
 
 ```ts

--- a/vue/src/strings.ts
+++ b/vue/src/strings.ts
@@ -50,6 +50,8 @@ export interface I18NObject {
 
 /**
  * Creates an alternative to Vue I18n's $t function, which takes the English text instead of a key. This is mainly so TypeScript enforces that keys are translated to strings.
+ *
+ * For strings with placeholders, use vue-i18n message syntax (`{name}` in the English string) and call `t(englishString, { name: value })`. Do not use `{{name}}` inside messages passed to `t` — it is invalid for the message compiler (often only fails in production builds).
  */
 export const makeReverseTComposable = (strings: I18nMessages) => {
   const stringToKeyMap = makeStringToKeyMap(strings);

--- a/vue/src/strings.ts
+++ b/vue/src/strings.ts
@@ -60,13 +60,20 @@ export const makeReverseTComposable = (strings: I18nMessages) => {
     };
     // Function overloads to preserve input type
     function wrappedT(s: string): string;
+    function wrappedT(s: string, values: Record<string, unknown>): string;
     function wrappedT(s: I18NObject): I18NObject;
-    function wrappedT(s: string | I18NObject): string | I18NObject {
+    function wrappedT(
+      s: string | I18NObject,
+      values?: Record<string, unknown>,
+    ): string | I18NObject {
       if (typeof s === "string") {
-        return stringToKeyMap.get(s) ? t(lookupTKey(s)) : s;
-      } else {
-        return tObject(s);
+        if (!stringToKeyMap.get(s)) return s;
+        const key = lookupTKey(s);
+        return values !== undefined
+          ? (t(key, values) as string)
+          : (t(key) as string);
       }
+      return tObject(s);
     }
     const tObject = (o: I18NObject): I18NObject => {
       return Object.fromEntries(

--- a/vue/workflows/add-view.ts
+++ b/vue/workflows/add-view.ts
@@ -118,6 +118,7 @@ export const AddSpaViewWorkflowDefinition = defineWorkflow<
 
   docFiles: {
     components: path.join(import.meta.dirname, "../docs", "02-components.md"),
+    i18n: path.join(import.meta.dirname, "../docs", "03-i18n.md"),
   },
 
   versionControl: {
@@ -158,9 +159,9 @@ export const AddSpaViewWorkflowDefinition = defineWorkflow<
       * Take the data from the loader, assert that it's loaded, and render the page.
       * Do not add any sort of loading state or skeleton; that's the job of the "Async" component (and \`AsyncPage\` for query errors). Sub-components should receive **values to render** (e.g. lists, labels), not query \`isPending\`/\`isError\` or raw query objects—unless you have deliberately split loading (JIT) and documented it.
       * Don't break reactivity! Render the data directly from the tanstack queries, or if necessary create a computed property.
-      * Import and use the "useReverseT" function from the i18n.ts file at the root of the package, and use t(strings.key) instead of strings.key for all text.
+      * Import and use the "useReverseT" function from the i18n.ts file at the root of the package, and use t(strings.key) instead of strings.key for all text. If copy needs runtime values, use vue-i18n placeholders in the string (\`{name}\`, not \`{{name}}\`) and call \`t(strings.key, { name: value })\` — see **Interpolation** in ${context.docFiles?.i18n}.
       
-      For more information, see ${context.docFiles?.components}`,
+      For more information, see ${context.docFiles?.components} and ${context.docFiles?.i18n}.`,
     })),
 
     step(PromptStepMachine, ({ context }) => ({
@@ -209,7 +210,9 @@ Run \`npm run typecheck\` in ${context.cwd} to verify the code is type-safe.
 
 * **Strings**: Each sub-component gets its own \`.strings.ts\` file (e.g. \`MyDialog.strings.ts\`).
   Don't pile all strings into the view's strings file. Remember to do this if you opt to break
-  a vue file into sub-components.
+  a vue file into sub-components. Interpolation in \`.strings.ts\` must use vue-i18n form:
+  \`{placeholder}\` in the English string and \`t(strings.key, { placeholder: value })\` in the
+  component — never \`{{placeholder}}\` (breaks message compilation in production builds).
 * **Sub-component interfaces**: Keep them simple. Props = **render data** from the loader (plain
   values) + simple display state (booleans, IDs). Omit loader query **loading/errors** for that
   data—the \`*Async\` page owns fetch UX. Omit **mutation instances** passed from parents; the
@@ -225,7 +228,7 @@ Run \`npm run typecheck\` in ${context.cwd} to verify the code is type-safe.
 * **Deciding What to Test**: Don't extract simple logic just to test it. We already have tests for each tanstack query, so there's no need to pull that into a separate composable either. Save testing for more complex logic, for example when multiple or tanstack queries are used together.
 * **When NOT to extract a composable**: A single mutation + local UI state (e.g. edit form + one save, delete + redirect) can stay in the component. Composables are for multi-step or shared flows.
 
-For more information, see ${context.docFiles?.components}`,
+For more information, see ${context.docFiles?.components} and ${context.docFiles?.i18n}.`,
     })),
 
     step(CommandStepMachine, () => ({

--- a/vue/workflows/add-view.ts
+++ b/vue/workflows/add-view.ts
@@ -156,7 +156,7 @@ export const AddSpaViewWorkflowDefinition = defineWorkflow<
       * Use the adjacent (${path.basename(context.copiedFiles!.loader)}) to add Tanstack queries for any data needed to render the page (the Tanstack queries are imported from the appropriate sdk package)
       * Use the adjacent (${path.basename(context.copiedFiles!.strings)}) for all user-facing copy.
       * Take the data from the loader, assert that it's loaded, and render the page.
-      * Do not add any sort of loading state or skeleton; that's the job of the "Async" component.
+      * Do not add any sort of loading state or skeleton; that's the job of the "Async" component (and \`AsyncPage\` for query errors). Sub-components should receive **values to render** (e.g. lists, labels), not query \`isPending\`/\`isError\` or raw query objects—unless you have deliberately split loading (JIT) and documented it.
       * Don't break reactivity! Render the data directly from the tanstack queries, or if necessary create a computed property.
       * Import and use the "useReverseT" function from the i18n.ts file at the root of the package, and use t(strings.key) instead of strings.key for all text.
       
@@ -172,7 +172,7 @@ Review the view you worked on, then break out:
 
 Extract sub-components from the view. Sub-components should be small, focused components that are used to render a part of the view. They should be in the same directory as the view.
 
-**Important**: Sub-components should have simple prop interfaces — pass only loader data and simple display state through props. If a sub-component needs mutations or stateful flows (editing, deleting, uploading), it should call the relevant composable **directly** inside its own \`<script setup>\`, not receive a flow object or mutation callbacks through props. This keeps parent-child interfaces clean and avoids awkward ref-unwrapping in templates.
+**Important**: Sub-components should have simple prop interfaces — pass **data needed to render** (resolved values from the loader: models, arrays, strings) and simple display state (booleans, IDs). Do **not** pass query loading/error flags for loader-owned data (\`AsyncPage\` already gates the route on the loader). Do **not** pass TanStack **mutations** as props; the child calls \`useMutation\` / a composable **directly** in its own \`<script setup>\` (button \`:loading\` from that mutation is fine—it is not the same as page fetch loading). Do not receive flow objects or mutation callbacks through props. This keeps parent-child interfaces clean and avoids awkward ref-unwrapping in templates.
 
 ## 1. Logic files (\`ComponentName.logic.ts\`)
 
@@ -210,12 +210,14 @@ Run \`npm run typecheck\` in ${context.cwd} to verify the code is type-safe.
 * **Strings**: Each sub-component gets its own \`.strings.ts\` file (e.g. \`MyDialog.strings.ts\`).
   Don't pile all strings into the view's strings file. Remember to do this if you opt to break
   a vue file into sub-components.
-* **Sub-component interfaces**: Keep them simple. Props should be limited to loader data and
-  simple display state (booleans, IDs, etc.). Sub-components should call composables and
+* **Sub-component interfaces**: Keep them simple. Props = **render data** from the loader (plain
+  values) + simple display state (booleans, IDs). Omit loader query **loading/errors** for that
+  data—the \`*Async\` page owns fetch UX. Omit **mutation instances** passed from parents; the
+  child imports mutations or a small composable instead. Sub-components should call composables and
   TanStack mutations **directly** in their own \`<script setup>\` rather than receiving flow
   objects, refs, or mutation callbacks through props. This avoids ref-unwrapping issues in
   templates and keeps parent-child interfaces focused on **what to render**, not
-  **how to orchestrate**.
+  **how to orchestrate** (except local mutation wiring, which stays inside the child).
 * **Render test**: Update the generated \`${context.targetName}.test.ts\` as necessary — This smoke
   test drives baseline coverage on the Vue file; uncovered lines highlight logic worth extracting.
   Don't add interaction tests here — Playwright covers that. Focus deeper tests on the extracted

--- a/vue/workflows/index.ts
+++ b/vue/workflows/index.ts
@@ -1,4 +1,4 @@
-// BEGIN SORTED WORKFLOW AREA workflow-imports FOR workflows/add-workflow
+// BEGIN WORKFLOW AREA workflow-imports FOR workflows/add-workflow
 import { AddE2eTestWorkflowDefinition } from "./add-e2e-test.ts";
 import { AddSpaViewWorkflowDefinition } from "./add-view.ts";
 import { AddSpaWorkflowDefinition } from "./add-spa.ts";
@@ -8,7 +8,7 @@ import { AddStaticSiteWorkflowDefinition } from "./add-static-site.ts";
 import type { WorkflowDefinition } from "@saflib/workflows";
 
 export {
-  // BEGIN SORTED WORKFLOW AREA workflow-exports FOR workflows/add-workflow
+  // BEGIN WORKFLOW AREA workflow-exports FOR workflows/add-workflow
   AddE2eTestWorkflowDefinition,
   AddSpaViewWorkflowDefinition,
   AddSpaWorkflowDefinition,
@@ -17,7 +17,7 @@ export {
 };
 
 const workflowDefinitions: WorkflowDefinition[] = [
-  // BEGIN SORTED WORKFLOW AREA workflow-array FOR workflows/add-workflow
+  // BEGIN WORKFLOW AREA workflow-array FOR workflows/add-workflow
   AddE2eTestWorkflowDefinition,
   AddSpaViewWorkflowDefinition,
   AddSpaWorkflowDefinition,

--- a/vue/workflows/template/__subdomain-name__/__group-name__/__TargetName__.strings.ts
+++ b/vue/workflows/template/__subdomain-name__/__group-name__/__TargetName__.strings.ts
@@ -11,6 +11,7 @@ export const __full_name__ = {
     label: "Enter your name",
   },
 
+  // Interpolation: single braces `{name}` (vue-i18n). Do not use `{{name}}` in strings passed to t() — breaks prod message compilation.
   logged_in_with_email: "Logged in with {email}",
   not_logged_in: "Not logged in",
 };

--- a/vue/workflows/template/__subdomain-name__/fixtures.ts
+++ b/vue/workflows/template/__subdomain-name__/fixtures.ts
@@ -1,3 +1,3 @@
 // Re-export fixtures for each page here.
-// BEGIN SORTED WORKFLOW AREA fixture-exports FOR vue/add-view
+// BEGIN WORKFLOW AREA fixture-exports FOR vue/add-view
 // END WORKFLOW AREA

--- a/vue/workflows/template/__subdomain-name__/router.ts
+++ b/vue/workflows/template/__subdomain-name__/router.ts
@@ -10,7 +10,7 @@ import { PageNotFound } from "@saflib/vue/components";
 // TODO: remove this log once __subdomainName__Links is being used by the routes
 console.log("__subdomainName__Links:", __subdomainName__Links);
 
-// BEGIN SORTED WORKFLOW AREA page-imports FOR vue/add-view
+// BEGIN WORKFLOW AREA page-imports FOR vue/add-view
 import __FullName__Async from "./__group-name__/__TargetName__Async.vue";
 // END WORKFLOW AREA
 

--- a/vue/workflows/template/__subdomain-name__/strings.ts
+++ b/vue/workflows/template/__subdomain-name__/strings.ts
@@ -1,12 +1,12 @@
 import { __product_name___common_strings } from "../common/strings.ts";
 
-// BEGIN SORTED WORKFLOW AREA string-imports FOR vue/add-view sdk/add-component
+// BEGIN WORKFLOW AREA string-imports FOR vue/add-view sdk/add-component
 import { __full_name__ } from "./__group-name__/__TargetName__.strings.ts";
 // END WORKFLOW AREA
 
 export const __subdomain_name___strings = {
   ...__product_name___common_strings,
-  // BEGIN SORTED WORKFLOW AREA string-object FOR vue/add-view sdk/add-component
+  // BEGIN WORKFLOW AREA string-object FOR vue/add-view sdk/add-component
   __full_name__,
   // END WORKFLOW AREA
 };

--- a/vue/workflows/template/links/index.ts
+++ b/vue/workflows/template/links/index.ts
@@ -1,3 +1,3 @@
-// BEGIN SORTED WORKFLOW AREA subdomain-links FOR vue/add-spa vue/add-static-site
+// BEGIN WORKFLOW AREA subdomain-links FOR vue/add-spa vue/add-static-site
 export { __subdomainName__Links } from "./__subdomain-name__-links.ts";
 // END WORKFLOW AREA

--- a/workflows/bin/saf-workflow/kickoff.ts
+++ b/workflows/bin/saf-workflow/kickoff.ts
@@ -67,7 +67,7 @@ export const addKickoffCommand = (commandOptions: WorkflowCommandOptions) => {
         });
         if (givenRunMode === "run") {
           addPendingMessage(
-            "You are going through a well-defined developer workflow specific to this codebase and project. You will receive logs and prompts, please follow them to the best of your ability. If you need to halt the workflow because of a blocker, please include the --- HALT WORKFLOW --- string in your final response. If you mention that you don't need to halt the workflow, don't cite the string that halts the workflow though...\n",
+            "You are going through a well-defined developer workflow specific to this codebase and project. You will receive logs and prompts, please follow them to the best of your ability.\n",
           );
           if (commandOptions.systemPrompt) {
             addPendingMessage(`${commandOptions.systemPrompt}\n`);

--- a/workflows/core/agents/cursor-agent.ts
+++ b/workflows/core/agents/cursor-agent.ts
@@ -7,8 +7,6 @@ import { popPendingMessages } from "./message.ts";
 import { logFile, type CostTsvRow, appendToCostFile } from "./log.ts";
 import { addTimeMs, getPercentTimeUsed, getTimeMs } from "./timeout.ts";
 
-const HALT_WORKFLOW_STRING = "--- HALT WORKFLOW ---";
-
 interface CursorSystemLog {
   type: "system";
   session_id: string;
@@ -223,7 +221,6 @@ export const executePromptWithCursor = async ({
   // set up a promise to resolve when the agent is done
   let resolve: (value: PromptResult) => void;
   let reject: (reason?: any) => void;
-  let halt = false;
   const p = new Promise<PromptResult>((r, rej) => {
     resolve = r;
     reject = rej;
@@ -458,13 +455,8 @@ export const executePromptWithCursor = async ({
         printLineSlowly("\n---------- RESULT ---------- " + shortTimestamp());
         printLineSlowly(`> ${json.is_error ? "Error" : "Success"}`);
         resultReceived = true;
-        halt = json.result.includes(HALT_WORKFLOW_STRING);
         if (pipeClosed) {
-          if (halt) {
-            reject(new Error("Workflow halted"));
-          } else {
-            resolve(response);
-          }
+          resolve(response);
         }
       }
     }
@@ -509,11 +501,7 @@ export const executePromptWithCursor = async ({
     response.shouldContinue = shouldContinue;
     pipeClosed = true;
     if (resultReceived) {
-      if (halt) {
-        reject(new Error("Workflow halted"));
-      } else {
-        resolve(response);
-      }
+      resolve(response);
     }
   });
   return p;

--- a/workflows/core/agents/cursor-agent.ts
+++ b/workflows/core/agents/cursor-agent.ts
@@ -220,10 +220,8 @@ export const executePromptWithCursor = async ({
 
   // set up a promise to resolve when the agent is done
   let resolve: (value: PromptResult) => void;
-  let reject: (reason?: any) => void;
-  const p = new Promise<PromptResult>((r, rej) => {
+  const p = new Promise<PromptResult>((r) => {
     resolve = r;
-    reject = rej;
   });
 
   // prepending pending messages to the message

--- a/workflows/core/make.ts
+++ b/workflows/core/make.ts
@@ -26,7 +26,7 @@ import { addNewLinesToString } from "@saflib/utils";
 import { getWorkflowLogger } from "./store.ts";
 import { addPendingMessage } from "./agents/message.ts";
 
-import { handleGitChanges, commitChanges } from "./version/git.ts";
+import { commitChanges } from "./version/git.ts";
 import { resetTimeMs } from "./agents/timeout.ts";
 
 let lastSystemPrompt: string | undefined;
@@ -189,31 +189,31 @@ function _makeWorkflowMachine<I extends readonly WorkflowArgument[], C>(
           const lastChecklistDescription =
             input.checklist[input.checklist.length - 1]?.description;
 
-          if (input.manageVersionControl) {
-            let allowPaths:
-              | string[]
-              | ((context: Context) => string[])
-              | undefined = undefined;
-            if (typeof workflow.versionControl?.allowPaths === "function") {
-              allowPaths = workflow.versionControl.allowPaths({
-                context: input,
-              });
-            } else {
-              allowPaths = workflow.versionControl?.allowPaths;
-            }
-            if (!allowPaths) {
-              allowPaths = [`${input.cwd}/**`];
-            }
-            const successful = await handleGitChanges({
-              workflowId: workflow.id,
-              context: input,
-              checklistDescription: lastChecklistDescription,
-              allowPaths,
-            });
-            if (!successful) {
-              throw new Error("Failed to handle git changes");
-            }
-          }
+          // if (input.manageVersionControl) {
+          //   let allowPaths:
+          //     | string[]
+          //     | ((context: Context) => string[])
+          //     | undefined = undefined;
+          //   if (typeof workflow.versionControl?.allowPaths === "function") {
+          //     allowPaths = workflow.versionControl.allowPaths({
+          //       context: input,
+          //     });
+          //   } else {
+          //     allowPaths = workflow.versionControl?.allowPaths;
+          //   }
+          //   if (!allowPaths) {
+          //     allowPaths = [`${input.cwd}/**`];
+          //   }
+          //   const successful = await handleGitChanges({
+          //     workflowId: workflow.id,
+          //     context: input,
+          //     checklistDescription: lastChecklistDescription,
+          //     allowPaths,
+          //   });
+          //   if (!successful) {
+          //     throw new Error("Failed to handle git changes");
+          //   }
+          // }
 
           if (step.validate) {
             const output = await step.validate({ context: input });

--- a/workflows/core/steps/copy/inline/parse.test.ts
+++ b/workflows/core/steps/copy/inline/parse.test.ts
@@ -29,13 +29,13 @@ describe("parseWorkflowAreaStart", () => {
     });
   });
 
-  it("parses SORTED WORKFLOW AREA", () => {
+  it("parses BEGIN WORKFLOW AREA with multiple workflow IDs", () => {
     const line = "// BEGIN WORKFLOW AREA area2 FOR workflow1 workflow2";
     const parsed = parseWorkflowAreaStart(line);
     expect(parsed).toEqual({
       areaName: "area2",
       workflowIds: ["workflow1", "workflow2"],
-      isSorted: true,
+      isSorted: false,
       isOnce: false,
       ifFlag: undefined,
       fullLine: line,

--- a/workflows/core/steps/copy/inline/parse.test.ts
+++ b/workflows/core/steps/copy/inline/parse.test.ts
@@ -30,7 +30,7 @@ describe("parseWorkflowAreaStart", () => {
   });
 
   it("parses SORTED WORKFLOW AREA", () => {
-    const line = "// BEGIN SORTED WORKFLOW AREA area2 FOR workflow1 workflow2";
+    const line = "// BEGIN WORKFLOW AREA area2 FOR workflow1 workflow2";
     const parsed = parseWorkflowAreaStart(line);
     expect(parsed).toEqual({
       areaName: "area2",

--- a/workflows/core/steps/copy/inline/update.test.ts
+++ b/workflows/core/steps/copy/inline/update.test.ts
@@ -231,7 +231,7 @@ describe("updateWorkflowAreas", () => {
     ]);
   });
 
-  it("sorted: sorts and deduplicates lines", () => {
+  it("non-sorted: appends full source block when sequence is not consecutive (may duplicate lines)", () => {
     const result = updateWorkflowAreas({
       targetLines: [
         "// BEGIN WORKFLOW AREA myArea FOR workflow1",
@@ -255,6 +255,7 @@ describe("updateWorkflowAreas", () => {
       "  apple",
       "  monkey",
       "  zebra",
+      "  apple",
       "// END WORKFLOW AREA",
     ]);
   });

--- a/workflows/core/steps/copy/inline/update.test.ts
+++ b/workflows/core/steps/copy/inline/update.test.ts
@@ -234,14 +234,14 @@ describe("updateWorkflowAreas", () => {
   it("sorted: sorts and deduplicates lines", () => {
     const result = updateWorkflowAreas({
       targetLines: [
-        "// BEGIN SORTED WORKFLOW AREA myArea FOR workflow1",
+        "// BEGIN WORKFLOW AREA myArea FOR workflow1",
         "  apple",
         "  monkey",
         "// END WORKFLOW AREA",
       ],
       targetPath: "test.ts",
       sourceLines: [
-        "// BEGIN SORTED WORKFLOW AREA myArea FOR workflow1",
+        "// BEGIN WORKFLOW AREA myArea FOR workflow1",
         "  zebra",
         "  apple",
         "// END WORKFLOW AREA",
@@ -251,7 +251,7 @@ describe("updateWorkflowAreas", () => {
     });
 
     expect(result).toEqual([
-      "// BEGIN SORTED WORKFLOW AREA myArea FOR workflow1",
+      "// BEGIN WORKFLOW AREA myArea FOR workflow1",
       "  apple",
       "  monkey",
       "  zebra",

--- a/workflows/core/steps/copy/inline/validate.test.ts
+++ b/workflows/core/steps/copy/inline/validate.test.ts
@@ -51,7 +51,7 @@ describe("extractWorkflowAreas", () => {
       "// BEGIN WORKFLOW AREA area1 FOR workflow1",
       "  code1",
       "// END WORKFLOW AREA",
-      "// BEGIN SORTED WORKFLOW AREA area2 FOR workflow1 workflow2",
+      "// BEGIN WORKFLOW AREA area2 FOR workflow1 workflow2",
       "  code2",
       "// END WORKFLOW AREA",
     ];
@@ -334,7 +334,7 @@ describe("validateWorkflowAreas", () => {
       "// END WORKFLOW AREA",
     ];
     const target = [
-      "// BEGIN SORTED WORKFLOW AREA myArea FOR workflow1",
+      "// BEGIN WORKFLOW AREA myArea FOR workflow1",
       "  existing",
       "// END WORKFLOW AREA",
     ];

--- a/workflows/core/steps/copy/inline/validate.test.ts
+++ b/workflows/core/steps/copy/inline/validate.test.ts
@@ -60,7 +60,7 @@ describe("extractWorkflowAreas", () => {
     expect(areas[0].areaName).toBe("area1");
     expect(areas[0].isSorted).toBe(false);
     expect(areas[1].areaName).toBe("area2");
-    expect(areas[1].isSorted).toBe(true);
+    expect(areas[1].isSorted).toBe(false);
     expect(areas[1].workflowIds).toEqual(["workflow1", "workflow2"]);
   });
 
@@ -325,26 +325,6 @@ describe("validateWorkflowAreas", () => {
         ...ctx,
       }),
     ).toThrow(/without matching END marker/);
-  });
-
-  it("throws when areas differ in sorted status (different keys)", () => {
-    const source = [
-      "// BEGIN WORKFLOW AREA myArea FOR workflow1",
-      "  code",
-      "// END WORKFLOW AREA",
-    ];
-    const target = [
-      "// BEGIN WORKFLOW AREA myArea FOR workflow1",
-      "  existing",
-      "// END WORKFLOW AREA",
-    ];
-    expect(() =>
-      validateWorkflowAreas({
-        sourceLines: source,
-        targetLines: target,
-        ...ctx,
-      }),
-    ).toThrow();
   });
 
   it("throws when areas differ in workflow IDs (different keys)", () => {

--- a/workflows/core/steps/copy/rename-next-file.test.ts
+++ b/workflows/core/steps/copy/rename-next-file.test.ts
@@ -160,7 +160,7 @@ describe("processFileContent", () => {
 
   it("should handle SORTED WORKFLOW AREA", () => {
     const contentLines = [
-      "// BEGIN SORTED WORKFLOW AREA myArea FOR workflow1",
+      "// BEGIN WORKFLOW AREA myArea FOR workflow1",
       "  code",
       "// END WORKFLOW AREA",
     ];
@@ -171,7 +171,7 @@ describe("processFileContent", () => {
     });
 
     expect(result).toEqual([
-      "// BEGIN SORTED WORKFLOW AREA myArea FOR workflow1",
+      "// BEGIN WORKFLOW AREA myArea FOR workflow1",
       "  code",
       "// END WORKFLOW AREA",
     ]);

--- a/workflows/workflows/index.ts
+++ b/workflows/workflows/index.ts
@@ -1,16 +1,16 @@
-// BEGIN SORTED WORKFLOW AREA workflow-imports FOR workflows/add-workflow
+// BEGIN WORKFLOW AREA workflow-imports FOR workflows/add-workflow
 import { AddWorkflowDefinition } from "./add-workflow.ts";
 // END WORKFLOW AREA
 import type { WorkflowDefinition } from "../core/index.ts";
 
 const workflowClasses: WorkflowDefinition[] = [
-  // BEGIN SORTED WORKFLOW AREA workflow-exports FOR workflows/add-workflow
+  // BEGIN WORKFLOW AREA workflow-exports FOR workflows/add-workflow
   AddWorkflowDefinition,
   // END WORKFLOW AREA
 ];
 
 export {
-  // BEGIN SORTED WORKFLOW AREA workflow-array FOR workflows/add-workflow
+  // BEGIN WORKFLOW AREA workflow-array FOR workflows/add-workflow
   AddWorkflowDefinition,
   // END WORKFLOW AREA
 };

--- a/workflows/workflows/templates/index.ts
+++ b/workflows/workflows/templates/index.ts
@@ -1,17 +1,17 @@
-// BEGIN SORTED WORKFLOW AREA workflow-imports FOR workflows/add-workflow
+// BEGIN WORKFLOW AREA workflow-imports FOR workflows/add-workflow
 import { __WorkflowNamespace____TargetName__WorkflowDefinition } from "./__target-name__.ts";
 // END WORKFLOW AREA
 
 import type { WorkflowDefinition } from "@saflib/workflows";
 
 export {
-  // BEGIN SORTED WORKFLOW AREA workflow-exports FOR workflows/add-workflow
+  // BEGIN WORKFLOW AREA workflow-exports FOR workflows/add-workflow
   __WorkflowNamespace____TargetName__WorkflowDefinition,
   // END WORKFLOW AREA
 };
 
 const __WorkflowNamespace__WorkflowDefinitions: WorkflowDefinition[] = [
-  // BEGIN SORTED WORKFLOW AREA workflow-array FOR workflows/add-workflow
+  // BEGIN WORKFLOW AREA workflow-array FOR workflows/add-workflow
   __WorkflowNamespace____TargetName__WorkflowDefinition,
   // END WORKFLOW AREA
 ];


### PR DESCRIPTION
Handful of updates from working on products.

* Shored up cron packages, in particular making it agents are prompted to hook things together when running cron/init
* Remove sorted workflows. They're not that important, and they lead to bugs, and it'd more trouble than it's worth to fix
* Tweak drizzle workflow to specify error subclasses. One agent got confused.
* Tweak test object store. I forget why.
* Make some additions to the api design doc, in particular discouraging having separate schemas for specific requests/responses.
* Fix registration fixture to work with name fields.
* Tweak vue docs around i18n, based on some breaking changes an agent made, that only showed up in production.
* Remove workflow halting from workflow tool
* Disable prompting agents when they make unexpected edits. It's pretty much always called for.