### PR TITLE
Add @saflib/analytics-service

### DIFF
--- a/analytics-service/AnalyticsServiceBase.ts
+++ b/analytics-service/AnalyticsServiceBase.ts
@@ -15,7 +15,9 @@ export abstract class AnalyticsServiceBase implements AnalyticsService {
    * Fields merged under capture `context` / PostHog `properties` from the current SafContext.
    * Subclasses do not override this for normal HTTP use; extend only if you add more keys.
    */
-  protected getCapturePropertiesFromSafContext(ctx: SafContext): Record<string, unknown> {
+  protected getCapturePropertiesFromSafContext(
+    ctx: SafContext,
+  ): Record<string, unknown> {
     const out: Record<string, unknown> = {};
     const str = (v: unknown): string | undefined =>
       v != null && String(v).trim() !== "" ? String(v).trim() : undefined;
@@ -26,7 +28,6 @@ export abstract class AnalyticsServiceBase implements AnalyticsService {
     put("host", ctx.host);
     put("origin", ctx.origin);
     put("user_agent", ctx.userAgent);
-    put("ip", ctx.clientIp);
     put("accept_language", ctx.acceptLanguage);
     return out;
   }

--- a/analytics-service/AnalyticsServiceBase.ts
+++ b/analytics-service/AnalyticsServiceBase.ts
@@ -15,9 +15,7 @@ export abstract class AnalyticsServiceBase implements AnalyticsService {
    * Fields merged under capture `context` / PostHog `properties` from the current SafContext.
    * Subclasses do not override this for normal HTTP use; extend only if you add more keys.
    */
-  protected getCapturePropertiesFromSafContext(
-    ctx: SafContext,
-  ): Record<string, unknown> {
+  protected getCapturePropertiesFromSafContext(ctx: SafContext): Record<string, unknown> {
     const out: Record<string, unknown> = {};
     const str = (v: unknown): string | undefined =>
       v != null && String(v).trim() !== "" ? String(v).trim() : undefined;
@@ -28,6 +26,7 @@ export abstract class AnalyticsServiceBase implements AnalyticsService {
     put("host", ctx.host);
     put("origin", ctx.origin);
     put("user_agent", ctx.userAgent);
+    put("ip", ctx.clientIp);
     put("accept_language", ctx.acceptLanguage);
     return out;
   }

--- a/analytics-service/AnalyticsServiceBase.ts
+++ b/analytics-service/AnalyticsServiceBase.ts
@@ -1,10 +1,6 @@
 import { getSafContext } from "@saflib/node";
-import type {
-  AnalyticsService,
-  CommonEvent,
-  IdentifyProps,
-  WithDistinctId,
-} from "./types.ts";
+import type { SafContext } from "@saflib/node";
+import type { AnalyticsService, CommonEvent, IdentifyProps } from "./types.ts";
 
 /**
  * Shared server-side analytics behavior: merges `getSafContext()`-derived fields into every
@@ -16,31 +12,34 @@ export abstract class AnalyticsServiceBase implements AnalyticsService {
   abstract shutdown(): void | Promise<void>;
 
   /**
-   * Fields merged under capture `context` / PostHog `properties` after SafContext lookup.
+   * Fields merged under capture `context` / PostHog `properties` from the current SafContext.
    * Subclasses do not override this for normal HTTP use; extend only if you add more keys.
    */
-  protected getCapturePropertiesFromSafContext(): Record<string, unknown> {
-    try {
-      const ctx = getSafContext();
-      const out: Record<string, unknown> = {};
-      if (ctx.host != null && String(ctx.host).trim() !== "") {
-        out.host = ctx.host;
-      }
-      return out;
-    } catch {
-      return {};
+  protected getCapturePropertiesFromSafContext(ctx: SafContext): Record<string, unknown> {
+    const out: Record<string, unknown> = {};
+    if (ctx.host != null && String(ctx.host).trim() !== "") {
+      out.host = ctx.host;
     }
+    return out;
   }
 
-  capture(event: CommonEvent & WithDistinctId): void {
-    const fromContext = this.getCapturePropertiesFromSafContext();
+  capture(event: CommonEvent): void {
+    const ctx = getSafContext();
+    const userId = ctx.auth?.userId;
+    if (userId == null || String(userId).trim() === "") {
+      throw new Error(
+        "Analytics capture requires SafContext.auth.userId (authenticated request).",
+      );
+    }
+    const distinctId = String(userId).trim();
+    const fromContext = this.getCapturePropertiesFromSafContext(ctx);
     const mergedContext =
       event.context === undefined && Object.keys(fromContext).length === 0
         ? undefined
         : { ...fromContext, ...event.context };
 
     this.emitCapture({
-      distinctId: event.distinctId,
+      distinctId,
       event: event.event,
       context: mergedContext,
     });

--- a/analytics-service/AnalyticsServiceBase.ts
+++ b/analytics-service/AnalyticsServiceBase.ts
@@ -1,0 +1,54 @@
+import { getSafContext } from "@saflib/node";
+import type {
+  AnalyticsService,
+  CommonEvent,
+  IdentifyProps,
+  WithDistinctId,
+} from "./types.ts";
+
+/**
+ * Shared server-side analytics behavior: merges `getSafContext()`-derived fields into every
+ * `capture` payload so all integrations (PostHog, in-memory, etc.) stay consistent.
+ */
+export abstract class AnalyticsServiceBase implements AnalyticsService {
+  abstract identify(props: IdentifyProps): void;
+
+  abstract shutdown(): void | Promise<void>;
+
+  /**
+   * Fields merged under capture `context` / PostHog `properties` after SafContext lookup.
+   * Subclasses do not override this for normal HTTP use; extend only if you add more keys.
+   */
+  protected getCapturePropertiesFromSafContext(): Record<string, unknown> {
+    try {
+      const ctx = getSafContext();
+      const out: Record<string, unknown> = {};
+      if (ctx.host != null && String(ctx.host).trim() !== "") {
+        out.host = ctx.host;
+      }
+      return out;
+    } catch {
+      return {};
+    }
+  }
+
+  capture(event: CommonEvent & WithDistinctId): void {
+    const fromContext = this.getCapturePropertiesFromSafContext();
+    const mergedContext =
+      event.context === undefined && Object.keys(fromContext).length === 0
+        ? undefined
+        : { ...fromContext, ...event.context };
+
+    this.emitCapture({
+      distinctId: event.distinctId,
+      event: event.event,
+      context: mergedContext,
+    });
+  }
+
+  protected abstract emitCapture(event: {
+    distinctId: string;
+    event: string;
+    context?: Record<string, unknown>;
+  }): void;
+}

--- a/analytics-service/AnalyticsServiceBase.ts
+++ b/analytics-service/AnalyticsServiceBase.ts
@@ -17,9 +17,17 @@ export abstract class AnalyticsServiceBase implements AnalyticsService {
    */
   protected getCapturePropertiesFromSafContext(ctx: SafContext): Record<string, unknown> {
     const out: Record<string, unknown> = {};
-    if (ctx.host != null && String(ctx.host).trim() !== "") {
-      out.host = ctx.host;
-    }
+    const str = (v: unknown): string | undefined =>
+      v != null && String(v).trim() !== "" ? String(v).trim() : undefined;
+    const put = (key: string, v: unknown) => {
+      const s = str(v);
+      if (s !== undefined) out[key] = s;
+    };
+    put("host", ctx.host);
+    put("origin", ctx.origin);
+    put("user_agent", ctx.userAgent);
+    put("ip", ctx.clientIp);
+    put("accept_language", ctx.acceptLanguage);
     return out;
   }
 

--- a/analytics-service/createAnalyticsService.ts
+++ b/analytics-service/createAnalyticsService.ts
@@ -1,0 +1,37 @@
+import type { AnalyticsService } from "./types.ts";
+import { InMemoryAnalyticsService } from "./in-memory/InMemoryAnalyticsService.ts";
+import { PosthogAnalyticsService } from "./posthog/PosthogAnalyticsService.ts";
+
+export type CreateAnalyticsServiceOptions =
+  | {
+      type: "posthog";
+      apiKey: string;
+      host: string;
+    }
+  | { type: "in-memory" };
+
+/**
+ * Creates an analytics service (PostHog or in-memory).
+ * When `NODE_ENV` is `"test"`, always returns an in-memory implementation so tests
+ * never send events to PostHog, regardless of the requested `type`.
+ */
+export function createAnalyticsService(
+  options: CreateAnalyticsServiceOptions,
+): AnalyticsService {
+  if (process.env.NODE_ENV === "test") {
+    return new InMemoryAnalyticsService();
+  }
+  switch (options.type) {
+    case "posthog":
+      return new PosthogAnalyticsService({
+        apiKey: options.apiKey,
+        host: options.host,
+      });
+    case "in-memory":
+      return new InMemoryAnalyticsService();
+    default: {
+      const _: never = options;
+      return _;
+    }
+  }
+}

--- a/analytics-service/in-memory/InMemoryAnalyticsService.ts
+++ b/analytics-service/in-memory/InMemoryAnalyticsService.ts
@@ -1,9 +1,5 @@
-import type {
-  AnalyticsService,
-  CommonEvent,
-  IdentifyProps,
-  WithDistinctId,
-} from "../types.ts";
+import { AnalyticsServiceBase } from "../AnalyticsServiceBase.ts";
+import type { IdentifyProps } from "../types.ts";
 
 export type CapturedAnalyticsCall =
   | {
@@ -26,7 +22,7 @@ export function clearCapturedAnalyticsCalls(): void {
   capturedAnalyticsCalls.length = 0;
 }
 
-export class InMemoryAnalyticsService implements AnalyticsService {
+export class InMemoryAnalyticsService extends AnalyticsServiceBase {
   identify(props: IdentifyProps): void {
     capturedAnalyticsCalls.push({
       kind: "identify",
@@ -40,7 +36,11 @@ export class InMemoryAnalyticsService implements AnalyticsService {
     // no-op
   }
 
-  capture(event: CommonEvent & WithDistinctId): void {
+  protected emitCapture(event: {
+    distinctId: string;
+    event: string;
+    context?: Record<string, unknown>;
+  }): void {
     capturedAnalyticsCalls.push({
       kind: "capture",
       distinctId: event.distinctId,

--- a/analytics-service/in-memory/InMemoryAnalyticsService.ts
+++ b/analytics-service/in-memory/InMemoryAnalyticsService.ts
@@ -1,0 +1,51 @@
+import type {
+  AnalyticsService,
+  CommonEvent,
+  IdentifyProps,
+  WithDistinctId,
+} from "../types.ts";
+
+export type CapturedAnalyticsCall =
+  | {
+      kind: "capture";
+      distinctId: string;
+      event: string;
+      context?: Record<string, unknown>;
+    }
+  | {
+      kind: "identify";
+      distinctId: string;
+      properties?: Record<string, unknown>;
+      disableGeoip?: boolean;
+    };
+
+/** Shared log for all in-memory analytics instances (mirrors the email mock store pattern). */
+export const capturedAnalyticsCalls: CapturedAnalyticsCall[] = [];
+
+export function clearCapturedAnalyticsCalls(): void {
+  capturedAnalyticsCalls.length = 0;
+}
+
+export class InMemoryAnalyticsService implements AnalyticsService {
+  identify(props: IdentifyProps): void {
+    capturedAnalyticsCalls.push({
+      kind: "identify",
+      distinctId: props.distinctId,
+      properties: props.properties,
+      disableGeoip: props.disableGeoip,
+    });
+  }
+
+  shutdown(): void {
+    // no-op
+  }
+
+  capture(event: CommonEvent & WithDistinctId): void {
+    capturedAnalyticsCalls.push({
+      kind: "capture",
+      distinctId: event.distinctId,
+      event: event.event,
+      context: event.context,
+    });
+  }
+}

--- a/analytics-service/index.test.ts
+++ b/analytics-service/index.test.ts
@@ -1,16 +1,18 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const { mockCapture, mockIdentify, mockShutdown, PostHogMock } = vi.hoisted(() => {
-  const mockCapture = vi.fn();
-  const mockIdentify = vi.fn();
-  const mockShutdown = vi.fn();
-  const PostHogMock = vi.fn().mockImplementation(() => ({
-    capture: mockCapture,
-    identify: mockIdentify,
-    shutdown: mockShutdown,
-  }));
-  return { mockCapture, mockIdentify, mockShutdown, PostHogMock };
-});
+const { mockCapture, mockIdentify, mockShutdown, PostHogMock } = vi.hoisted(
+  () => {
+    const mockCapture = vi.fn();
+    const mockIdentify = vi.fn();
+    const mockShutdown = vi.fn();
+    const PostHogMock = vi.fn().mockImplementation(() => ({
+      capture: mockCapture,
+      identify: mockIdentify,
+      shutdown: mockShutdown,
+    }));
+    return { mockCapture, mockIdentify, mockShutdown, PostHogMock };
+  },
+);
 
 vi.mock("posthog-node", () => ({
   PostHog: PostHogMock,
@@ -179,7 +181,6 @@ describe("capture merges SafContext (e.g. host)", () => {
         host: "api.example.com",
         origin: "https://app.example",
         user_agent: "vitest/1",
-        ip: "203.0.113.1",
         accept_language: "en-US,en;q=0.9",
         a: 1,
       },
@@ -197,7 +198,6 @@ describe("capture merges SafContext (e.g. host)", () => {
         host: "client",
         origin: "https://app.example",
         user_agent: "vitest/1",
-        ip: "203.0.113.1",
         accept_language: "en-US,en;q=0.9",
       },
     });

--- a/analytics-service/index.test.ts
+++ b/analytics-service/index.test.ts
@@ -143,6 +143,10 @@ describe("capture merges SafContext (e.g. host)", () => {
     subsystemName: "http",
     operationName: "PostMatter",
     host: "api.example.com",
+    origin: "https://app.example",
+    userAgent: "vitest/1",
+    clientIp: "203.0.113.1",
+    acceptLanguage: "en-US,en;q=0.9",
     auth: { userId: "merge-user" },
   };
 
@@ -171,7 +175,14 @@ describe("capture merges SafContext (e.g. host)", () => {
     expect(mockCapture).toHaveBeenCalledWith({
       distinctId: "merge-user",
       event: "evt",
-      properties: { host: "api.example.com", a: 1 },
+      properties: {
+        host: "api.example.com",
+        origin: "https://app.example",
+        user_agent: "vitest/1",
+        ip: "203.0.113.1",
+        accept_language: "en-US,en;q=0.9",
+        a: 1,
+      },
     });
   });
 
@@ -179,12 +190,16 @@ describe("capture merges SafContext (e.g. host)", () => {
     vi.spyOn(node, "getSafContext").mockReturnValue(safWithHost);
     const svc = createAnalyticsService({ type: "in-memory" });
     svc.capture({ event: "evt", context: { host: "client" } });
-    expect(capturedAnalyticsCalls[0]).toEqual(
-      expect.objectContaining({
-        kind: "capture",
-        distinctId: "merge-user",
-        context: { host: "client" },
-      }),
-    );
+    expect(capturedAnalyticsCalls[0]).toMatchObject({
+      kind: "capture",
+      distinctId: "merge-user",
+      context: {
+        host: "client",
+        origin: "https://app.example",
+        user_agent: "vitest/1",
+        ip: "203.0.113.1",
+        accept_language: "en-US,en;q=0.9",
+      },
+    });
   });
 });

--- a/analytics-service/index.test.ts
+++ b/analytics-service/index.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const { mockCapture, mockIdentify, mockShutdown, PostHogMock } = vi.hoisted(() => {
+  const mockCapture = vi.fn();
+  const mockIdentify = vi.fn();
+  const mockShutdown = vi.fn();
+  const PostHogMock = vi.fn().mockImplementation(() => ({
+    capture: mockCapture,
+    identify: mockIdentify,
+    shutdown: mockShutdown,
+  }));
+  return { mockCapture, mockIdentify, mockShutdown, PostHogMock };
+});
+
+vi.mock("posthog-node", () => ({
+  PostHog: PostHogMock,
+}));
+
+import {
+  clearCapturedAnalyticsCalls,
+  capturedAnalyticsCalls,
+  createAnalyticsService,
+  makeTypedAnalytics,
+  PosthogAnalyticsService,
+} from "./index.ts";
+
+describe("createAnalyticsService", () => {
+  beforeEach(() => {
+    clearCapturedAnalyticsCalls();
+    mockCapture.mockClear();
+    mockIdentify.mockClear();
+    mockShutdown.mockClear();
+    PostHogMock.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("uses in-memory when NODE_ENV is test even if posthog is requested", () => {
+    vi.stubEnv("NODE_ENV", "test");
+    const svc = createAnalyticsService({
+      type: "posthog",
+      apiKey: "phc_fake",
+      host: "https://example.com",
+    });
+    svc.capture({ distinctId: "u1", event: "thing_happened", context: { n: 1 } });
+    expect(PostHogMock).not.toHaveBeenCalled();
+    expect(capturedAnalyticsCalls).toEqual([
+      {
+        kind: "capture",
+        distinctId: "u1",
+        event: "thing_happened",
+        context: { n: 1 },
+      },
+    ]);
+  });
+
+  it("uses PostHog when not in test and type is posthog", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const svc = createAnalyticsService({
+      type: "posthog",
+      apiKey: "phc_key",
+      host: "https://app.posthog.com",
+    });
+    expect(svc).toBeInstanceOf(PosthogAnalyticsService);
+    expect(PostHogMock).toHaveBeenCalledWith("phc_key", {
+      host: "https://app.posthog.com",
+    });
+    svc.capture({ distinctId: "u2", event: "evt", context: { a: true } });
+    expect(mockCapture).toHaveBeenCalledWith({
+      distinctId: "u2",
+      event: "evt",
+      properties: { a: true },
+    });
+  });
+
+  it("uses in-memory when type is in-memory and not in test", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    const svc = createAnalyticsService({ type: "in-memory" });
+    svc.capture({ distinctId: "u", event: "e" });
+    expect(capturedAnalyticsCalls).toHaveLength(1);
+    expect(PostHogMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("makeTypedAnalytics", () => {
+  beforeEach(() => {
+    clearCapturedAnalyticsCalls();
+    vi.stubEnv("NODE_ENV", "test");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("forwards capture with typed events", () => {
+    type MyEvent = { event: "custom"; context?: { x: number } };
+    const base = createAnalyticsService({ type: "in-memory" });
+    const typed = makeTypedAnalytics<MyEvent>(base);
+    typed.capture({ distinctId: "d", event: "custom", context: { x: 3 } });
+    expect(capturedAnalyticsCalls[0]).toMatchObject({
+      kind: "capture",
+      event: "custom",
+      context: { x: 3 },
+    });
+  });
+});

--- a/analytics-service/index.test.ts
+++ b/analytics-service/index.test.ts
@@ -16,6 +16,7 @@ vi.mock("posthog-node", () => ({
   PostHog: PostHogMock,
 }));
 
+import * as node from "@saflib/node";
 import {
   clearCapturedAnalyticsCalls,
   capturedAnalyticsCalls,
@@ -104,5 +105,53 @@ describe("makeTypedAnalytics", () => {
       event: "custom",
       context: { x: 3 },
     });
+  });
+});
+
+describe("capture merges SafContext (e.g. host)", () => {
+  const safWithHost: node.SafContext = {
+    requestId: "r1",
+    serviceName: "daemon-http",
+    subsystemName: "http",
+    operationName: "PostMatter",
+    host: "api.example.com",
+  };
+
+  beforeEach(() => {
+    clearCapturedAnalyticsCalls();
+    mockCapture.mockClear();
+    vi.stubEnv("NODE_ENV", "development");
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.restoreAllMocks();
+  });
+
+  it("merges host from getSafContext into PostHog properties", () => {
+    vi.spyOn(node, "getSafContext").mockReturnValue(safWithHost);
+    const svc = createAnalyticsService({
+      type: "posthog",
+      apiKey: "phc_key",
+      host: "https://app.posthog.com",
+    });
+    svc.capture({ distinctId: "u", event: "evt", context: { a: 1 } });
+    expect(mockCapture).toHaveBeenCalledWith({
+      distinctId: "u",
+      event: "evt",
+      properties: { host: "api.example.com", a: 1 },
+    });
+  });
+
+  it("event context overrides duplicate keys from SafContext merge", () => {
+    vi.spyOn(node, "getSafContext").mockReturnValue(safWithHost);
+    const svc = createAnalyticsService({ type: "in-memory" });
+    svc.capture({ distinctId: "u", event: "evt", context: { host: "client" } });
+    expect(capturedAnalyticsCalls[0]).toEqual(
+      expect.objectContaining({
+        kind: "capture",
+        context: { host: "client" },
+      }),
+    );
   });
 });

--- a/analytics-service/index.test.ts
+++ b/analytics-service/index.test.ts
@@ -36,6 +36,10 @@ describe("createAnalyticsService", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
+    const g = node.getSafContext;
+    if (vi.isMockFunction(g)) {
+      vi.mocked(g).mockRestore();
+    }
   });
 
   it("uses in-memory when NODE_ENV is test even if posthog is requested", () => {
@@ -45,12 +49,12 @@ describe("createAnalyticsService", () => {
       apiKey: "phc_fake",
       host: "https://example.com",
     });
-    svc.capture({ distinctId: "u1", event: "thing_happened", context: { n: 1 } });
+    svc.capture({ event: "thing_happened", context: { n: 1 } });
     expect(PostHogMock).not.toHaveBeenCalled();
     expect(capturedAnalyticsCalls).toEqual([
       {
         kind: "capture",
-        distinctId: "u1",
+        distinctId: "test-user-id",
         event: "thing_happened",
         context: { n: 1 },
       },
@@ -59,6 +63,12 @@ describe("createAnalyticsService", () => {
 
   it("uses PostHog when not in test and type is posthog", () => {
     vi.stubEnv("NODE_ENV", "development");
+    vi.spyOn(node, "getSafContext").mockReturnValue({
+      serviceName: "daemon-http",
+      subsystemName: "http",
+      operationName: "op",
+      auth: { userId: "u2" },
+    });
     const svc = createAnalyticsService({
       type: "posthog",
       apiKey: "phc_key",
@@ -68,7 +78,7 @@ describe("createAnalyticsService", () => {
     expect(PostHogMock).toHaveBeenCalledWith("phc_key", {
       host: "https://app.posthog.com",
     });
-    svc.capture({ distinctId: "u2", event: "evt", context: { a: true } });
+    svc.capture({ event: "evt", context: { a: true } });
     expect(mockCapture).toHaveBeenCalledWith({
       distinctId: "u2",
       event: "evt",
@@ -78,10 +88,27 @@ describe("createAnalyticsService", () => {
 
   it("uses in-memory when type is in-memory and not in test", () => {
     vi.stubEnv("NODE_ENV", "development");
+    vi.spyOn(node, "getSafContext").mockReturnValue({
+      serviceName: "daemon-http",
+      subsystemName: "http",
+      operationName: "op",
+      auth: { userId: "u" },
+    });
     const svc = createAnalyticsService({ type: "in-memory" });
-    svc.capture({ distinctId: "u", event: "e" });
+    svc.capture({ event: "e" });
     expect(capturedAnalyticsCalls).toHaveLength(1);
     expect(PostHogMock).not.toHaveBeenCalled();
+  });
+
+  it("throws when SafContext has no auth.userId", () => {
+    vi.stubEnv("NODE_ENV", "development");
+    vi.spyOn(node, "getSafContext").mockReturnValue({
+      serviceName: "daemon-http",
+      subsystemName: "http",
+      operationName: "op",
+    });
+    const svc = createAnalyticsService({ type: "in-memory" });
+    expect(() => svc.capture({ event: "e" })).toThrow(/auth\.userId/);
   });
 });
 
@@ -99,9 +126,10 @@ describe("makeTypedAnalytics", () => {
     type MyEvent = { event: "custom"; context?: { x: number } };
     const base = createAnalyticsService({ type: "in-memory" });
     const typed = makeTypedAnalytics<MyEvent>(base);
-    typed.capture({ distinctId: "d", event: "custom", context: { x: 3 } });
+    typed.capture({ event: "custom", context: { x: 3 } });
     expect(capturedAnalyticsCalls[0]).toMatchObject({
       kind: "capture",
+      distinctId: "test-user-id",
       event: "custom",
       context: { x: 3 },
     });
@@ -115,6 +143,7 @@ describe("capture merges SafContext (e.g. host)", () => {
     subsystemName: "http",
     operationName: "PostMatter",
     host: "api.example.com",
+    auth: { userId: "merge-user" },
   };
 
   beforeEach(() => {
@@ -125,7 +154,10 @@ describe("capture merges SafContext (e.g. host)", () => {
 
   afterEach(() => {
     vi.unstubAllEnvs();
-    vi.restoreAllMocks();
+    const g = node.getSafContext;
+    if (vi.isMockFunction(g)) {
+      vi.mocked(g).mockRestore();
+    }
   });
 
   it("merges host from getSafContext into PostHog properties", () => {
@@ -135,9 +167,9 @@ describe("capture merges SafContext (e.g. host)", () => {
       apiKey: "phc_key",
       host: "https://app.posthog.com",
     });
-    svc.capture({ distinctId: "u", event: "evt", context: { a: 1 } });
+    svc.capture({ event: "evt", context: { a: 1 } });
     expect(mockCapture).toHaveBeenCalledWith({
-      distinctId: "u",
+      distinctId: "merge-user",
       event: "evt",
       properties: { host: "api.example.com", a: 1 },
     });
@@ -146,10 +178,11 @@ describe("capture merges SafContext (e.g. host)", () => {
   it("event context overrides duplicate keys from SafContext merge", () => {
     vi.spyOn(node, "getSafContext").mockReturnValue(safWithHost);
     const svc = createAnalyticsService({ type: "in-memory" });
-    svc.capture({ distinctId: "u", event: "evt", context: { host: "client" } });
+    svc.capture({ event: "evt", context: { host: "client" } });
     expect(capturedAnalyticsCalls[0]).toEqual(
       expect.objectContaining({
         kind: "capture",
+        distinctId: "merge-user",
         context: { host: "client" },
       }),
     );

--- a/analytics-service/index.ts
+++ b/analytics-service/index.ts
@@ -1,0 +1,22 @@
+export type {
+  AnalyticsService,
+  CommonEvent,
+  IdentifyProps,
+  TypedAnalytics,
+  WithDistinctId,
+} from "./types.ts";
+export { makeTypedAnalytics } from "./makeTypedAnalytics.ts";
+export {
+  createAnalyticsService,
+  type CreateAnalyticsServiceOptions,
+} from "./createAnalyticsService.ts";
+export {
+  InMemoryAnalyticsService,
+  capturedAnalyticsCalls,
+  clearCapturedAnalyticsCalls,
+  type CapturedAnalyticsCall,
+} from "./in-memory/InMemoryAnalyticsService.ts";
+export {
+  PosthogAnalyticsService,
+  type PosthogAnalyticsServiceOptions,
+} from "./posthog/PosthogAnalyticsService.ts";

--- a/analytics-service/index.ts
+++ b/analytics-service/index.ts
@@ -5,6 +5,7 @@ export type {
   TypedAnalytics,
   WithDistinctId,
 } from "./types.ts";
+export { AnalyticsServiceBase } from "./AnalyticsServiceBase.ts";
 export { makeTypedAnalytics } from "./makeTypedAnalytics.ts";
 export {
   createAnalyticsService,

--- a/analytics-service/index.ts
+++ b/analytics-service/index.ts
@@ -3,7 +3,6 @@ export type {
   CommonEvent,
   IdentifyProps,
   TypedAnalytics,
-  WithDistinctId,
 } from "./types.ts";
 export { AnalyticsServiceBase } from "./AnalyticsServiceBase.ts";
 export { makeTypedAnalytics } from "./makeTypedAnalytics.ts";

--- a/analytics-service/makeTypedAnalytics.ts
+++ b/analytics-service/makeTypedAnalytics.ts
@@ -1,9 +1,4 @@
-import type {
-  AnalyticsService,
-  CommonEvent,
-  TypedAnalytics,
-  WithDistinctId,
-} from "./types.ts";
+import type { AnalyticsService, CommonEvent, TypedAnalytics } from "./types.ts";
 
 export function makeTypedAnalytics<E extends CommonEvent>(
   service: AnalyticsService,
@@ -11,7 +6,7 @@ export function makeTypedAnalytics<E extends CommonEvent>(
   return {
     identify: (props) => service.identify(props),
     shutdown: () => service.shutdown(),
-    capture: (event: E & WithDistinctId) => {
+    capture: (event: E) => {
       service.capture(event);
     },
   };

--- a/analytics-service/makeTypedAnalytics.ts
+++ b/analytics-service/makeTypedAnalytics.ts
@@ -1,0 +1,18 @@
+import type {
+  AnalyticsService,
+  CommonEvent,
+  TypedAnalytics,
+  WithDistinctId,
+} from "./types.ts";
+
+export function makeTypedAnalytics<E extends CommonEvent>(
+  service: AnalyticsService,
+): TypedAnalytics<E> {
+  return {
+    identify: (props) => service.identify(props),
+    shutdown: () => service.shutdown(),
+    capture: (event: E & WithDistinctId) => {
+      service.capture(event);
+    },
+  };
+}

--- a/analytics-service/package.json
+++ b/analytics-service/package.json
@@ -13,6 +13,7 @@
     "typecheck": "tsc"
   },
   "dependencies": {
+    "@saflib/node": "*",
     "posthog-node": "^5.33.2"
   },
   "devDependencies": {

--- a/analytics-service/package.json
+++ b/analytics-service/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@saflib/analytics-service",
+  "description": "Server-side analytics abstraction (PostHog) with in-memory implementation for tests",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "typecheck": "tsc"
+  },
+  "dependencies": {
+    "posthog-node": "^5.33.2"
+  },
+  "devDependencies": {
+    "@saflib/monorepo": "*",
+    "@saflib/vitest": "*"
+  }
+}

--- a/analytics-service/posthog/PosthogAnalyticsService.ts
+++ b/analytics-service/posthog/PosthogAnalyticsService.ts
@@ -1,20 +1,17 @@
 import { PostHog } from "posthog-node";
-import type {
-  AnalyticsService,
-  CommonEvent,
-  IdentifyProps,
-  WithDistinctId,
-} from "../types.ts";
+import { AnalyticsServiceBase } from "../AnalyticsServiceBase.ts";
+import type { IdentifyProps } from "../types.ts";
 
 export type PosthogAnalyticsServiceOptions = {
   apiKey: string;
   host: string;
 };
 
-export class PosthogAnalyticsService implements AnalyticsService {
+export class PosthogAnalyticsService extends AnalyticsServiceBase {
   private readonly client: PostHog;
 
   constructor(options: PosthogAnalyticsServiceOptions) {
+    super();
     this.client = new PostHog(options.apiKey, { host: options.host });
   }
 
@@ -30,7 +27,11 @@ export class PosthogAnalyticsService implements AnalyticsService {
     return this.client.shutdown();
   }
 
-  capture(event: CommonEvent & WithDistinctId): void {
+  protected emitCapture(event: {
+    distinctId: string;
+    event: string;
+    context?: Record<string, unknown>;
+  }): void {
     this.client.capture({
       distinctId: event.distinctId,
       event: event.event,

--- a/analytics-service/posthog/PosthogAnalyticsService.ts
+++ b/analytics-service/posthog/PosthogAnalyticsService.ts
@@ -1,0 +1,40 @@
+import { PostHog } from "posthog-node";
+import type {
+  AnalyticsService,
+  CommonEvent,
+  IdentifyProps,
+  WithDistinctId,
+} from "../types.ts";
+
+export type PosthogAnalyticsServiceOptions = {
+  apiKey: string;
+  host: string;
+};
+
+export class PosthogAnalyticsService implements AnalyticsService {
+  private readonly client: PostHog;
+
+  constructor(options: PosthogAnalyticsServiceOptions) {
+    this.client = new PostHog(options.apiKey, { host: options.host });
+  }
+
+  identify(props: IdentifyProps): void {
+    this.client.identify({
+      distinctId: props.distinctId,
+      properties: props.properties,
+      disableGeoip: props.disableGeoip,
+    });
+  }
+
+  shutdown(): void | Promise<void> {
+    return this.client.shutdown();
+  }
+
+  capture(event: CommonEvent & WithDistinctId): void {
+    this.client.capture({
+      distinctId: event.distinctId,
+      event: event.event,
+      properties: event.context,
+    });
+  }
+}

--- a/analytics-service/tsconfig.json
+++ b/analytics-service/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "@saflib/monorepo/tsconfig.json"
+}

--- a/analytics-service/types.ts
+++ b/analytics-service/types.ts
@@ -14,6 +14,10 @@ export interface IdentifyProps {
   disableGeoip?: boolean;
 }
 
+/**
+ * Server-side analytics client. Concrete implementations should extend
+ * `AnalyticsServiceBase` so each `capture` is enriched from `getSafContext()` (e.g. HTTP `host`).
+ */
 export interface AnalyticsService {
   identify: (props: IdentifyProps) => void;
   shutdown: () => void | Promise<void>;

--- a/analytics-service/types.ts
+++ b/analytics-service/types.ts
@@ -1,0 +1,28 @@
+export interface WithDistinctId {
+  distinctId: string;
+}
+
+export interface CommonEvent {
+  event: string;
+  context?: Record<string, unknown>;
+}
+
+/** Matches PostHog `identify` input closely enough for both integrations. */
+export interface IdentifyProps {
+  distinctId: string;
+  properties?: Record<string, unknown>;
+  disableGeoip?: boolean;
+}
+
+export interface AnalyticsService {
+  identify: (props: IdentifyProps) => void;
+  shutdown: () => void | Promise<void>;
+  capture: (event: CommonEvent & WithDistinctId) => void;
+}
+
+export type TypedAnalytics<E extends CommonEvent> = Pick<
+  AnalyticsService,
+  "identify" | "shutdown"
+> & {
+  capture: (event: E & WithDistinctId) => void;
+};

--- a/analytics-service/types.ts
+++ b/analytics-service/types.ts
@@ -1,7 +1,3 @@
-export interface WithDistinctId {
-  distinctId: string;
-}
-
 export interface CommonEvent {
   event: string;
   context?: Record<string, unknown>;
@@ -16,17 +12,18 @@ export interface IdentifyProps {
 
 /**
  * Server-side analytics client. Concrete implementations should extend
- * `AnalyticsServiceBase` so each `capture` is enriched from `getSafContext()` (e.g. HTTP `host`).
+ * `AnalyticsServiceBase` so each `capture` uses `getSafContext().auth.userId` as PostHog distinct id
+ * and enriches payloads from SafContext (e.g. HTTP `host`).
  */
 export interface AnalyticsService {
   identify: (props: IdentifyProps) => void;
   shutdown: () => void | Promise<void>;
-  capture: (event: CommonEvent & WithDistinctId) => void;
+  capture: (event: CommonEvent) => void;
 }
 
 export type TypedAnalytics<E extends CommonEvent> = Pick<
   AnalyticsService,
   "identify" | "shutdown"
 > & {
-  capture: (event: E & WithDistinctId) => void;
+  capture: (event: E) => void;
 };

--- a/analytics-service/vitest.config.js
+++ b/analytics-service/vitest.config.js
@@ -1,0 +1,3 @@
+import { defaultConfig } from "@saflib/vitest/vitest.config.js";
+
+export default defaultConfig;

--- a/express/src/middleware/context.ts
+++ b/express/src/middleware/context.ts
@@ -113,12 +113,19 @@ export const makeContextMiddleware = () => {
 
     resolveAuth(req)
       .then((auth) => {
+        const hostHeader = req.headers?.host;
+        const host =
+          typeof hostHeader === "string" && hostHeader.trim() !== ""
+            ? hostHeader.trim()
+            : undefined;
+
         const context: SafContext = {
           requestId: reqId,
           serviceName: getServiceName(),
           subsystemName: "http",
           operationName,
           auth,
+          host,
         };
 
         const reporters: SafReporters = {

--- a/express/src/middleware/context.ts
+++ b/express/src/middleware/context.ts
@@ -88,6 +88,28 @@ function resolveTestAuth(req: Request): Auth | undefined {
   return undefined;
 }
 
+function trimmedHeader(req: Request, name: string): string | undefined {
+  const v = req.headers?.[name];
+  return typeof v === "string" && v.trim() !== "" ? v.trim() : undefined;
+}
+
+function resolveClientIp(req: Request): string | undefined {
+  const xff = trimmedHeader(req, "x-forwarded-for");
+  if (xff) {
+    const first = xff.split(",")[0]?.trim();
+    if (first) return first;
+  }
+  const ip = req.ip;
+  if (typeof ip === "string" && ip.trim() !== "") {
+    return ip.trim();
+  }
+  const socketAddr = req.socket?.remoteAddress;
+  if (typeof socketAddr === "string" && socketAddr.trim() !== "") {
+    return socketAddr.trim();
+  }
+  return undefined;
+}
+
 async function resolveAuth(req: Request): Promise<Auth | undefined> {
   const kratosId = req.headers["x-kratos-authenticated-identity-id"];
   if (typeof kratosId === "string" && kratosId.length > 0) {
@@ -119,6 +141,11 @@ export const makeContextMiddleware = () => {
             ? hostHeader.trim()
             : undefined;
 
+        const origin = trimmedHeader(req, "origin");
+        const userAgent = trimmedHeader(req, "user-agent");
+        const acceptLanguage = trimmedHeader(req, "accept-language");
+        const clientIp = resolveClientIp(req);
+
         const context: SafContext = {
           requestId: reqId,
           serviceName: getServiceName(),
@@ -126,6 +153,10 @@ export const makeContextMiddleware = () => {
           operationName,
           auth,
           host,
+          origin,
+          userAgent,
+          clientIp,
+          acceptLanguage,
         };
 
         const reporters: SafReporters = {

--- a/node/src/context.ts
+++ b/node/src/context.ts
@@ -12,6 +12,8 @@ export const testContext: SafContext = {
   serviceName: "test",
   subsystemName: "test",
   operationName: "test",
+  /** Placeholder so code paths that require an acting user (e.g. analytics capture) work in tests. */
+  auth: { userId: "test-user-id" },
 };
 
 /**

--- a/node/src/types.ts
+++ b/node/src/types.ts
@@ -62,6 +62,12 @@ export interface SafContext {
    * More info should be gotten directly from the auth service.
    */
   auth?: Auth;
+
+  /**
+   * HTTP `Host` header (or equivalent) for the inbound request, when known (e.g. Express).
+   * Used for analytics and routing diagnostics.
+   */
+  host?: string;
 }
 
 /**

--- a/node/src/types.ts
+++ b/node/src/types.ts
@@ -68,6 +68,26 @@ export interface SafContext {
    * Used for analytics and routing diagnostics.
    */
   host?: string;
+
+  /**
+   * HTTP `Origin` header when the client sends it (e.g. browsers, CORS).
+   */
+  origin?: string;
+
+  /**
+   * HTTP `User-Agent` header when present.
+   */
+  userAgent?: string;
+
+  /**
+   * Best-effort client IP for the inbound request (e.g. first `X-Forwarded-For` hop, else Express `req.ip`, else socket).
+   */
+  clientIp?: string;
+
+  /**
+   * HTTP `Accept-Language` header when present.
+   */
+  acceptLanguage?: string;
 }
 
 /**

--- a/posthog-client/posthog.ts
+++ b/posthog-client/posthog.ts
@@ -59,13 +59,14 @@ export function identifyToPostHog(
     return;
   }
   if ("posthog" in globalThis && !identified) {
-    // @ts-expect-error - posthog is not typed
-    globalThis.posthog.identify(id, {
+    const userProps = {
       id: id,
       email: sendEmail ? email : undefined,
       firstName: sendName ? name?.first : undefined,
       lastName: sendName ? name?.last : undefined,
-    });
+    };
+    // @ts-expect-error - posthog is not typed
+    globalThis.posthog.identify(id, userProps);
     console.log("id'd to posthog", id);
     identified = true;
   }

--- a/posthog-client/posthog.ts
+++ b/posthog-client/posthog.ts
@@ -41,9 +41,19 @@ export function usePostHogFeatureFlag(feature: string): Ref<FeatureFlag> {
 
 let identified = false;
 
-export function identifyToPostHog(session: Session) {
+interface IdentifyToPostHogOptions {
+  sendEmail?: boolean;
+  sendName?: boolean;
+}
+
+export function identifyToPostHog(
+  session: Session,
+  options: IdentifyToPostHogOptions = {},
+) {
   const email = kratosEmailFromSession(session);
   const name = kratosNameFromSession(session);
+  const sendEmail = options.sendEmail ?? true;
+  const sendName = options.sendName ?? true;
   const id = session.identity?.id;
   if (!email || !id) {
     return;
@@ -52,9 +62,9 @@ export function identifyToPostHog(session: Session) {
     // @ts-expect-error - posthog is not typed
     globalThis.posthog.identify(id, {
       id: id,
-      email: email,
-      firstName: name?.first,
-      lastName: name?.last,
+      email: sendEmail ? email : undefined,
+      firstName: sendName ? name?.first : undefined,
+      lastName: sendName ? name?.last : undefined,
     });
     console.log("id'd to posthog", id);
     identified = true;


### PR DESCRIPTION
Continuing to work on product analytics, extending SAF to support.

Added the analytics service package mimicking how object-store and email-service are set up cause that structure's working rather well. Just two implementations: posthog and in-memory.

Also:
* add host and other bits of info to saf context, since events can use that info
* For the frontend client, add a way to not send email/name of user to PostHog on identify

Incidentally, I tried a couple different ways to pas IP to posthog from the backend so it would do GeoIP but nothing seemed to work. No biggie.