### PR TITLE
Update drizzle, csrf, caddy

### DIFF
--- a/drizzle/instances.test.ts
+++ b/drizzle/instances.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll } from "vitest";
-import { rmSync, existsSync } from "node:fs";
+import { createHash } from "node:crypto";
+import { readFileSync, rmSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { eq } from "drizzle-orm";
 import { DbManager } from "./instances.ts";
@@ -183,5 +184,29 @@ describe("Instance Manager", () => {
       "memory",
     );
     manager.disconnect(key as DbKey);
+  });
+
+  it("skipMigrations leaves on-disk bytes unchanged across reconnect", () => {
+    const dbPath = getTempDbPath("skip-mig");
+    const key1 = manager.connect({
+      onDisk: dbPath,
+      overrideTestDefault: true,
+    });
+    manager.disconnect(key1 as DbKey);
+
+    const hash1 = createHash("sha256").update(readFileSync(dbPath)).digest("hex");
+
+    const key2 = manager.connect({
+      onDisk: dbPath,
+      overrideTestDefault: true,
+      skipMigrations: true,
+    });
+    manager.disconnect(key2 as DbKey);
+
+    const hash2 = createHash("sha256").update(readFileSync(dbPath)).digest("hex");
+
+    expect(hash2).toBe(hash1);
+
+    rmSync(dbPath, { force: true });
   });
 });

--- a/drizzle/instances.ts
+++ b/drizzle/instances.ts
@@ -87,7 +87,7 @@ export class DbManager<S extends Schema, C extends Config> {
     }
     const db = drizzle(sqlite, { schema: this.schema });
 
