### PR TITLE
Update caddy, npm packages, mock emails, express middleware and more for security

### DIFF
--- a/backup/backup-sdk/Dockerfile.template
+++ b/backup/backup-sdk/Dockerfile.template
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:labs
 FROM node:24-slim AS builder
 
+RUN npm install -g npm@11.14.1
+
 # Copy package.json
 WORKDIR /app
 

--- a/cron/cron-db/drizzle.config.ts
+++ b/cron/cron-db/drizzle.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from "drizzle-kit";
+import type { Config } from "drizzle-kit";
 import path from "path";
 import { fileURLToPath } from "url";
 import { typedEnv } from "@saflib/env";
@@ -19,9 +19,9 @@ export const getMigrationsPath = () => {
   return path.join(getDirname(), "./migrations");
 };
 
-export default defineConfig({
-  out: "./migrations", // Keep relative for drizzle-kit
-  schema: "./schema.ts", // Keep relative for drizzle-kit
-  dialect: "sqlite", // Use dialect instead of driver
+export default {
+  out: "./migrations",
+  schema: "./schema.ts",
+  dialect: "sqlite",
   dbCredentials: { url: `./data/${dbName}` },
-});
+} satisfies Config;

--- a/cron/cron-db/package.json
+++ b/cron/cron-db/package.json
@@ -15,10 +15,10 @@
   },
   "dependencies": {
     "@saflib/drizzle": "*",
-    "@saflib/env": "*",
-    "drizzle-kit": "*"
+    "@saflib/env": "*"
   },
   "devDependencies": {
-    "@saflib/vitest": "*"
+    "@saflib/vitest": "*",
+    "drizzle-kit": "*"
   }
 }

--- a/drizzle/drizzle.config.ts
+++ b/drizzle/drizzle.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from "drizzle-kit";
+import type { Config } from "drizzle-kit";
 
-export default defineConfig({
+export default {
   out: "./test-migrations",
   schema: "./test-schema.ts",
   dialect: "sqlite",
-});
+} satisfies Config;

--- a/drizzle/package.json
+++ b/drizzle/package.json
@@ -18,11 +18,11 @@
     "@saflib/node": "*",
     "@saflib/utils": "*",
     "better-sqlite3": "12.9.0",
-    "drizzle-kit": "^0.31.10",
     "drizzle-orm": "^0.45.1"
   },
   "devDependencies": {
     "@saflib/vitest": "*",
-    "@types/better-sqlite3": "^7.0.0"
+    "@types/better-sqlite3": "^7.0.0",
+    "drizzle-kit": "^0.31.10"
   }
 }

--- a/drizzle/workflows/templates/drizzle.config.ts
+++ b/drizzle/workflows/templates/drizzle.config.ts
@@ -1,7 +1,7 @@
-import { defineConfig } from "drizzle-kit";
+import type { Config } from "drizzle-kit";
 
-export default defineConfig({
+export default {
   out: "./migrations",
   schema: "./schema.ts",
   dialect: "sqlite",
-});
+} satisfies Config;

--- a/email/email-vue/package.json
+++ b/email/email-vue/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@saflib/email-spec": "*",
+    "@saflib/ory-kratos-sdk": "*",
     "@saflib/sdk": "*",
     "@saflib/vue": "*",
     "@saflib/cron-spec": "*",

--- a/email/email-vue/package.json
+++ b/email/email-vue/package.json
@@ -10,7 +10,10 @@
     "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
+    "@saflib/email-spec": "*",
+    "@saflib/sdk": "*",
     "@saflib/vue": "*",
-    "@saflib/cron-spec": "*"
+    "@saflib/cron-spec": "*",
+    "@tanstack/vue-query": "*"
   }
 }

--- a/email/email-vue/pages/last-mock-email-page/LastMockEmailPage.loader.ts
+++ b/email/email-vue/pages/last-mock-email-page/LastMockEmailPage.loader.ts
@@ -31,18 +31,18 @@ export function useLastMockEmailPageLoader() {
     throw new Error("Subdomain query param is required");
   }
 
