### PR TITLE
Hide passkey signup

### DIFF
--- a/ory-kratos-spa/pages/registration/Registration.vue
+++ b/ory-kratos-spa/pages/registration/Registration.vue
@@ -17,6 +17,7 @@
 </template>
 
 <script setup lang="ts">
+import type { RegistrationFlow } from "@ory/client";
 import {
   FlowGone,
   RegistrationFlowFetched,
@@ -27,16 +28,17 @@ import CsrfViolationPanel from "../common/CsrfViolationPanel.vue";
 import FlowGonePanel from "../common/FlowGonePanel.vue";
 import UnhandledResponsePanel from "../common/UnhandledResponsePanel.vue";
 import RegistrationFlowForm from "./RegistrationFlowForm.vue";
+import { registrationFlowHidingPasskeySignup } from "./kratosRegistrationPasskeyUi.logic.ts";
 import { computed, toValue } from "vue";
 
 const { getRegistrationFlowQuery } = useRegistrationLoader();
 
 const queryData = computed(() => toValue(getRegistrationFlowQuery.data));
 
-const flow = computed(() => {
+const flow = computed((): RegistrationFlow | null => {
   const d = queryData.value;
   if (d instanceof RegistrationFlowFetched) {
-    return d.flow;
+    return registrationFlowHidingPasskeySignup(d.flow);
   }
   return null;
 });

--- a/ory-kratos-spa/pages/registration/kratosRegistrationPasskeyUi.logic.test.ts
+++ b/ory-kratos-spa/pages/registration/kratosRegistrationPasskeyUi.logic.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import type { RegistrationFlow, UiNode } from "@ory/client";
+import {
+  omitRegistrationPasskeySignupNodes,
+  registrationFlowHidingPasskeySignup,
+} from "./kratosRegistrationPasskeyUi.logic.ts";
+
+function passkeyTriggerNode(): UiNode {
+  return {
+    type: "input",
+    group: "passkey",
+    attributes: {
+      name: "passkey_register_trigger",
+      type: "button",
+      disabled: false,
+      onclick: "window.oryPasskeyRegistration()",
+      onclickTrigger: "oryPasskeyRegistration",
+      node_type: "input",
+    },
+    messages: [],
+    meta: {
+      label: {
+        id: 1040007,
+        text: "Sign up with passkey",
+        type: "info",
+      },
+    },
+  };
+}
+
+describe("kratosRegistrationPasskeyUi", () => {
+  it("omits passkey-group nodes", () => {
+    const email: UiNode = {
+      type: "input",
+      group: "default",
+      attributes: {
+        name: "traits.email",
+        type: "email",
+        node_type: "input",
+      },
+      messages: [],
+    };
+    const out = omitRegistrationPasskeySignupNodes([email, passkeyTriggerNode()]);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toBe(email);
+  });
+
+  it("returns the same flow reference when nothing is removed", () => {
+    const flow = {
+      id: "flow-1",
+      ui: { nodes: [{ type: "text", group: "default" } as UiNode] },
+    } as RegistrationFlow;
+    expect(registrationFlowHidingPasskeySignup(flow)).toBe(flow);
+  });
+
+  it("clones flow when passkey nodes are stripped", () => {
+    const flow = {
+      id: "flow-1",
+      ui: { nodes: [passkeyTriggerNode()] },
+    } as RegistrationFlow;
+    const next = registrationFlowHidingPasskeySignup(flow);
+    expect(next).not.toBe(flow);
+    expect(next.ui.nodes).toHaveLength(0);
+  });
+});

--- a/ory-kratos-spa/pages/registration/kratosRegistrationPasskeyUi.logic.test.ts
+++ b/ory-kratos-spa/pages/registration/kratosRegistrationPasskeyUi.logic.test.ts
@@ -36,9 +36,11 @@ describe("kratosRegistrationPasskeyUi", () => {
       attributes: {
         name: "traits.email",
         type: "email",
+        disabled: false,
         node_type: "input",
       },
       messages: [],
+      meta: {},
     };
     const out = omitRegistrationPasskeySignupNodes([email, passkeyTriggerNode()]);
     expect(out).toHaveLength(1);

--- a/ory-kratos-spa/pages/registration/kratosRegistrationPasskeyUi.logic.ts
+++ b/ory-kratos-spa/pages/registration/kratosRegistrationPasskeyUi.logic.ts
@@ -1,0 +1,20 @@
+import type { RegistrationFlow, UiNode } from "@ory/client";
+
+/**
+ * Drops Kratos registration UI nodes in the `passkey` group (e.g. "Sign up with passkey").
+ * Passkeys remain available after signup via settings.
+ */
+export function omitRegistrationPasskeySignupNodes(
+  nodes: readonly UiNode[],
+): UiNode[] {
+  return nodes.filter((n) => (n.group ?? "default") !== "passkey");
+}
+
+/** Shallow clone only when nodes are removed so consumers keep referential stability. */
+export function registrationFlowHidingPasskeySignup(
+  flow: RegistrationFlow,
+): RegistrationFlow {
+  const nodes = omitRegistrationPasskeySignupNodes(flow.ui.nodes);
+  if (nodes.length === flow.ui.nodes.length) return flow;
+  return { ...flow, ui: { ...flow.ui, nodes } };
+}


### PR DESCRIPTION
When passkeys are enabled, I'd rather they not show up on the registration form. Hide them. This also helps fix playwright tests.