### PR TITLE
Clean daemon mentions

### DIFF
--- a/dev-site/dev-site-http/analyze-commit.ts
+++ b/dev-site/dev-site-http/analyze-commit.ts
@@ -29,7 +29,7 @@ export const ANALYZER_VERSION = "4";
 
 export interface AnalyzeCommitOptions {
   repoRoot: string;
-  /** Limit analysis to paths under this prefix (e.g. `daemon`). Empty = whole repo. */
+  /** Limit analysis to paths under this prefix (e.g. `products`). Empty = whole repo. */
   productRoot?: string;
   /** Main branch ref for isMainAncestor. Defaults to `main`. */
   mainRef?: string;

--- a/dev-site/dev-site-http/bin/saf-dev-site/diff.ts
+++ b/dev-site/dev-site-http/bin/saf-dev-site/diff.ts
@@ -16,7 +16,7 @@ export const addDiffCommand = (program: Command) => {
     )
     .option(
       "--product-root <path>",
-      "Path prefix within the repo (e.g. daemon)",
+      "Path prefix within the repo (e.g. products)",
       "",
     )
     .option("--main-ref <ref>", "Main branch ref", "main")

--- a/dev-site/dev-site-http/bin/saf-dev-site/scan.ts
+++ b/dev-site/dev-site-http/bin/saf-dev-site/scan.ts
@@ -16,7 +16,7 @@ export const addScanCommand = (program: Command) => {
     )
     .option(
       "--product-root <path>",
-      "Path prefix within the repo (e.g. daemon)",
+      "Path prefix within the repo (e.g. products)",
       "",
     )
     .option("--main-ref <ref>", "Main branch ref", "main")

--- a/dev-site/dev-site-http/bin/saf-dev-site/show.ts
+++ b/dev-site/dev-site-http/bin/saf-dev-site/show.ts
@@ -15,7 +15,7 @@ export const addShowCommand = (program: Command) => {
     )
     .option(
       "--product-root <path>",
-      "Path prefix within the repo (e.g. daemon)",
+      "Path prefix within the repo (e.g. products)",
       "",
     )
     .option("--main-ref <ref>", "Main branch ref", "main")

--- a/dev-site/dev-site-http/checkout.ts
+++ b/dev-site/dev-site-http/checkout.ts
@@ -19,7 +19,7 @@ export interface CheckoutStatus {
   message: string;
   authoredAt: string;
   analyzed: boolean;
-  /** Path prefix used when analyzing (e.g. `daemon`). Empty = whole repo. */
+  /** Path prefix used when analyzing (e.g. `products`). Empty = whole repo. */
   productRoot: string;
   packages: CheckoutPackage[];
 }

--- a/dev-site/dev-site-http/classify.ts
+++ b/dev-site/dev-site-http/classify.ts
@@ -1,5 +1,5 @@
 /**
- * Classification heuristics ported/generalized from `daemon/code-health/inventory.ts`.
+ * Classification heuristics for inventory-style package/file categorization.
  * Applied to git-tree paths (no checkout) so historical commits classify the same way.
  */
 

--- a/dev-site/dev-site-http/http.ts
+++ b/dev-site/dev-site-http/http.ts
@@ -25,7 +25,7 @@ export type CreateDevSiteHttpAppOptions = {
   devSiteDbKey?: DbKey;
   /** Absolute path to the git repo to analyze. Defaults to process.cwd(). */
   repoRoot?: string;
-  /** Path prefix within the repo (e.g. `daemon`). Defaults to "". */
+  /** Path prefix within the repo (e.g. `products`). Defaults to "". */
   productRoot?: string;
   /** Main branch ref. Defaults to `main`. */
   mainRef?: string;

--- a/dev-site/dev-site-http/scan-worker.ts
+++ b/dev-site/dev-site-http/scan-worker.ts
@@ -28,7 +28,7 @@ async function main(): Promise<void> {
     throw new Error("scan-worker must run as a worker thread");
   }
   // DbManager logging uses @saflib/node reporters, which require a service name.
-  setServiceName("daemon-dev-site-scan-worker");
+  setServiceName("dev-site-scan-worker");
 
   const data = workerData as ScanWorkerData;
   const dbKey = devSiteDb.connect({

--- a/dev-site/dev-site-http/scan.ts
+++ b/dev-site/dev-site-http/scan.ts
@@ -14,7 +14,7 @@ import { analyzeCommit, ANALYZER_VERSION } from "./analyze-commit.ts";
 
 export interface ScanOptions {
   repoRoot: string;
-  /** Limit analysis to this path prefix (e.g. `daemon`). */
+  /** Limit analysis to this path prefix (e.g. `products`). */
   productRoot?: string;
   /** Main branch ref. Defaults to `main`. */
   mainRef?: string;

--- a/dev-site/dev-site-spec/dist/openapi.d.ts
+++ b/dev-site/dev-site-spec/dist/openapi.d.ts
@@ -544,7 +544,7 @@ export interface operations {
             header?: never;
             path: {
                 hash: string;
-                /** @description npm package name (URL-encoded), e.g. `%40pathclerk%2Fdaemon-forms` */
+                /** @description npm package name (URL-encoded), e.g. `%40example%2Fbilling-http` */
                 packageName: string;
             };
             cookie?: never;
@@ -665,7 +665,7 @@ export interface operations {
                         /** Format: date-time */
                         authoredAt: string;
                         analyzed: boolean;
-                        /** @description Analysis path prefix within the repo (e.g. `daemon`). Empty string means the whole repository. Package `directory` values are relative to this prefix; prepend it for repo-absolute paths. */
+                        /** @description Analysis path prefix within the repo (e.g. `products`). Empty string means the whole repository. Package `directory` values are relative to this prefix; prepend it for repo-absolute paths. */
                         productRoot: string;
                         packages: {
                             packageName: string;

--- a/dev-site/dev-site-spec/dist/openapi.json
+++ b/dev-site/dev-site-spec/dist/openapi.json
@@ -202,7 +202,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "npm package name (URL-encoded), e.g. `%40pathclerk%2Fdaemon-forms`"
+            "description": "npm package name (URL-encoded), e.g. `%40example%2Fbilling-http`"
           }
         ],
         "responses": {
@@ -432,7 +432,7 @@
                     },
                     "productRoot": {
                       "type": "string",
-                      "description": "Analysis path prefix within the repo (e.g. `daemon`). Empty string means the whole repository. Package `directory` values are relative to this prefix; prepend it for repo-absolute paths.\n"
+                      "description": "Analysis path prefix within the repo (e.g. `products`). Empty string means the whole repository. Package `directory` values are relative to this prefix; prepend it for repo-absolute paths.\n"
                     },
                     "packages": {
                       "type": "array",

--- a/dev-site/dev-site-spec/dist/operations/getCheckout/openapi.d.ts
+++ b/dev-site/dev-site-spec/dist/operations/getCheckout/openapi.d.ts
@@ -67,7 +67,7 @@ export interface operations {
                         /** Format: date-time */
                         authoredAt: string;
                         analyzed: boolean;
-                        /** @description Analysis path prefix within the repo (e.g. `daemon`). Empty string means the whole repository. Package `directory` values are relative to this prefix; prepend it for repo-absolute paths. */
+                        /** @description Analysis path prefix within the repo (e.g. `products`). Empty string means the whole repository. Package `directory` values are relative to this prefix; prepend it for repo-absolute paths. */
                         productRoot: string;
                         packages: {
                             packageName: string;

--- a/dev-site/dev-site-spec/dist/operations/getCheckout/openapi.json
+++ b/dev-site/dev-site-spec/dist/operations/getCheckout/openapi.json
@@ -44,7 +44,7 @@
                     },
                     "productRoot": {
                       "type": "string",
-                      "description": "Analysis path prefix within the repo (e.g. `daemon`). Empty string means the whole repository. Package `directory` values are relative to this prefix; prepend it for repo-absolute paths.\n"
+                      "description": "Analysis path prefix within the repo (e.g. `products`). Empty string means the whole repository. Package `directory` values are relative to this prefix; prepend it for repo-absolute paths.\n"
                     },
                     "packages": {
                       "type": "array",

--- a/dev-site/dev-site-spec/dist/operations/getCommitPackage/openapi.d.ts
+++ b/dev-site/dev-site-spec/dist/operations/getCommitPackage/openapi.d.ts
@@ -125,7 +125,7 @@ export interface operations {
             header?: never;
             path: {
                 hash: string;
-                /** @description npm package name (URL-encoded), e.g. `%40pathclerk%2Fdaemon-forms` */
+                /** @description npm package name (URL-encoded), e.g. `%40example%2Fbilling-http` */
                 packageName: string;
             };
             cookie?: never;

--- a/dev-site/dev-site-spec/dist/operations/getCommitPackage/openapi.json
+++ b/dev-site/dev-site-spec/dist/operations/getCommitPackage/openapi.json
@@ -29,7 +29,7 @@
             "schema": {
               "type": "string"
             },
-            "description": "npm package name (URL-encoded), e.g. `%40pathclerk%2Fdaemon-forms`"
+            "description": "npm package name (URL-encoded), e.g. `%40example%2Fbilling-http`"
           }
         ],
         "responses": {

--- a/dev-site/dev-site-spec/routes/checkout/get.yaml
+++ b/dev-site/dev-site-spec/routes/checkout/get.yaml
@@ -33,7 +33,7 @@ getCheckout:
               productRoot:
                 type: string
                 description: >
-                  Analysis path prefix within the repo (e.g. `daemon`). Empty
+                  Analysis path prefix within the repo (e.g. `products`). Empty
                   string means the whole repository. Package `directory` values
                   are relative to this prefix; prepend it for repo-absolute paths.
               packages:

--- a/dev-site/dev-site-spec/routes/commits/package.yaml
+++ b/dev-site/dev-site-spec/routes/commits/package.yaml
@@ -18,7 +18,7 @@ getCommitPackage:
       required: true
       schema:
         type: string
-      description: npm package name (URL-encoded), e.g. `%40pathclerk%2Fdaemon-forms`
+      description: npm package name (URL-encoded), e.g. `%40example%2Fbilling-http`
   responses:
     "200":
       description: Package detail at commit

--- a/dev-site/dev-site-vue/package-dir-tree.test.ts
+++ b/dev-site/dev-site-vue/package-dir-tree.test.ts
@@ -8,24 +8,28 @@ describe("buildPackageDirTree", () => {
   it("stops at package roots and nests path segments", () => {
     const tree = buildPackageDirTree([
       {
-        packageName: "@pathclerk/daemon-forms",
-        directory: "daemon/forms",
+        packageName: "@example/billing-db",
+        directory: "products/billing/service/db",
       },
       {
-        packageName: "@pathclerk/daemon-dev-site-http",
-        directory: "daemon/dev-site/service/http",
+        packageName: "@example/billing-http",
+        directory: "products/billing/service/http",
       },
       {
         packageName: "@saflib/git",
         directory: "saflib/git",
       },
     ]);
-    expect(tree.map((n) => n.label).sort()).toEqual(["daemon", "saflib"]);
-    const daemon = tree.find((n) => n.label === "daemon")!;
-    const forms = daemon.children.find((c) => c.label === "forms");
-    expect(forms?.kind).toBe("package");
-    expect(forms?.packageName).toBe("@pathclerk/daemon-forms");
-    expect(forms?.packageKind).toBe("other");
+    expect(tree.map((n) => n.label).sort()).toEqual(["products", "saflib"]);
+    const products = tree.find((n) => n.label === "products")!;
+    const billing = products.children.find((c) => c.label === "billing")!;
+    expect(billing.kind).toBe("dir");
+    const db = billing.children
+      .find((c) => c.label === "service")!
+      .children.find((c) => c.label === "db");
+    expect(db?.kind).toBe("package");
+    expect(db?.packageName).toBe("@example/billing-db");
+    expect(db?.packageKind).toBe("db");
   });
 });
 

--- a/imports/src/spa/spa-analyze.test.ts
+++ b/imports/src/spa/spa-analyze.test.ts
@@ -7,8 +7,8 @@ import { spaClientDir } from "./paths.ts";
 
 /**
  * Nearest workspace root from this file. When saflib is nested under a product
- * monorepo (pathclerk) that configures SPA gates, prefer that outer root so
- * analyze-router exercises real routers; standalone saflib CI just skips.
+ * monorepo that configures SPA gates, prefer that outer root so analyze-router
+ * exercises real routers; standalone saflib CI just skips.
  */
 function resolveSpaTestRoot(): string | undefined {
   let nearest: string;

--- a/openapi/bin/saf-specs/generate.ts
+++ b/openapi/bin/saf-specs/generate.ts
@@ -3,9 +3,22 @@ import { addNewLinesToString } from "@saflib/utils";
 import { execFileSync } from "child_process";
 import { getSafReporters } from "@saflib/node";
 import { errorSchema } from "@saflib/openapi/error";
-import { mkdirSync, rmSync, writeFileSync } from "fs";
+import { mkdirSync, readdirSync, rmSync, writeFileSync } from "fs";
 import path from "path";
 import { resolvePackageBin } from "./resolve-bin.ts";
+
+/**
+ * Clear codegen outputs under `-o` while preserving `types/` (composite `tsc -b`
+ * declaration emit). A full `rmSync(dist)` leaves `vue-tsc -b` with stale
+ * tsbuildinfo and missing `.d.ts` → TS6305 until a forced rebuild.
+ */
+function clearGeneratedOutput(outputDir: string): void {
+  mkdirSync(outputDir, { recursive: true });
+  for (const entry of readdirSync(outputDir)) {
+    if (entry === "types") continue;
+    rmSync(path.join(outputDir, entry), { recursive: true, force: true });
+  }
+}
 
 export const addGenerateCommand = (program: Command) => {
   program
@@ -24,8 +37,7 @@ export const addGenerateCommand = (program: Command) => {
       const { file, output } = options;
       const outputDir = path.resolve(process.cwd(), output);
 
-      rmSync(outputDir, { recursive: true, force: true });
-      mkdirSync(outputDir, { recursive: true });
+      clearGeneratedOutput(outputDir);
 
       mkdirSync(path.join(process.cwd(), "./schemas"), { recursive: true });
 

--- a/product/workflows/templates/__product-name__/service/monolith/Dockerfile.template
+++ b/product/workflows/templates/__product-name__/service/monolith/Dockerfile.template
@@ -9,7 +9,7 @@ RUN npm ci --omit=dev
 
 WORKDIR /app/__product-name__/service/monolith
 
-COPY ./deploy/__product-name__/env.defaults /etc/pathclerk/env.defaults
+COPY ./deploy/__product-name__/env.defaults /etc/__product-name__/env.defaults
 COPY ./deploy/scripts/apply-env-defaults.sh /usr/local/bin/apply-env-defaults.sh
 RUN chmod +x /usr/local/bin/apply-env-defaults.sh
 

--- a/product/workflows/templates/deploy/Dockerfile.kratos
+++ b/product/workflows/templates/deploy/Dockerfile.kratos
@@ -7,10 +7,10 @@ COPY ./deploy/kratos/courier-body.jsonnet \
      ./deploy/kratos/kratos-action-body.jsonnet \
      ./deploy/kratos/kratos.yml \
      /etc/config/kratos/
-COPY ./deploy/kratos/env.defaults /etc/pathclerk/env.defaults
+COPY ./deploy/kratos/env.defaults /etc/__product-name__/env.defaults
 COPY ./deploy/scripts/apply-env-defaults.sh /usr/local/bin/apply-env-defaults.sh
 RUN chmod +x /usr/local/bin/apply-env-defaults.sh \
-    && chown -R 10000:10000 /etc/config/kratos /etc/pathclerk
+    && chown -R 10000:10000 /etc/config/kratos /etc/__product-name__
 
 USER 10000
 

--- a/product/workflows/templates/deploy/Dockerfile.prod
+++ b/product/workflows/templates/deploy/Dockerfile.prod
@@ -25,7 +25,7 @@ COPY --from=__product-name__-builder /app/__product-name__/clients/build/dist /s
 # END WORKFLOW AREA
 
 COPY ./deploy/caddy/Caddyfile ./deploy/caddy/common.Caddyfile ./deploy/caddy/__product-name__.Caddyfile /etc/caddy/
-COPY ./deploy/caddy/env.defaults /etc/pathclerk/env.defaults
+COPY ./deploy/caddy/env.defaults /etc/__product-name__/env.defaults
 COPY ./deploy/scripts/apply-env-defaults.sh /usr/local/bin/apply-env-defaults.sh
 RUN chmod +x /usr/local/bin/apply-env-defaults.sh
 

--- a/product/workflows/templates/deploy/scripts/apply-env-defaults.sh
+++ b/product/workflows/templates/deploy/scripts/apply-env-defaults.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-# Apply /etc/pathclerk/env.defaults for any vars not already set (Compose
+# Apply /etc/__product-name__/env.defaults for any vars not already set (Compose
 # env_file / secrets / prod-local overrides win).
 set -eu
 
-DEFAULTS="${PATHCLERK_ENV_DEFAULTS:-/etc/pathclerk/env.defaults}"
+DEFAULTS="${SAF_ENV_DEFAULTS:-/etc/__product-name__/env.defaults}"
 
 if [ -f "$DEFAULTS" ]; then
   while IFS= read -r line || [ -n "$line" ]; do


### PR DESCRIPTION
As I'm extending SAF and refactoring platform stuff into it, the "daemon" product I'm building keeps seeping in via the agents. This is just a cleanup of mentions to keep saflib product-agnostic.