-    if (this.config.out) {
+    if (this.config.out && !options?.skipMigrations) {
       log.info("Running migrations...");
       let migrationsPath = this.config.out;
       if (migrationsPath.startsWith("./")) {
@@ -205,15 +205,31 @@ export class DbManager<S extends Schema, C extends Config> {
   }
 
   private closeSqliteDb(instance: DbConnection<S>): void {
+    // NOTE: reaches into Drizzle's internal session shape (`instance.session.client`)
+    // to call better-sqlite3's `close()`. This is a private API and may break on
+    // a future Drizzle major; if the cast or method lookup fails we log and move
+    // on (the handle leak only matters at process exit).
+    let client: { close?: () => void } | undefined;
     try {
-      const client = (
+      client = (
         instance as unknown as {
-          session: { client: { close?: () => void } };
+          session?: { client?: { close?: () => void } };
         }
-      ).session.client;
-      if (client && typeof client.close === "function") {
-        client.close();
-      }
+      ).session?.client;
+    } catch {
+      /* ignore */
+    }
+    if (!client || typeof client.close !== "function") {
+      const { log } = makeSubsystemReporters("db", "db.closeSqliteDb");
+      log.warn(
+        "closeSqliteDb: could not locate underlying better-sqlite3 client " +
+          "via instance.session.client — handle may leak. Drizzle internals " +
+          "may have changed.",
+      );
+      return;
+    }
+    try {
+      client.close();
     } catch {
       /* ignore close failures */
     }
@@ -239,6 +255,26 @@ export class DbManager<S extends Schema, C extends Config> {
   };
 
   /**
+   * Online SQLite backup of the database registered under `key` to `destinationPath`.
+   * Uses better-sqlite3's `db.backup()` (SQLite Online Backup API), so the
+   * source DB can stay open and writable during the copy.
+   *
+   * The destination file is overwritten if it exists. Parent directory must exist.
+   */
+  backupTo = async (key: DbKey, destinationPath: string): Promise<void> => {
+    const instance = this.instances.get(key);
+    if (!instance) {
+      throw new Error("backupTo: database instance not found");
+    }
+    const client = (
+      instance as unknown as {
+        session: { client: { backup: (path: string) => Promise<unknown> } };
+      }
+    ).session.client;
+    await client.backup(destinationPath);
+  };
+
+  /**
    * Open an on-disk SQLite file and register it under an existing {@link DbKey}
    * (after {@link disconnect} removed the prior connection). Used for audit seal
    * rotation so the process keeps the same key while replacing the file.
@@ -259,7 +295,7 @@ export class DbManager<S extends Schema, C extends Config> {
       sqlite.pragma(`${pragmaKey} = ${value}`);
     }
     const db = drizzle(sqlite, { schema: this.schema });
-    if (this.config.out) {
+    if (this.config.out && !options?.skipMigrations) {
       log.info("Running migrations...");
       let migrationsPath = this.config.out;
       if (migrationsPath.startsWith("./")) {
@@ -359,6 +395,7 @@ export class DbManager<S extends Schema, C extends Config> {
       getDbPath: this.getDbPath,
       walCheckpointTruncate: this.walCheckpointTruncate,
       attachConnection: this.attachConnection,
+      backupTo: this.backupTo.bind(this),
     };
   }
 }

--- a/drizzle/instances.ts
+++ b/drizzle/instances.ts
@@ -204,9 +204,87 @@ export class DbManager<S extends Schema, C extends Config> {
     return this.instances.get(key);
   }
 
+  private closeSqliteDb(instance: DbConnection<S>): void {
+    try {
+      const client = (
+        instance as unknown as {
+          session: { client: { close?: () => void } };
+        }
+      ).session.client;
+      if (client && typeof client.close === "function") {
+        client.close();
+      }
+    } catch {
+      /* ignore close failures */
+    }
+  }
+
+  /** SQLite path for the key, or `:memory:`, or `undefined` if unknown. */
+  getDbPath = (key: DbKey): string | undefined => {
+    return this.dbPaths.get(key);
+  };
+
+  /** Flush WAL pages into the main db file and reset the WAL (SQLite backup-safe). */
+  walCheckpointTruncate = (key: DbKey): void => {
+    const instance = this.instances.get(key);
+    if (!instance) {
+      throw new Error("walCheckpointTruncate: database instance not found");
+    }
+    const client = (
+      instance as unknown as {
+        session: { client: { pragma: (s: string) => unknown } };
+      }
+    ).session.client;
+    client.pragma("wal_checkpoint(TRUNCATE)");
+  };
+
+  /**
+   * Open an on-disk SQLite file and register it under an existing {@link DbKey}
+   * (after {@link disconnect} removed the prior connection). Used for audit seal
+   * rotation so the process keeps the same key while replacing the file.
+   */
+  attachConnection = (
+    key: DbKey,
+    sqlitePath: string,
+    options?: DbOptions,
+  ): void => {
+    if (this.instances.has(key)) {
+      throw new Error("attachConnection: DbKey already has an open connection");
+    }
+    const { log } = makeSubsystemReporters("init", "db.attachConnection");
+    log.info(`Attaching database at ${sqlitePath}`);
+    const sqlite = new Database(sqlitePath);
+    const pragmas = options?.pragmas ?? {};
+    for (const [pragmaKey, value] of Object.entries(pragmas)) {
+      sqlite.pragma(`${pragmaKey} = ${value}`);
+    }
+    const db = drizzle(sqlite, { schema: this.schema });
+    if (this.config.out) {
+      log.info("Running migrations...");
+      let migrationsPath = this.config.out;
+      if (migrationsPath.startsWith("./")) {
+        migrationsPath = path.join(this.rootPath, migrationsPath);
+      }
+      try {
+        migrate(db, {
+          migrationsFolder: migrationsPath,
+        });
+      } catch (error) {
+        if (error instanceof Error && error.cause) {
+          log.error(error.stack);
+          log.error(`Cause:\n\n${error.cause}\n\n`);
+        }
+        throw error;
+      }
+    }
+    this.instances.set(key, db);
+    this.dbPaths.set(key, sqlitePath);
+  };
+
   disconnect = (key: DbKey): boolean => {
     const instance = this.instances.get(key);
     if (instance) {
+      this.closeSqliteDb(instance);
       this.instances.delete(key);
       this.dbPaths.delete(key);
       return true;
@@ -234,14 +312,13 @@ export class DbManager<S extends Schema, C extends Config> {
     log.info(`Restoring database from stream to temporary file: ${tempPath}`);
 
     const writeStream = fs.createWriteStream(tempPath);
-    
+
     return new Promise((resolve, reject) => {
       stream.on("error", async (error) => {
         writeStream.destroy();
         try {
           await fs.promises.unlink(tempPath);
-        } catch {
-        }
+        } catch {}
         log.error(`Stream error during restore: ${error}`);
         reject(error);
       });
@@ -250,8 +327,7 @@ export class DbManager<S extends Schema, C extends Config> {
         stream.destroy();
         try {
           await fs.promises.unlink(tempPath);
-        } catch {
-        }
+        } catch {}
         log.error(`Write error during restore: ${error}`);
         reject(error);
       });
@@ -264,8 +340,7 @@ export class DbManager<S extends Schema, C extends Config> {
         } catch (error) {
           try {
             await fs.promises.unlink(tempPath);
-          } catch {
-          }
+          } catch {}
           log.error(`Failed to rename temporary file: ${error}`);
           reject(error);
         }
@@ -281,6 +356,9 @@ export class DbManager<S extends Schema, C extends Config> {
       disconnect: this.disconnect,
       createBackup: this.createBackup.bind(this),
       restore: this.restore.bind(this),
+      getDbPath: this.getDbPath,
+      walCheckpointTruncate: this.walCheckpointTruncate,
+      attachConnection: this.attachConnection,
     };
   }
 }

--- a/drizzle/types.ts
+++ b/drizzle/types.ts
@@ -40,6 +40,15 @@ export interface DbOptions {
    * Example: `{ journal_mode: "WAL", synchronous: "FULL" }`.
    */
   pragmas?: Record<string, string | number>;
+
+  /**
+   * If true, skip running drizzle migrations on connect/attach. Use for
+   * read-only or verify-only opens of an existing on-disk SQLite file (e.g.
+   * verifying a sealed audit-log snapshot, opening an archived file for
+   * forensics) where mutating the file's `__drizzle_migrations` table before
+   * read would change the bytes we're about to verify.
+   */
+  skipMigrations?: boolean;
 }
 
 /**

--- a/express/src/index.ts
+++ b/express/src/index.ts
@@ -18,6 +18,7 @@ export {
 export { makeContextMiddleware } from "./middleware/context.ts";
 export { makeAuthMiddleware, drainRequest } from "./middleware/auth.ts";
 export { makeCsrfMiddleware } from "./middleware/csrf.ts";
+export { makeCsrfTokenMiddleware } from "./middleware/csrf-token.ts";
 
 // multer options
 export * from "./middleware/multer.ts";

--- a/express/src/middleware/composition.ts
+++ b/express/src/middleware/composition.ts
@@ -12,6 +12,7 @@ import { blockHtml } from "./blockHtml.ts";
 import { metricsMiddleware } from "./metrics.ts";
 import { makeAuthMiddleware } from "./auth.ts";
 import { makeCsrfMiddleware } from "./csrf.ts";
+import { makeCsrfTokenMiddleware } from "./csrf-token.ts";
 import multer from "multer";
 
 /**
@@ -62,6 +63,7 @@ export const createGlobalMiddleware = (
   return [
     metricsMiddleware,
     helmet(),
+    makeCsrfTokenMiddleware(),
     healthRouter,
     everyRequestLogger,
     json(jsonLimit ? { limit: jsonLimit } : undefined),

--- a/express/src/middleware/csrf-token.ts
+++ b/express/src/middleware/csrf-token.ts
@@ -1,0 +1,80 @@
+import crypto from "node:crypto";
+import type { Handler } from "express";
+import { typedEnv } from "@saflib/env";
+
+const CSRF_COOKIE_NAME = "_csrf_token";
+const CSRF_HEADER_NAME = "x-csrf-token";
+
+declare global {
+  namespace Express {
+    interface Request {
+      isValidCsrfToken: () => boolean;
+    }
+  }
+}
+
+const normalizeDomain = (domain: string | undefined): string | undefined => {
+  if (!domain) {
+    return undefined;
+  }
+
+  return `.${domain.replace(/^\.+/, "")}`;
+};
+
+const getCookieValue = (
+  cookieHeader: string | string[] | undefined,
+  name: string,
+): string | undefined => {
+  const raw = Array.isArray(cookieHeader) ? cookieHeader.join(";") : cookieHeader;
+  if (!raw) {
+    return undefined;
+  }
+
+  const cookies = raw.split(";");
+  for (const cookie of cookies) {
+    const [cookieName, ...cookieValue] = cookie.trim().split("=");
+    if (cookieName === name) {
+      return decodeURIComponent(cookieValue.join("="));
+    }
+  }
+  return undefined;
+};
+
+const getHeaderValue = (
+  headerValue: string | string[] | undefined,
+): string | undefined => {
+  if (Array.isArray(headerValue)) {
+    return headerValue[0];
+  }
+  return headerValue;
+};
+
+const makeCsrfToken = (): string => crypto.randomBytes(24).toString("hex");
+
+export const makeCsrfTokenMiddleware = (): Handler => {
+  return (req, res, next): void => {
+    req.isValidCsrfToken = () => {
+      const cookieToken = getCookieValue(req.headers.cookie, CSRF_COOKIE_NAME);
+      const headerToken = getHeaderValue(req.headers[CSRF_HEADER_NAME]);
+      return (
+        typeof cookieToken === "string" &&
+        typeof headerToken === "string" &&
+        cookieToken.length > 0 &&
+        cookieToken === headerToken
+      );
+    };
+
+    const existingToken = getCookieValue(req.headers.cookie, CSRF_COOKIE_NAME);
+    if (!existingToken) {
+      res.cookie(CSRF_COOKIE_NAME, makeCsrfToken(), {
+        path: "/",
+        httpOnly: false,
+        sameSite: "lax",
+        secure: typedEnv.PROTOCOL === "https",
+        domain: normalizeDomain(typedEnv.DOMAIN),
+      });
+    }
+
+    return next();
+  };
+};

--- a/express/src/middleware/csrf.test.ts
+++ b/express/src/middleware/csrf.test.ts
@@ -5,6 +5,15 @@ import { typedEnv } from "@saflib/env";
 import { makeCsrfMiddleware } from "./csrf.ts";
 import { makeCsrfTokenMiddleware } from "./csrf-token.ts";
 
+const getSetCookieValues = (
+  value: string | string[] | undefined,
+): string[] | undefined => {
+  if (value === undefined) {
+    return undefined;
+  }
+  return Array.isArray(value) ? value : [value];
+};
+
 const parseSetCookie = (setCookieHeader: string): Record<string, string> => {
   const parts = setCookieHeader.split(";").map((part) => part.trim());
   const [nameValue, ...attributes] = parts;
@@ -43,10 +52,9 @@ describe("CSRF token middleware", () => {
     const response = await request(app).get("/issue");
 
     expect(response.status).toBe(200);
-    expect(response.headers["set-cookie"]).toBeTruthy();
-    const csrfCookie = (response.headers["set-cookie"] as string[]).find((c) =>
-      c.startsWith("_csrf_token="),
-    );
+    const setCookies = getSetCookieValues(response.headers["set-cookie"]);
+    expect(setCookies).toBeTruthy();
+    const csrfCookie = setCookies!.find((c) => c.startsWith("_csrf_token="));
     expect(csrfCookie).toBeTruthy();
 
     const parsed = parseSetCookie(csrfCookie as string);
@@ -75,8 +83,7 @@ describe("CSRF token middleware", () => {
       .set("Cookie", [`_csrf_token=${token}`]);
 
     expect(response.status).toBe(200);
-    const setCookie = response.headers["set-cookie"] as string[] | undefined;
-    expect(setCookie).toBeUndefined();
+    expect(getSetCookieValues(response.headers["set-cookie"])).toBeUndefined();
   });
 });
 

--- a/express/src/middleware/csrf.test.ts
+++ b/express/src/middleware/csrf.test.ts
@@ -1,0 +1,160 @@
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import express from "express";
+import request from "supertest";
+import { typedEnv } from "@saflib/env";
+import { makeCsrfMiddleware } from "./csrf.ts";
+import { makeCsrfTokenMiddleware } from "./csrf-token.ts";
+
+const parseSetCookie = (setCookieHeader: string): Record<string, string> => {
+  const parts = setCookieHeader.split(";").map((part) => part.trim());
+  const [nameValue, ...attributes] = parts;
+  const [, value = ""] = nameValue.split("=");
+  const parsed: Record<string, string> = { value };
+
+  for (const attr of attributes) {
+    const [attrName, attrValue = "true"] = attr.split("=");
+    parsed[attrName.toLowerCase()] = attrValue;
+  }
+
+  return parsed;
+};
+
+describe("CSRF token middleware", () => {
+  const originalDomain = process.env.DOMAIN;
+  const originalProtocol = process.env.PROTOCOL;
+
+  beforeAll(() => {
+    process.env.DOMAIN = "daemon.docker.localhost";
+    process.env.PROTOCOL = "http";
+  });
+
+  afterAll(() => {
+    process.env.DOMAIN = originalDomain;
+    process.env.PROTOCOL = originalProtocol;
+  });
+
+  it("issues a csrf cookie with expected attributes when missing", async () => {
+    const app = express();
+    app.use(makeCsrfTokenMiddleware());
+    app.get("/issue", (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+
+    const response = await request(app).get("/issue");
+
+    expect(response.status).toBe(200);
+    expect(response.headers["set-cookie"]).toBeTruthy();
+    const csrfCookie = (response.headers["set-cookie"] as string[]).find((c) =>
+      c.startsWith("_csrf_token="),
+    );
+    expect(csrfCookie).toBeTruthy();
+
+    const parsed = parseSetCookie(csrfCookie as string);
+    expect(parsed.value).toMatch(/^[a-f0-9]{48}$/);
+    expect(parsed.path).toBe("/");
+    expect(parsed.samesite).toBe("Lax");
+    expect(parsed.domain).toBe(".daemon.docker.localhost");
+
+    if (typedEnv.PROTOCOL === "https") {
+      expect(parsed.secure).toBe("true");
+    } else {
+      expect(parsed.secure).toBeUndefined();
+    }
+  });
+
+  it("does not regenerate token when cookie already exists", async () => {
+    const app = express();
+    app.use(makeCsrfTokenMiddleware());
+    app.get("/issue", (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+
+    const token = "a".repeat(48);
+    const response = await request(app)
+      .get("/issue")
+      .set("Cookie", [`_csrf_token=${token}`]);
+
+    expect(response.status).toBe(200);
+    const setCookie = response.headers["set-cookie"] as string[] | undefined;
+    expect(setCookie).toBeUndefined();
+  });
+});
+
+describe("CSRF validator middleware", () => {
+  const originalNodeEnv = process.env.NODE_ENV;
+
+  beforeAll(() => {
+    process.env.NODE_ENV = "development";
+  });
+
+  afterAll(() => {
+    process.env.NODE_ENV = originalNodeEnv;
+  });
+
+  it("returns 403 for mismatched token", async () => {
+    const app = express();
+    app.use(makeCsrfTokenMiddleware());
+    app.use(makeCsrfMiddleware());
+    app.post("/protected", (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+
+    const response = await request(app)
+      .post("/protected")
+      .set("Cookie", ["_csrf_token=abc"])
+      .set("X-CSRF-Token", "xyz");
+
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({
+      error: "Forbidden",
+      message: "CSRF validation failed",
+    });
+  });
+
+  it("allows state-changing request when cookie and header match", async () => {
+    const app = express();
+    app.use(makeCsrfTokenMiddleware());
+    app.use(makeCsrfMiddleware());
+    app.post("/protected", (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+
+    const token = "b".repeat(48);
+    const response = await request(app)
+      .post("/protected")
+      .set("Cookie", [`_csrf_token=${token}`])
+      .set("X-CSRF-Token", token);
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+  });
+
+  it("bypasses csrf for routes tagged no-auth", async () => {
+    const app = express();
+    app.use((req, _res, next) => {
+      req.openapi = { schema: { tags: ["no-auth"] } } as any;
+      next();
+    });
+    app.use(makeCsrfTokenMiddleware());
+    app.use(makeCsrfMiddleware());
+    app.post("/contact", (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+
+    const response = await request(app).post("/contact");
+    expect(response.status).toBe(200);
+  });
+
+  it("bypasses csrf for safe methods", async () => {
+    const app = express();
+    app.use(makeCsrfTokenMiddleware());
+    app.use(makeCsrfMiddleware());
+    app.get("/safe", (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+
+    const response = await request(app).get("/safe");
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+  });
+});

--- a/express/src/middleware/csrf.ts
+++ b/express/src/middleware/csrf.ts
@@ -4,8 +4,7 @@ import { typedEnv } from "@saflib/env";
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 
 /**
- * Require a non-simple header on state-changing requests so cross-site form POSTs
- * cannot mutate state (browser same-origin policy blocks setting custom headers).
+ * Enforce CSRF double-submit token validation on state-changing requests.
  * Skips routes tagged `no-auth` (same convention as auth middleware).
  */
 export const makeCsrfMiddleware = (): Handler => {
@@ -23,9 +22,8 @@ export const makeCsrfMiddleware = (): Handler => {
       return next();
     }
 
-    const xrw = req.headers["x-requested-with"];
     const ok =
-      typeof xrw === "string" && xrw.toLowerCase() === "xmlhttprequest";
+      typeof req.isValidCsrfToken === "function" && req.isValidCsrfToken();
 
     if (!ok) {
       if (!res.headersSent) {

--- a/express/src/middleware/metrics.ts
+++ b/express/src/middleware/metrics.ts
@@ -1,8 +1,18 @@
 import { getServiceName } from "@saflib/node";
 import promBundle from "express-prom-bundle";
 import { Router } from "express";
+import type { Request } from "express";
 
 export const metricsRouter = Router();
+
+/** Path label: Express route template from OpenAPI, or "unspecified" when no spec match. */
+function normalizeMetricPath(req: Request): string {
+  const expressRoute = req.openapi?.expressRoute;
+  if (typeof expressRoute === "string" && expressRoute.length > 0) {
+    return expressRoute;
+  }
+  return "unspecified";
+}
 
 // block external access to /metrics
 metricsRouter.get("/metrics", (req, res, next) => {
@@ -19,18 +29,14 @@ export const metricsMiddleware = promBundle({
   includeStatusCode: true,
   customLabels: {
     service_name: "",
+    operation_id: "",
   },
   includeUp: true,
-  transformLabels: (labels, req, res) => {
+  normalizePath: normalizeMetricPath,
+  transformLabels: (labels, req) => {
     labels.service_name = getServiceName();
-    // For 404s stemming from random requests trying to find vulnerabilities
-    if (res.statusCode === 404 && !req.openapi) {
-      labels.path = "/#404";
-    }
-    // OPTIONS tend to pollute metrics, so group successful ones
-    if (res.statusCode === 204 && req.method === "OPTIONS") {
-      labels.path = "/#options";
-    }
+    const opId = req.openapi?.schema?.operationId;
+    labels.operation_id = typeof opId === "string" ? opId : "";
     return labels;
   },
 });

--- a/product/workflows/templates/__product-name__/dev/caddy-config/common.Caddyfile
+++ b/product/workflows/templates/__product-name__/dev/caddy-config/common.Caddyfile
@@ -66,25 +66,6 @@ http://caddy:2020 {
 	header @has_origin Access-Control-Allow-Origin "{http.request.header.Origin}"
 }
 
-# Used for static assets accessible only to admins.
-# With "browse" enabled, you can go to the subdomain root path
-# and explore the contents.
-(admin-file-server) {
-	import cors
-	encode gzip
-	root * /srv{args[1]}
-	forward_auth {args[0]} {
-		uri /auth/verify?
-		header_up X-Csrf-Skip true
-		header_up X-Require-Admin {$BLOCK_ADMIN_PAGES}
-	}
-
-	file_server {
-		pass_thru
-		browse
-	}
-}
-
 # Recipes API (and similar): forward_auth to Kratos whoami; Express resolves identity via admin API.
 # args[0]: target service host (e.g. monolith:3002)
 (kratos-api-proxy) {
@@ -103,19 +84,5 @@ http://caddy:2020 {
 		reverse_proxy {args[0]} {
 			import reverse_proxy_common
 		}
-	}
-}
-
-# Used for standalone services which provide their own UI, only accessible to admins,
-# such as Grafana and Prometheus.
-(admin-proxy) {
-	forward_auth {args[0]} {
-		uri /auth/verify?
-		header_up X-Csrf-Skip true
-		header_up X-Require-Admin {$BLOCK_ADMIN_PAGES}
-	}
-
-	reverse_proxy {args[1]} {
-		import reverse_proxy_common
 	}
 }

--- a/product/workflows/templates/deploy/remote-assets/config/common.Caddyfile
+++ b/product/workflows/templates/deploy/remote-assets/config/common.Caddyfile
@@ -70,25 +70,6 @@ http://caddy:2020 {
 	header @has_origin Access-Control-Allow-Origin "{http.request.header.Origin}"
 }
 
-# Used for static assets accessible only to admins.
-# With "browse" enabled, you can go to the subdomain root path
-# and explore the contents.
-(admin-file-server) {
-	import cors
-	encode gzip
-	root * /srv{args[1]}
-	forward_auth {args[0]} {
-		uri /auth/verify?
-		header_up X-Csrf-Skip true
-		header_up X-Require-Admin {$BLOCK_ADMIN_PAGES}
-	}
-
-	file_server {
-		pass_thru
-		browse
-	}
-}
-
 # Recipes API (and similar): probe Kratos /sessions/whoami; copy identity on 2xx, but never short-circuit the client on 401.
 # args[0]: target service host (e.g. monolith:3002)
 (kratos-api-proxy) {
@@ -118,19 +99,5 @@ http://caddy:2020 {
 		reverse_proxy {args[0]} {
 			import reverse_proxy_common
 		}
-	}
-}
-
-# Used for standalone services which provide their own UI, only accessible to admins,
-# such as Grafana and Prometheus.
-(admin-proxy) {
-	forward_auth {args[0]} {
-		uri /auth/verify?
-		header_up X-Csrf-Skip true
-		header_up X-Require-Admin {$BLOCK_ADMIN_PAGES}
-	}
-
-	reverse_proxy {args[1]} {
-		import reverse_proxy_common
 	}
 }


### PR DESCRIPTION
Working on a few security measures here. This PR has a mix of them:
* Add some functions to the drizzle interface so it can be used for an audit log
* Fix CSRF token middleware. It got a bit simplified in the identity-service -> kratos crossover, and it's been in the back of my mind since. This fixes it.
* Fix metrics to handle short ids. Apparently the library I'm using just uses a regex to strip out ids, and my new short ids don't get caught by that, so it was incorporating ids into labels. So instead I'm using openapi, which makes a lot more sense.
* Clean up some unused caddyfile snippets. Not using them, don't want to worry about them.