-  // const profileQuery = useQuery(getProfile());
-  // const email = computed(() => profileQuery.data.value?.email);
-  const email = "stub@example.com";
-  const emailLoaded = true;
+  const userEmail = computed(() => {
+    const q = route.query.userEmail;
+    if (typeof q === "string" && q.trim()) {
+      return q.trim();
+    }
+    return "stub@example.com";
+  });
 
   return {
     sentEmailsQuery: useQuery({
-      ...getSentEmails(
-        subdomain,
-        computed(() => email),
-      ),
-      enabled: emailLoaded,
+      ...getSentEmails(subdomain, userEmail),
+      enabled: true,
     }),
   };
 }

--- a/email/email-vue/pages/last-mock-email-page/LastMockEmailPage.loader.ts
+++ b/email/email-vue/pages/last-mock-email-page/LastMockEmailPage.loader.ts
@@ -1,22 +1,30 @@
-// import { getProfile } from "@saflib/auth";
 import { computed, type Ref } from "vue";
 import { useQuery } from "@tanstack/vue-query";
 import { useRoute } from "vue-router";
 import { handleClientMethod } from "@saflib/sdk";
 import { createSafClient } from "@saflib/sdk";
 import type { paths as emailPaths } from "@saflib/email-spec";
+import {
+  kratosEmailFromSession,
+  useKratosSession,
+} from "@saflib/ory-kratos-sdk";
 
 export const getSentEmails = (
-  subdomain: string,
-  email?: Ref<string | undefined>,
+  subdomain: Ref<string>,
+  userEmail: Ref<string>,
 ) => {
-  const client = createSafClient<emailPaths>(subdomain);
   return {
-    queryKey: ["sent-emails", "auth", email],
+    queryKey: computed(() => [
+      "sent-emails",
+      subdomain.value,
+      userEmail.value,
+    ]),
     queryFn: async () => {
+      const client = createSafClient<emailPaths>(subdomain.value);
+      const q = userEmail.value.trim();
       return handleClientMethod(
         client.GET("/email/sent", {
-          params: { query: { userEmail: email?.value } },
+          params: { query: { userEmail: q || undefined } },
         }),
       );
     },
@@ -25,24 +33,41 @@ export const getSentEmails = (
 
 export function useLastMockEmailPageLoader() {
   const route = useRoute();
-  const subdomain = route.query.subdomain as string;
-  if (!subdomain) {
-    console.log("subdomain is required", route.query);
-    throw new Error("Subdomain query param is required");
-  }
+  const { data: session, status: sessionStatus } = useKratosSession();
+
+  const subdomain = computed(() => {
+    const q = route.query.subdomain;
+    if (typeof q === "string" && q.trim()) {
+      return q.trim();
+    }
+    return "api";
+  });
 
   const userEmail = computed(() => {
     const q = route.query.userEmail;
     if (typeof q === "string" && q.trim()) {
       return q.trim();
     }
-    return "stub@example.com";
+    return kratosEmailFromSession(session.value) ?? "";
+  });
+
+  const sentEmailsEnabled = computed(() => {
+    const explicitUserEmail =
+      typeof route.query.userEmail === "string" &&
+      route.query.userEmail.trim().length > 0;
+    if (explicitUserEmail) {
+      return true;
+    }
+    return (
+      sessionStatus.value === "success" &&
+      !!kratosEmailFromSession(session.value)
+    );
   });
 
   return {
     sentEmailsQuery: useQuery({
       ...getSentEmails(subdomain, userEmail),
-      enabled: true,
+      enabled: sentEmailsEnabled,
     }),
   };
 }

--- a/email/email-vue/pages/last-mock-email-page/LastMockEmailPage.test.ts
+++ b/email/email-vue/pages/last-mock-email-page/LastMockEmailPage.test.ts
@@ -33,6 +33,9 @@ const mockEmails: EmailResponseBody["listSentEmails"][200] = [
 ];
 
 const handlers = [
+  http.get("http://kratos.localhost:3000/sessions/whoami", () => {
+    return HttpResponse.json(null, { status: 401 });
+  }),
   http.get("http://app.localhost:3000/email/sent", () => {
     return HttpResponse.json(mockEmails);
   }),
@@ -45,7 +48,7 @@ describe("LastMockEmailPage", () => {
   expect(server).toBeDefined();
 
   const mountComponent = async (component: Component) => {
-    const route = `/last-email?subdomain=app`;
+    const route = `/last-email?subdomain=app&userEmail=recipient@example.com`;
     await router.push(route);
     const res = mountTestApp(component);
     return res;

--- a/email/email-vue/pages/last-mock-email-page/LastMockEmailPage.vue
+++ b/email/email-vue/pages/last-mock-email-page/LastMockEmailPage.vue
@@ -63,10 +63,6 @@ import { useLastMockEmailPageLoader } from "./LastMockEmailPage.loader.ts";
 
 const { sentEmailsQuery } = useLastMockEmailPageLoader();
 
-if (!sentEmailsQuery.data.value) {
-  throw new Error("Failed to load sent emails");
-}
-
 const lastEmail = computed(() => {
   const emails = sentEmailsQuery.data.value?.slice() || [];
   emails.sort((a, b) => (b.timeSent || 0) - (a.timeSent || 0));

--- a/express/src/index.ts
+++ b/express/src/index.ts
@@ -27,3 +27,5 @@ export * from "./middleware/multer.ts";
 export { createHandler } from "./handler.ts";
 
 export { makeUserHeaders, makeAdminHeaders } from "./vitest-helpers.ts";
+
+export { noStoreCacheControl } from "./middleware/noStore.ts";

--- a/express/src/middleware/composition.ts
+++ b/express/src/middleware/composition.ts
@@ -10,6 +10,7 @@ import { healthRouter } from "./health.ts";
 import { makeContextMiddleware } from "./context.ts";
 import { blockHtml } from "./blockHtml.ts";
 import { metricsMiddleware } from "./metrics.ts";
+import { noStoreCacheControl } from "./noStore.ts";
 import { makeAuthMiddleware } from "./auth.ts";
 import { makeCsrfMiddleware } from "./csrf.ts";
 import { makeCsrfTokenMiddleware } from "./csrf-token.ts";
@@ -36,6 +37,7 @@ export const createInternalMiddleware = (
   const { jsonLimit } = options;
   return [
     metricsMiddleware,
+    noStoreCacheControl,
     everyRequestLogger,
     json(
       jsonLimit
@@ -62,6 +64,7 @@ export const createGlobalMiddleware = (
   let sanitizeMiddleware: Handler[] = [blockHtml];
   return [
     metricsMiddleware,
+    noStoreCacheControl,
     helmet(),
     makeCsrfTokenMiddleware(),
     healthRouter,

--- a/express/src/middleware/noStore.test.ts
+++ b/express/src/middleware/noStore.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import express from "express";
+import request from "supertest";
+import { noStoreCacheControl } from "./noStore.ts";
+
+describe("noStoreCacheControl", () => {
+  it("sets anti-cache headers on the response", async () => {
+    const app = express();
+    app.use(noStoreCacheControl);
+    app.get("/x", (_req, res) => {
+      res.status(200).json({ ok: true });
+    });
+
+    const res = await request(app).get("/x").expect(200);
+
+    expect(res.headers["cache-control"]).toBe(
+      "private, no-store, no-cache, must-revalidate",
+    );
+    expect(res.headers["pragma"]).toBe("no-cache");
+  });
+});

--- a/express/src/middleware/noStore.ts
+++ b/express/src/middleware/noStore.ts
@@ -1,0 +1,18 @@
+import type { NextFunction, Request, Response } from "express";
+
+/**
+ * Disallow storing responses in shared or private caches. Use for APIs that
+ * return session-, tenant-, or user-specific data (RFC 7234).
+ */
+export const noStoreCacheControl = (
+  _req: Request,
+  res: Response,
+  next: NextFunction,
+) => {
+  res.setHeader(
+    "Cache-Control",
+    "private, no-store, no-cache, must-revalidate",
+  );
+  res.setHeader("Pragma", "no-cache");
+  next();
+};

--- a/ory-kratos-spa/fixtures.ts
+++ b/ory-kratos-spa/fixtures.ts
@@ -5,6 +5,10 @@ export {
   loginPageFixture,
 } from "./pages/login/login.fixture.ts";
 export {
+  LogoutPageFixture,
+  logoutPageFixture,
+} from "./pages/logout/logout.fixture.ts";
+export {
   RegistrationPageFixture,
   registrationPageFixture,
 } from "./pages/registration/registration.fixture.ts";

--- a/ory-kratos-spa/fixtures.ts
+++ b/ory-kratos-spa/fixtures.ts
@@ -16,4 +16,8 @@ export {
   VerifyWallPageFixture,
   verifyWallPageFixture,
 } from "./pages/verify-wall/verify-wall.fixture.ts";
+export {
+  VerificationPageFixture,
+  verificationPageFixture,
+} from "./pages/verification/verification.fixture.ts";
 // END WORKFLOW AREA

--- a/ory-kratos-spa/pages/login/login.fixture.ts
+++ b/ory-kratos-spa/pages/login/login.fixture.ts
@@ -8,6 +8,19 @@ export class LoginPageFixture {
   constructor(public readonly page: Page) {}
 
   /**
+   * Opens the auth host login flow (browser flow creation). Optional {@link returnTo} sets `?return_to=`.
+   */
+  async gotoLogin(options?: { returnTo?: string }): Promise<void> {
+    const protocol = process.env.PROTOCOL ?? "http";
+    const domain = process.env.DOMAIN ?? "daemon.docker.localhost";
+    let url = `${protocol}://auth.${domain}/new-login`;
+    if (options?.returnTo) {
+      url += `?return_to=${encodeURIComponent(options.returnTo)}`;
+    }
+    await this.page.goto(url);
+  }
+
+  /**
    * Asserts the first-step login view is visible, like `expect(locator).toBeVisible()`.
    */
   async toBeVisible(): Promise<void> {

--- a/ory-kratos-spa/pages/logout/logout.fixture.ts
+++ b/ory-kratos-spa/pages/logout/logout.fixture.ts
@@ -1,4 +1,4 @@
-import type { Page } from "@playwright/test";
+import { expect, type Page } from "@playwright/test";
 
 /**
  * Navigation helpers for {@link ./LogoutAsync.vue} (browser logout flow; redirects via Kratos).
@@ -7,17 +7,25 @@ export class LogoutPageFixture {
   constructor(public readonly page: Page) {}
 
   /**
-   * Starts logout on the auth host. After Kratos finishes, the browser typically lands on the site
-   * root or {@link returnTo} when passed as `?return_to=`.
+   * Runs browser logout on the auth host and waits until the browser has reached {@link returnTo}
+   * (defaults to site root: {@link process.env.PROTOCOL}://{@link process.env.DOMAIN}/).
    */
   async gotoLogout(options?: { returnTo?: string }): Promise<void> {
     const protocol = process.env.PROTOCOL ?? "http";
     const domain = process.env.DOMAIN ?? "daemon.docker.localhost";
-    let url = `${protocol}://auth.${domain}/logout`;
-    if (options?.returnTo) {
-      url += `?return_to=${encodeURIComponent(options.returnTo)}`;
-    }
+    const siteRoot = `${protocol}://${domain}/`;
+    const returnTo = options?.returnTo ?? siteRoot;
+    const url = `${protocol}://auth.${domain}/logout?return_to=${encodeURIComponent(returnTo)}`;
     await this.page.goto(url);
+
+    const target = new URL(returnTo);
+    const normPath = (p: string) => p.replace(/\/$/, "") || "/";
+    await expect(this.page).toHaveURL((u) => {
+      if (u.hostname !== target.hostname) {
+        return false;
+      }
+      return normPath(u.pathname) === normPath(target.pathname);
+    });
   }
 }
 

--- a/ory-kratos-spa/pages/logout/logout.fixture.ts
+++ b/ory-kratos-spa/pages/logout/logout.fixture.ts
@@ -1,0 +1,29 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Navigation helpers for {@link ./LogoutAsync.vue} (browser logout flow; redirects via Kratos).
+ */
+export class LogoutPageFixture {
+  constructor(public readonly page: Page) {}
+
+  /**
+   * Starts logout on the auth host. After Kratos finishes, the browser typically lands on the site
+   * root or {@link returnTo} when passed as `?return_to=`.
+   */
+  async gotoLogout(options?: { returnTo?: string }): Promise<void> {
+    const protocol = process.env.PROTOCOL ?? "http";
+    const domain = process.env.DOMAIN ?? "daemon.docker.localhost";
+    let url = `${protocol}://auth.${domain}/logout`;
+    if (options?.returnTo) {
+      url += `?return_to=${encodeURIComponent(options.returnTo)}`;
+    }
+    await this.page.goto(url);
+  }
+}
+
+export const logoutPageFixture = async (
+  { page }: { page: Page },
+  use: (fixture: LogoutPageFixture) => Promise<void>,
+) => {
+  await use(new LogoutPageFixture(page));
+};

--- a/ory-kratos-spa/pages/registration/registration.fixture.ts
+++ b/ory-kratos-spa/pages/registration/registration.fixture.ts
@@ -8,6 +8,16 @@ export class RegistrationPageFixture {
   constructor(public readonly page: Page) {}
 
   /**
+   * Opens the auth host registration entry route (two-step Kratos flow).
+   * Uses {@link process.env.PROTOCOL} and {@link process.env.DOMAIN} (e.g. Playwright client config).
+   */
+  async gotoRegistration(): Promise<void> {
+    const protocol = process.env.PROTOCOL ?? "http";
+    const domain = process.env.DOMAIN ?? "daemon.docker.localhost";
+    await this.page.goto(`${protocol}://auth.${domain}/new-registration`);
+  }
+
+  /**
    * Asserts the registration view is visible (intro + flow shell), like `expect(locator).toBeVisible()`.
    */
   async toBeVisible(): Promise<void> {
@@ -66,12 +76,17 @@ export class RegistrationPageFixture {
 
   /**
    * Full registration: email step, then password step (two-step Kratos flow).
+   * Fills first/last name only when those traits exist in the flow (schema-dependent).
    */
   async completeRegistration(email: string, password: string): Promise<void> {
     await this.fillEmail(email);
     await this.submitEmailStep();
-    await this.fillFirstName("Test");
-    await this.fillLastName("User");
+    if ((await this.firstNameInput.count()) > 0) {
+      await this.fillFirstName("Test");
+    }
+    if ((await this.lastNameInput.count()) > 0) {
+      await this.fillLastName("User");
+    }
     await this.fillPassword(password);
     await this.submitPasswordStep();
   }

--- a/ory-kratos-spa/pages/registration/registration.fixture.ts
+++ b/ory-kratos-spa/pages/registration/registration.fixture.ts
@@ -96,17 +96,18 @@ export class RegistrationPageFixture {
    * Opens the admin last-mock-email page (`adminLinks.lastMockEmail` in `@pathclerk/daemon-links`),
    * then follows the Kratos verification link from the newest matching mock-sent email.
    *
-   * @param params.subdomain — SDK service subdomain for `GET /email/sent` (CaseDaemon: `"identity"`).
+   * @param params.subdomain — SDK service subdomain for `GET /email/sent` (defaults to `"api"`).
    */
   async completeEmailVerification(
     adminLastEmailLink: Link,
-    params: { subdomain: string; userEmail: string },
+    params: { subdomain?: string; userEmail: string },
   ): Promise<void> {
     const domain = process.env.DOMAIN ?? "daemon.docker.localhost";
+    const subdomain = params.subdomain ?? "api";
     const url = linkToHref(adminLastEmailLink, {
       domain,
       params: {
-        subdomain: params.subdomain,
+        subdomain,
         userEmail: params.userEmail,
       },
     });

--- a/ory-kratos-spa/pages/registration/registration.fixture.ts
+++ b/ory-kratos-spa/pages/registration/registration.fixture.ts
@@ -1,6 +1,7 @@
 import { expect, type Page } from "@playwright/test";
 import { linkToHref, type Link } from "@saflib/links";
 import { registration_intro as introStrings } from "./RegistrationIntro.strings.ts";
+import { VerificationPageFixture } from "../verification/verification.fixture.ts";
 
 /**
  * Page helpers for {@link ./Registration.vue} (Kratos registration flow UI).
@@ -112,11 +113,15 @@ export class RegistrationPageFixture {
       },
     });
     await this.page.goto(url);
-    const kratosLink = this.page.locator(
-      'a[href*="verification"], a[href*="self-service"]',
-    ).first();
+    const kratosLink = this.page
+      .locator('a[href*="verification"], a[href*="self-service"]')
+      .first();
     await expect(kratosLink).toBeVisible({ timeout: 60_000 });
     await kratosLink.click();
+    const verificationPage = new VerificationPageFixture(this.page);
+    await verificationPage.toBeVisible();
+    await verificationPage.clickContinue();
+    await verificationPage.expectRedirectToAppSubdomain();
   }
 }
 

--- a/ory-kratos-spa/pages/registration/registration.fixture.ts
+++ b/ory-kratos-spa/pages/registration/registration.fixture.ts
@@ -103,6 +103,9 @@ export class RegistrationPageFixture {
     adminLastEmailLink: Link,
     params: { subdomain?: string; userEmail: string },
   ): Promise<void> {
+    // wait briefly so the user becomes logged in
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
     const domain = process.env.DOMAIN ?? "daemon.docker.localhost";
     const subdomain = params.subdomain ?? "api";
     const url = linkToHref(adminLastEmailLink, {

--- a/ory-kratos-spa/pages/registration/registration.fixture.ts
+++ b/ory-kratos-spa/pages/registration/registration.fixture.ts
@@ -116,7 +116,7 @@ export class RegistrationPageFixture {
     const kratosLink = this.page
       .locator('a[href*="verification"], a[href*="self-service"]')
       .first();
-    await expect(kratosLink).toBeVisible({ timeout: 60_000 });
+    await expect(kratosLink).toBeVisible();
     await kratosLink.click();
     const verificationPage = new VerificationPageFixture(this.page);
     await verificationPage.toBeVisible();

--- a/ory-kratos-spa/pages/registration/registration.fixture.ts
+++ b/ory-kratos-spa/pages/registration/registration.fixture.ts
@@ -1,4 +1,5 @@
 import { expect, type Page } from "@playwright/test";
+import { linkToHref, type Link } from "@saflib/links";
 import { registration_intro as introStrings } from "./RegistrationIntro.strings.ts";
 
 /**
@@ -89,6 +90,32 @@ export class RegistrationPageFixture {
     }
     await this.fillPassword(password);
     await this.submitPasswordStep();
+  }
+
+  /**
+   * Opens the admin last-mock-email page (`adminLinks.lastMockEmail` in `@pathclerk/daemon-links`),
+   * then follows the Kratos verification link from the newest matching mock-sent email.
+   *
+   * @param params.subdomain — SDK service subdomain for `GET /email/sent` (CaseDaemon: `"identity"`).
+   */
+  async completeEmailVerification(
+    adminLastEmailLink: Link,
+    params: { subdomain: string; userEmail: string },
+  ): Promise<void> {
+    const domain = process.env.DOMAIN ?? "daemon.docker.localhost";
+    const url = linkToHref(adminLastEmailLink, {
+      domain,
+      params: {
+        subdomain: params.subdomain,
+        userEmail: params.userEmail,
+      },
+    });
+    await this.page.goto(url);
+    const kratosLink = this.page.locator(
+      'a[href*="verification"], a[href*="self-service"]',
+    ).first();
+    await expect(kratosLink).toBeVisible({ timeout: 60_000 });
+    await kratosLink.click();
   }
 }
 

--- a/ory-kratos-spa/pages/verification/verification.fixture.ts
+++ b/ory-kratos-spa/pages/verification/verification.fixture.ts
@@ -1,0 +1,49 @@
+import { expect, type Page } from "@playwright/test";
+import {
+  verification_intro,
+  verification_verified,
+} from "./VerificationIntro.strings.ts";
+
+/**
+ * Page helpers for {@link ./Verification.vue} (Kratos email verification flow).
+ */
+export class VerificationPageFixture {
+  constructor(public readonly page: Page) {}
+
+  /**
+   * Asserts the verification intro heading is visible ({@link verification_intro.title}).
+   */
+  async toBeVisible(): Promise<void> {
+    await expect(
+      this.page.getByRole("heading", { name: verification_intro.title }),
+    ).toBeVisible();
+  }
+
+  /**
+   * Submits the verification step using the flow submit button labeled {@link verification_verified.cta_continue}.
+   */
+  async clickContinue(): Promise<void> {
+    await this.page
+      .getByRole("button", { name: verification_verified.cta_continue })
+      .click();
+  }
+
+  /**
+   * Waits until the browser lands on the app host after post-verification redirect.
+   */
+  async expectRedirectToAppSubdomain(): Promise<void> {
+    const domain = process.env.DOMAIN ?? "daemon.docker.localhost";
+    const escaped = domain.replace(/\./g, "\\.");
+    await expect(this.page).toHaveURL(
+      new RegExp(`^https?://app\\.${escaped}(/|\\?|#|$)`),
+      { timeout: 60_000 },
+    );
+  }
+}
+
+export const verificationPageFixture = async (
+  { page }: { page: Page },
+  use: (fixture: VerificationPageFixture) => Promise<void>,
+) => {
+  await use(new VerificationPageFixture(page));
+};

--- a/playwright/global.setup.ts
+++ b/playwright/global.setup.ts
@@ -2,6 +2,7 @@ import { expect, test as setup } from "@playwright/test";
 
 const serviceSubdomains = process.env.SERVICE_SUBDOMAINS?.split(",") || [];
 const domain = process.env.DOMAIN;
+const protocol = process.env.PROTOCOL;
 
 setup("check docker service health", async ({ page }) => {
   let response;
@@ -13,7 +14,7 @@ setup("check docker service health", async ({ page }) => {
     anyUnhealthy = false;
     for (const serviceSubdomain of serviceSubdomains) {
       // uses @saflib/express's health middleware
-      const url = `http://${serviceSubdomain}.${domain}/health`;
+      const url = `${protocol}://${serviceSubdomain}.${domain}/health`;
       response = await page.goto(url);
       console.log(`Response from ${url}: ${response?.status()}`);
       if (response && response.status() !== 200) {

--- a/product/workflows/templates/.github/workflows/playwright.yml
+++ b/product/workflows/templates/.github/workflows/playwright.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Generate Docker
         run: node --experimental-strip-types --disable-warning=ExperimentalWarning saflib/dev-tools/src/saf-docker-cli.ts generate
       - name: Pre-build images
-        run: npm run build-no-generate
+        run: npm run build:ci
         working-directory: ./deploy
       - name: Run server
         run: npm run prod-local &> last-docker-compose.log &

--- a/product/workflows/templates/__product-name__/dev/Dockerfile.template
+++ b/product/workflows/templates/__product-name__/dev/Dockerfile.template
@@ -9,6 +9,8 @@ RUN npm run build
 # Monorepo install once — workspace closure of __organization-name__/__product-name__-dev (__product-name__ static builds for this stack).
 FROM node:24-slim AS deps
 
+RUN npm install -g npm@11.14.1
+
 WORKDIR /app
 
 #{ copy_packages }#

--- a/product/workflows/templates/deploy/Dockerfile.prod
+++ b/product/workflows/templates/deploy/Dockerfile.prod
@@ -10,7 +10,12 @@ RUN export $(grep -v "^#" /app/env.__product-name__.prod-local | xargs) && DOMAI
 
 # END WORKFLOW AREA
 
-FROM caddy:2.11.2
+FROM caddy:2.11.2-builder-alpine AS caddy-rebuild
+RUN xcaddy build v2.11.2
+
+FROM caddy:2.11.2-alpine
+COPY --from=caddy-rebuild /usr/bin/caddy /usr/bin/caddy
+RUN apk upgrade --no-cache && rm -rf /var/cache/apk/*
 
 # Copy over static client builds here:
 COPY --from=__organization-name__-__product-name__-root-builder /app/__product-name__/clients/root/.vitepress/dist /srv/__product-name__-root

--- a/product/workflows/templates/deploy/package.json
+++ b/product/workflows/templates/deploy/package.json
@@ -11,7 +11,7 @@
     "prod-local": ". ./env.remote && CONTAINER_REGISTRY=$CONTAINER_REGISTRY docker compose -f docker-compose.prod-local.yaml up",
     "exec-remote": "./local-scripts/exec-remote.sh",
     "build": "npm run generate && cd .. && ./deploy/local-scripts/build.sh",
-    "build-no-generate": "cd .. && ./deploy/local-scripts/build.sh",
+    "build:ci": "cd .. && ./deploy/local-scripts/build.sh",
     "push": "cd .. && ./deploy/local-scripts/push.sh",
     "sync": ". env.remote && cd .. && ./deploy/local-scripts/sync.sh",
     "remote-purge": "npm run exec-remote < ./remote-scripts/purge.sh",

--- a/sdk/workflows/templates/Dockerfile.template
+++ b/sdk/workflows/templates/Dockerfile.template
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:labs
 FROM node:24-slim AS builder
 
+RUN npm install -g npm@11.14.1
+
 # Copy package.json
 WORKDIR /app
 

--- a/vite/vite.config.ts
+++ b/vite/vite.config.ts
@@ -90,13 +90,18 @@ export interface MakeConfigProps {
    * Use subdomain proxy plugin
    */
   useSubdomainProxy?: boolean;
+  /**
+   * Emit `.js.map` files alongside chunks. Disable for production deploys where maps must not be served publicly (Sentry uploads may still use plugin defaults).
+   * @default true
+   */
+  sourcemap?: boolean;
 }
 
 /**
  * Make a Vite config for a multi-SPA, SAF project. Includes all the expected plugins.
  */
 export function makeConfig(config: MakeConfigProps = {}) {
-  const { plugins = [], vuetifyOverrides, monorepoRoot } = config;
+  const { plugins = [], vuetifyOverrides, monorepoRoot, sourcemap } = config;
   if (config.useSubdomainProxy !== false) {
     plugins.push(subDomainProxyPlugin);
   }
@@ -116,7 +121,7 @@ export function makeConfig(config: MakeConfigProps = {}) {
         input,
         plugins: [ignore(["**/*.test.ts"])],
       },
-      sourcemap: true,
+      sourcemap: sourcemap ?? true,
     },
 
     server: {

--- a/vue/workflows/template/__static-subdomain-name__/Dockerfile.template
+++ b/vue/workflows/template/__static-subdomain-name__/Dockerfile.template
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:labs
 FROM node:24-slim AS builder
 
+RUN npm install -g npm@11.14.1
+
 WORKDIR /app
 #{ copy_packages }#
 RUN npm install --omit=dev

--- a/vue/workflows/template/build/Dockerfile.template
+++ b/vue/workflows/template/build/Dockerfile.template
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:labs
 FROM node:24-slim AS builder
 
+RUN npm install -g npm@11.14.1
+
 # Copy package.json
 WORKDIR /app
 


### PR DESCRIPTION
Some more updates based on security.

* Update npm within docker images
* Don't include drizzle-kit in docker images; use types instead
* Improve mock email page to show the current user's last email by default
* Add some no-cache headers to the API server
* Extend the auth page fixtures and playwright config for testing
* Rename deploy's build-no-generate to build:ci to distinguish it better
* Upgrade caddy's OS packages to clear out some vulnerabilities
* Don't include source files in production builds