### PR TITLE
Add comparison to dev-site

### DIFF
--- a/analytics-service/package.json
+++ b/analytics-service/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/analytics-service",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Server-side analytics abstraction (PostHog) with in-memory implementation for tests",
   "private": true,
   "type": "module",

--- a/backup/backup-cron/package.json
+++ b/backup/backup-cron/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/backup-cron",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Cron service for the backup service",
   "type": "module",
   "exports": {

--- a/backup/backup-sdk/package.json
+++ b/backup/backup-sdk/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/backup-sdk",
+  "saf": {
+    "kind": "sdk"
+  },
   "description": "Tanstack queries and shared components for backup service",
   "private": true,
   "type": "module",

--- a/backup/backup-service-common/package.json
+++ b/backup/backup-service-common/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/backup-service-common",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Shared types and utilities for the backup service",
   "private": true,
   "type": "module",

--- a/commander/package.json
+++ b/commander/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/commander",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Shared commander utilities for SAF CLI applications",
   "private": true,
   "type": "module",

--- a/cron/cron/package.json
+++ b/cron/cron/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/cron",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Cron service",
   "private": true,
   "type": "module",

--- a/cron/cron/workflows/templates/package.json
+++ b/cron/cron/workflows/templates/package.json
@@ -1,5 +1,8 @@
 {
   "name": "template-package-cron",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Cron service for the __service-name__ service",
   "type": "module",
   "exports": {

--- a/dev-site/dev-site-http/assemble-package-spec-inventory.ts
+++ b/dev-site/dev-site-http/assemble-package-spec-inventory.ts
@@ -1,9 +1,10 @@
 /**
- * Assemble OpenAPI schemas + REST resources for one `-spec` package,
- * joined to sibling `-http` handlers and `-sdk` requests by route stem.
+ * Assemble OpenAPI schemas + REST resources for one spec package,
+ * joined to HTTP handlers and SDK requests that depend on it.
  */
 import type { DbKey } from "@saflib/drizzle";
 import type { ReturnsError } from "@saflib/monorepo";
+import { classifySafPackage, parseSafPackageJson } from "@saflib/monorepo";
 import type { GitCommandError } from "@saflib/git";
 import { listTree, readBlobs } from "@saflib/git";
 import { blobFactImports, blobFactTestCases } from "@saflib/dev-site-db/types";
@@ -19,6 +20,10 @@ import {
   moduleTargetFromImport,
   packageLocalPath,
 } from "./import-resolution.ts";
+import {
+  packagesDependingOn,
+  type PackageManifest,
+} from "./package-manifests.ts";
 import {
   buildSpecInventoryFromFiles,
   type PackageSpecInventory,
@@ -69,29 +74,22 @@ function specTargetFromImport(
   return null;
 }
 
-/** `@foo/bar-spec` → `{ http: "@foo/bar-http", sdk: "@foo/bar-sdk" }`. */
-export function siblingServicePackageNames(specPackageName: string): {
-  http: string | null;
-  sdk: string | null;
+/** HTTP/SDK packages that depend on this spec package. */
+export function servicePackageNamesForSpec(
+  specPackageName: string,
+  manifests: Parameters<typeof packagesDependingOn>[0],
+): {
+  http: string[];
+  sdk: string[];
 } {
-  if (!specPackageName.endsWith("-spec")) {
-    return { http: null, sdk: null };
-  }
-  const base = specPackageName.slice(0, -"-spec".length);
-  return { http: `${base}-http`, sdk: `${base}-sdk` };
-}
-
-/** `@foo/bar-http` or `@foo/bar-sdk` → `@foo/bar-spec`. */
-export function siblingSpecPackageName(
-  servicePackageName: string,
-): string | null {
-  if (servicePackageName.endsWith("-http")) {
-    return `${servicePackageName.slice(0, -"-http".length)}-spec`;
-  }
-  if (servicePackageName.endsWith("-sdk")) {
-    return `${servicePackageName.slice(0, -"-sdk".length)}-spec`;
-  }
-  return null;
+  return {
+    http: packagesDependingOn(manifests, specPackageName, "http").map(
+      (m) => m.packageName,
+    ),
+    sdk: packagesDependingOn(manifests, specPackageName, "sdk").map(
+      (m) => m.packageName,
+    ),
+  };
 }
 
 function handlerTestStem(filePath: string, stem: string): boolean {
@@ -192,13 +190,33 @@ export async function assemblePackageSpecInventory(
 
   const inventory = buildSpecInventoryFromFiles(files, "openapi.yaml");
 
-  const siblings = siblingServicePackageNames(packageName);
-  const httpRoot = siblings.http
-    ? roots.find((r) => r.packageName === siblings.http)
-    : undefined;
-  const sdkRoot = siblings.sdk
-    ? roots.find((r) => r.packageName === siblings.sdk)
-    : undefined;
+  const manifests: PackageManifest[] = [];
+  for (const entry of packageJsonEntries) {
+    const text = pkgBlobs.result.get(entry.blobHash);
+    if (text === undefined) continue;
+    const json = parseSafPackageJson(text);
+    const name = nameByPath.get(entry.path);
+    if (!json || !name) continue;
+    const directory =
+      entry.path === "package.json"
+        ? ""
+        : entry.path.slice(0, -"/package.json".length);
+    const classified = classifySafPackage({ ...json, name });
+    manifests.push({
+      packageName: name,
+      directory,
+      json,
+      kind: classified.kind,
+      mixedIdentifiers: classified.mixedIdentifiers,
+    });
+  }
+  const services = servicePackageNamesForSpec(packageName, manifests);
+  const httpRoots = services.http
+    .map((name) => roots.find((r) => r.packageName === name))
+    .filter((r): r is NonNullable<typeof r> => Boolean(r));
+  const sdkRoots = services.sdk
+    .map((name) => roots.find((r) => r.packageName === name))
+    .filter((r): r is NonNullable<typeof r> => Boolean(r));
 
   const handlerByStem = new Map<string, SpecInventoryFileRef>();
   /** Test file repo paths keyed by route stem (resolved to specs after blob facts). */
@@ -206,7 +224,7 @@ export async function assemblePackageSpecInventory(
     string,
     Array<{ path: string; blobHash: string }>
   >();
-  if (httpRoot) {
+  for (const httpRoot of httpRoots) {
     for (const entry of tree) {
       if (!underPackage(entry.path, httpRoot.directory)) continue;
       const local = relativeToPackage(entry.path, httpRoot.directory);
@@ -244,7 +262,7 @@ export async function assemblePackageSpecInventory(
 
   const requestByStem = new Map<string, SpecInventoryFileRef>();
   const fakeByStem = new Map<string, SpecInventoryFileRef>();
-  if (sdkRoot) {
+  for (const sdkRoot of sdkRoots) {
     for (const entry of tree) {
       if (!underPackage(entry.path, sdkRoot.directory)) continue;
       const local = relativeToPackage(entry.path, sdkRoot.directory);
@@ -388,7 +406,7 @@ export async function assemblePackageSpecInventory(
         }
       }
 
-      if (sdkRoot) {
+      for (const sdkRoot of sdkRoots) {
         const mod = moduleTargetFromImport(
           sdkRoot.packageName,
           sdkRoot.directory,
@@ -419,6 +437,7 @@ export async function assemblePackageSpecInventory(
               }
               pkgs.add(importerPkg);
             }
+            break;
           }
         }
       }

--- a/dev-site/dev-site-http/checkout.ts
+++ b/dev-site/dev-site-http/checkout.ts
@@ -8,12 +8,16 @@ import {
   listRenames,
   GitCommandError,
 } from "@saflib/git";
-import type { ReturnsError } from "@saflib/monorepo";
+import type { PackageKind, ReturnsError } from "@saflib/monorepo";
 import {
   debtCountFromIssueCounts,
   emptyIssueCountsByKind,
   type IssueCountsByKind,
 } from "./package-issues.ts";
+import {
+  loadPackageManifests,
+  manifestByRepoDirectory,
+} from "./package-manifests.ts";
 
 import { getByHash } from "@saflib/dev-site-db/queries/analyzed-commits/get-by-hash";
 import { listByCommit } from "@saflib/dev-site-db/queries/package-metrics/list-by-commit";
@@ -23,6 +27,7 @@ import { rollupIssueCounts } from "./issue-stats-rollup.ts";
 export interface CheckoutPackage {
   packageName: string;
   directory: string;
+  kind?: PackageKind;
   sourceFiles: number;
   sourceLines: number;
   prodLines: number;
@@ -191,6 +196,8 @@ export async function getCheckoutStatus(
   const metrics = (await listByCommit(dbKey, tip.hash)).result!;
   const issueRows = (await listIssueStats(dbKey, tip.hash)).result ?? [];
   const { byPackage } = rollupIssueCounts(issueRows);
+  const manifestsRes = loadPackageManifests(options.repoRoot, tip.hash);
+  const byDir = manifestByRepoDirectory(manifestsRes.result ?? []);
 
   return {
     result: {
@@ -205,9 +212,15 @@ export async function getCheckoutStatus(
       packages: metrics.map((m) => {
         const issueCountsByKind =
           byPackage.get(m.packageName) ?? emptyIssueCountsByKind();
+        const repoDir = [productRoot, m.directory]
+          .map((p) => p.replace(/^\/+|\/+$/g, ""))
+          .filter(Boolean)
+          .join("/");
+        const kind = byDir.get(repoDir)?.kind ?? "other";
         return {
           packageName: m.packageName,
           directory: m.directory,
+          kind,
           sourceFiles: m.sourceFiles,
           sourceLines: m.sourceLines,
           prodLines: m.prodLines,

--- a/dev-site/dev-site-http/checkout.ts
+++ b/dev-site/dev-site-http/checkout.ts
@@ -5,6 +5,7 @@ import {
   currentBranch,
   listRefs,
   mergeBase,
+  listRenames,
   GitCommandError,
 } from "@saflib/git";
 import type { ReturnsError } from "@saflib/monorepo";
@@ -31,12 +32,19 @@ export interface CheckoutPackage {
   debtCount: number;
 }
 
+export interface CheckoutPathRename {
+  fromPath: string;
+  toPath: string;
+  score?: number;
+}
+
 export interface CheckoutCompare {
   againstRef: string;
   mergeBaseHash: string;
   mergeBaseAnalyzed: boolean;
   mergeBaseMessage: string;
   mergeBaseAuthoredAt: string;
+  renames: CheckoutPathRename[];
 }
 
 export interface CheckoutStatus {
@@ -105,6 +113,7 @@ async function resolveCompare(
   }
 
   const existing = await getByHash(dbKey, tip.hash);
+  const renamed = listRenames(options.repoRoot, mb.result, "HEAD");
   return {
     result: {
       againstRef,
@@ -112,6 +121,7 @@ async function resolveCompare(
       mergeBaseAnalyzed: Boolean(existing.result),
       mergeBaseMessage: tip.subject,
       mergeBaseAuthoredAt: tip.authoredAt,
+      renames: renamed.result ?? [],
     },
   };
 }

--- a/dev-site/dev-site-http/checkout.ts
+++ b/dev-site/dev-site-http/checkout.ts
@@ -1,5 +1,12 @@
 import type { DbKey } from "@saflib/drizzle";
-import { resolveRef, log, currentBranch, GitCommandError } from "@saflib/git";
+import {
+  resolveRef,
+  log,
+  currentBranch,
+  listRefs,
+  mergeBase,
+  GitCommandError,
+} from "@saflib/git";
 import type { ReturnsError } from "@saflib/monorepo";
 import {
   debtCountFromIssueCounts,
@@ -24,6 +31,14 @@ export interface CheckoutPackage {
   debtCount: number;
 }
 
+export interface CheckoutCompare {
+  againstRef: string;
+  mergeBaseHash: string;
+  mergeBaseAnalyzed: boolean;
+  mergeBaseMessage: string;
+  mergeBaseAuthoredAt: string;
+}
+
 export interface CheckoutStatus {
   hash: string;
   message: string;
@@ -34,16 +49,79 @@ export interface CheckoutStatus {
   /** Short branch name for HEAD, or null when detached. */
   branch: string | null;
   packages: CheckoutPackage[];
+  compareCandidates: string[];
+  compare?: CheckoutCompare;
 }
 
 export type GetCheckoutError = GitCommandError;
+
+export interface GetCheckoutOptions {
+  repoRoot: string;
+  productRoot?: string;
+  mainRef: string;
+  /** Local branch/ref to merge-base against; defaults to `mainRef`. */
+  compareRef?: string;
+}
+
+function buildCompareCandidates(
+  branchNames: string[],
+  current: string | null,
+  mainRef: string,
+): string[] {
+  const set = new Set(branchNames.filter((name) => name !== current));
+  if (branchNames.includes(mainRef)) set.add(mainRef);
+  return [...set].sort((a, b) => {
+    if (a === mainRef) return -1;
+    if (b === mainRef) return 1;
+    return a.localeCompare(b);
+  });
+}
+
+async function resolveCompare(
+  dbKey: DbKey,
+  options: GetCheckoutOptions,
+): Promise<ReturnsError<CheckoutCompare | undefined, GitCommandError>> {
+  const explicit = options.compareRef?.trim() ?? "";
+  const againstRef = explicit || options.mainRef;
+  const mb = mergeBase(options.repoRoot, "HEAD", againstRef);
+  if (mb.error) {
+    if (explicit) return { error: mb.error };
+    return { result: undefined };
+  }
+
+  const tipLog = log(options.repoRoot, { ref: mb.result, limit: 1 });
+  if (tipLog.error) {
+    if (explicit) return { error: tipLog.error };
+    return { result: undefined };
+  }
+  const tip = tipLog.result[0];
+  if (!tip) {
+    const err = new GitCommandError(
+      "merge-base resolved but git log returned no commit",
+      { args: ["log", "-n1", mb.result], stderr: "" },
+    );
+    if (explicit) return { error: err };
+    return { result: undefined };
+  }
+
+  const existing = await getByHash(dbKey, tip.hash);
+  return {
+    result: {
+      againstRef,
+      mergeBaseHash: tip.hash,
+      mergeBaseAnalyzed: Boolean(existing.result),
+      mergeBaseMessage: tip.subject,
+      mergeBaseAuthoredAt: tip.authoredAt,
+    },
+  };
+}
 
 /**
  * Resolve HEAD and report whether that commit is already analyzed, plus packages when it is.
  */
 export async function getCheckoutStatus(
   dbKey: DbKey,
-  options: { repoRoot: string; productRoot?: string },
+  options: GetCheckoutOptions,
 ): Promise<ReturnsError<CheckoutStatus, GetCheckoutError>> {
   const productRoot = (options.productRoot ?? "").replace(/^\/+|\/+$/g, "");
   const head = resolveRef(options.repoRoot, "HEAD");
@@ -52,6 +130,17 @@ export async function getCheckoutStatus(
   const branchRes = currentBranch(options.repoRoot);
   if (branchRes.error) return { error: branchRes.error };
   const branch = branchRes.result;
+
+  const refsRes = listRefs(options.repoRoot);
+  if (refsRes.error) return { error: refsRes.error };
+  const branchNames = refsRes.result
+    .filter((r) => r.type === "branch")
+    .map((r) => r.name);
+  const compareCandidates = buildCompareCandidates(
+    branchNames,
+    branch,
+    options.mainRef,
+  );
 
   const tipLog = log(options.repoRoot, { ref: head.result, limit: 1 });
   if (tipLog.error) return { error: tipLog.error };
@@ -68,6 +157,10 @@ export async function getCheckoutStatus(
     };
   }
 
+  const compareRes = await resolveCompare(dbKey, options);
+  if (compareRes.error) return { error: compareRes.error };
+  const compare = compareRes.result;
+
   const existing = await getByHash(dbKey, tip.hash);
   if (!existing.result) {
     return {
@@ -79,6 +172,8 @@ export async function getCheckoutStatus(
         productRoot,
         branch,
         packages: [],
+        compareCandidates,
+        ...(compare ? { compare } : {}),
       },
     };
   }
@@ -95,6 +190,8 @@ export async function getCheckoutStatus(
       analyzed: true,
       productRoot,
       branch,
+      compareCandidates,
+      ...(compare ? { compare } : {}),
       packages: metrics.map((m) => {
         const issueCountsByKind =
           byPackage.get(m.packageName) ?? emptyIssueCountsByKind();

--- a/dev-site/dev-site-http/classify.test.ts
+++ b/dev-site/dev-site-http/classify.test.ts
@@ -21,13 +21,19 @@ describe("classify", () => {
       expect(isSourcePath("src/foo.ts")).toBe(true);
       expect(isSourcePath("pkg/Bar.vue")).toBe(true);
       expect(isSourcePath("a.js")).toBe(true);
+      expect(isSourcePath("daemon/service/spec/openapi.yaml")).toBe(true);
+      expect(isSourcePath("daemon/service/spec/routes/matters/core/get.yaml")).toBe(
+        true,
+      );
     });
 
-    it("rejects node_modules, dist, .d.ts, and dotfiles", () => {
+    it("rejects node_modules, dist, .d.ts, lockfiles, and dotfiles", () => {
       expect(isSourcePath("node_modules/x/a.ts")).toBe(false);
       expect(isSourcePath("pkg/dist/a.ts")).toBe(false);
+      expect(isSourcePath("pkg/dist/openapi.yaml")).toBe(false);
       expect(isSourcePath("src/a.d.ts")).toBe(false);
       expect(isSourcePath(".hidden/a.ts")).toBe(false);
+      expect(isSourcePath("pnpm-lock.yaml")).toBe(false);
     });
   });
 

--- a/dev-site/dev-site-http/classify.test.ts
+++ b/dev-site/dev-site-http/classify.test.ts
@@ -7,11 +7,6 @@ import {
   packageRootsFromPackageJsonPaths,
   packageForPath,
   parsePackageName,
-  looksLikeDbPackage,
-  looksLikeSpecPackage,
-  looksLikeHttpPackage,
-  looksLikeSdkPackage,
-  looksLikeSpaPackage,
   sdkRequestFromSpecifier,
 } from "./classify.ts";
 
@@ -21,10 +16,8 @@ describe("classify", () => {
       expect(isSourcePath("src/foo.ts")).toBe(true);
       expect(isSourcePath("pkg/Bar.vue")).toBe(true);
       expect(isSourcePath("a.js")).toBe(true);
-      expect(isSourcePath("daemon/service/spec/openapi.yaml")).toBe(true);
-      expect(isSourcePath("daemon/service/spec/routes/matters/core/get.yaml")).toBe(
-        true,
-      );
+      expect(isSourcePath("pkg/spec/openapi.yaml")).toBe(true);
+      expect(isSourcePath("pkg/spec/routes/billing/get.yaml")).toBe(true);
     });
 
     it("rejects node_modules, dist, .d.ts, lockfiles, and dotfiles", () => {
@@ -106,45 +99,12 @@ describe("classify", () => {
     });
   });
 
-  describe("looksLikeSpecPackage / looksLikeDbPackage / looksLikeHttpPackage / looksLikeSdkPackage", () => {
-    it("detects -spec, -db, -http, and -sdk naming", () => {
+  describe("sdkRequestFromSpecifier", () => {
+    it("parses package/requests/stem specifiers", () => {
       expect(
-        looksLikeSpecPackage("@pathclerk/daemon-spec", "daemon/service/spec"),
-      ).toBe(true);
-      expect(
-        looksLikeSpecPackage("@saflib/dev-site-spec", "saflib/dev-site/dev-site-spec"),
-      ).toBe(true);
-      expect(looksLikeSpecPackage("@pathclerk/daemon-db", "daemon/service/db")).toBe(
-        false,
-      );
-      expect(looksLikeDbPackage("@pathclerk/daemon-db", "daemon/service/db")).toBe(
-        true,
-      );
-      expect(
-        looksLikeHttpPackage("@pathclerk/daemon-http", "daemon/service/http"),
-      ).toBe(true);
-      expect(
-        looksLikeHttpPackage("@pathclerk/daemon-spec", "daemon/service/spec"),
-      ).toBe(false);
-      expect(
-        looksLikeSdkPackage("@pathclerk/daemon-sdk", "daemon/service/sdk"),
-      ).toBe(true);
-      expect(
-        looksLikeSdkPackage("@pathclerk/daemon-http", "daemon/service/http"),
-      ).toBe(false);
-      expect(
-        looksLikeSpaPackage("@pathclerk/daemon-account-spa", "daemon/clients/account"),
-      ).toBe(true);
-      expect(
-        looksLikeSpaPackage("@saflib/dev-site-vue", "saflib/dev-site/dev-site-vue"),
-      ).toBe(true);
-      expect(looksLikeSpaPackage("@pathclerk/daemon-sdk", "daemon/service/sdk")).toBe(
-        false,
-      );
-      expect(
-        sdkRequestFromSpecifier("@pathclerk/daemon-sdk/requests/orgs/list"),
+        sdkRequestFromSpecifier("@scope/billing/requests/orgs/list"),
       ).toEqual({
-        sdkPackageName: "@pathclerk/daemon-sdk",
+        sdkPackageName: "@scope/billing",
         requestStem: "orgs/list",
       });
       expect(sdkRequestFromSpecifier("./ChooseOrg.logic.ts")).toBeNull();

--- a/dev-site/dev-site-http/classify.ts
+++ b/dev-site/dev-site-http/classify.ts
@@ -1,6 +1,6 @@
 /**
- * Classification heuristics for inventory-style package/file categorization.
- * Applied to git-tree paths (no checkout) so historical commits classify the same way.
+ * File/path helpers for inventory (git-tree paths, no checkout).
+ * Package *kind* lives in `@saflib/monorepo` (`saf.kind` / identifier deps).
  */
 
 export const EXCLUDE_DIRS = new Set([
@@ -158,74 +158,9 @@ export function parsePackageName(packageJsonText: string): string | undefined {
   }
 }
 
-/** Heuristic: npm name / directory looks like a drizzle db package. */
-export function looksLikeDbPackage(
-  packageName: string,
-  directory: string = "",
-): boolean {
-  const name = packageName.toLowerCase();
-  const dir = directory.replace(/\\/g, "/").toLowerCase();
-  return (
-    name.endsWith("-db") ||
-    name.includes("-db-") ||
-    /\/[^/]*-db$/.test(dir) ||
-    dir.endsWith("/service/db") ||
-    /(^|\/)db$/.test(dir)
-  );
-}
-
-/** Heuristic: npm name / directory looks like an Express `-http` package. */
-export function looksLikeHttpPackage(
-  packageName: string,
-  directory: string = "",
-): boolean {
-  const name = packageName.toLowerCase();
-  const dir = directory.replace(/\\/g, "/").toLowerCase();
-  return (
-    name.endsWith("-http") ||
-    name.includes("-http-") ||
-    /\/[^/]*-http$/.test(dir) ||
-    dir.endsWith("/service/http") ||
-    /(^|\/)http$/.test(dir)
-  );
-}
-
-/** Heuristic: npm name / directory looks like a TanStack `-sdk` package. */
-export function looksLikeSdkPackage(
-  packageName: string,
-  directory: string = "",
-): boolean {
-  const name = packageName.toLowerCase();
-  const dir = directory.replace(/\\/g, "/").toLowerCase();
-  return (
-    name.endsWith("-sdk") ||
-    name.includes("-sdk-") ||
-    /\/[^/]*-sdk$/.test(dir) ||
-    dir.endsWith("/service/sdk") ||
-    /(^|\/)sdk$/.test(dir)
-  );
-}
-
-/** Heuristic: npm name / directory looks like a Vue SPA or `-vue` package. */
-export function looksLikeSpaPackage(
-  packageName: string,
-  directory: string = "",
-): boolean {
-  const name = packageName.toLowerCase();
-  const dir = directory.replace(/\\/g, "/").toLowerCase();
-  return (
-    name.endsWith("-vue") ||
-    name.endsWith("-spa") ||
-    name.includes("-vue-") ||
-    name.includes("-spa-") ||
-    dir.includes("/clients/") ||
-    /(^|\/)clients\//.test(dir)
-  );
-}
-
 /**
- * `@scope/foo-sdk/requests/orgs/list` → SDK package + request stem.
- * Returns null for non-SDK request specifiers.
+ * `@scope/pkg/requests/orgs/list` → SDK package + request stem.
+ * Returns null when the specifier is not a `requests/` subpath import.
  */
 export function sdkRequestFromSpecifier(specifier: string): {
   sdkPackageName: string;
@@ -233,24 +168,6 @@ export function sdkRequestFromSpecifier(specifier: string): {
 } | null {
   const m = /^((?:@[^/]+\/)?[^/]+)\/requests\/(.+)$/.exec(specifier);
   if (!m) return null;
-  const sdkPackageName = m[1]!;
-  if (!sdkPackageName.endsWith("-sdk")) return null;
   const requestStem = m[2]!.replace(/\.(tsx?|jsx?|mjs|cjs)$/, "");
-  return { sdkPackageName, requestStem };
-}
-
-/** Heuristic: npm name / directory looks like an OpenAPI `-spec` package. */
-export function looksLikeSpecPackage(
-  packageName: string,
-  directory: string = "",
-): boolean {
-  const name = packageName.toLowerCase();
-  const dir = directory.replace(/\\/g, "/").toLowerCase();
-  return (
-    name.endsWith("-spec") ||
-    name.includes("-spec-") ||
-    /\/[^/]*-spec$/.test(dir) ||
-    dir.endsWith("/service/spec") ||
-    /(^|\/)spec$/.test(dir)
-  );
+  return { sdkPackageName: m[1]!, requestStem };
 }

--- a/dev-site/dev-site-http/classify.ts
+++ b/dev-site/dev-site-http/classify.ts
@@ -35,6 +35,9 @@ export const SOURCE_EXTS = new Set([
   ".jsx",
   ".mjs",
   ".cjs",
+  /** Authored OpenAPI (and similar) YAML; generated output is under `dist/`. */
+  ".yaml",
+  ".yml",
 ]);
 
 /** Heuristic: *.test.* / *.spec.* / *.fixture(s).* / *.test-helpers.*, or under testing/ / tests/ / __tests__/. */

--- a/dev-site/dev-site-http/compute-commit-issue-stats.ts
+++ b/dev-site/dev-site-http/compute-commit-issue-stats.ts
@@ -3,13 +3,14 @@
  * Layout/oversized use commit-scoped inputs (not the live working tree).
  */
 import type { DbKey } from "@saflib/drizzle";
-import type { ReturnsError } from "@saflib/monorepo";
 import {
   checkPackageLayoutFromInputs,
+  classifySafPackage,
   DEFAULT_MAX_SOURCE_LINES,
   listPackageJsonExportTargetFiles,
   type PackageJsonLayoutFields,
   type PackageLayoutIssue,
+  type ReturnsError,
 } from "@saflib/monorepo";
 import type { GitCommandError } from "@saflib/git";
 import { listTree, readBlobs } from "@saflib/git";
@@ -41,7 +42,6 @@ import {
   packageForPath,
   packageRootsFromPackageJsonPaths,
   parsePackageName,
-  looksLikeDbPackage,
 } from "./classify.ts";
 import { assemblePackageDbInventory } from "./assemble-package-db-inventory.ts";
 import {
@@ -76,12 +76,7 @@ function packageLocalFromRepo(
 
 function parsePackageJsonFields(text: string): PackageJsonLayoutFields | null {
   try {
-    const parsed = JSON.parse(text) as PackageJsonLayoutFields;
-    return {
-      bin: parsed.bin,
-      scripts: parsed.scripts,
-      exports: parsed.exports,
-    };
+    return JSON.parse(text) as PackageJsonLayoutFields;
   } catch {
     return null;
   }
@@ -262,7 +257,7 @@ export async function computeCommitIssueStats(
       repoPath: i.repoPath,
     }));
 
-    const isDb = looksLikeDbPackage(pkg.packageName, pkg.directory);
+    const isDb = classifySafPackage(pj).kind === "db";
     let dbInventory:
       | {
           entities: Array<{

--- a/dev-site/dev-site-http/diff-commits.ts
+++ b/dev-site/dev-site-http/diff-commits.ts
@@ -12,8 +12,11 @@ import {
   assemblePackageDbInventory,
   flattenInventoryTables,
 } from "./assemble-package-db-inventory.ts";
-import { looksLikeDbPackage } from "./classify.ts";
 import type { RepoReadOptions } from "./get-commit.ts";
+import {
+  loadPackageManifests,
+  manifestByPackageName,
+} from "./package-manifests.ts";
 
 import { getByHash } from "@saflib/dev-site-db/queries/analyzed-commits/get-by-hash";
 import { listByCommit } from "@saflib/dev-site-db/queries/package-metrics/list-by-commit";
@@ -200,8 +203,19 @@ export async function diffCommits(
   const testDiff = diffLists(fromTests, toTests, testCaseKey);
 
   const dbPkgNames = new Set<string>();
-  for (const m of [...fromMetrics, ...toMetrics]) {
-    if (looksLikeDbPackage(m.packageName, m.directory)) {
+  const [fromManifests, toManifests] = [
+    loadPackageManifests(repo.repoRoot, fromHash),
+    loadPackageManifests(repo.repoRoot, toHash),
+  ];
+  const fromByName = manifestByPackageName(fromManifests.result ?? []);
+  const toByName = manifestByPackageName(toManifests.result ?? []);
+  for (const m of fromMetrics) {
+    if (fromByName.get(m.packageName)?.kind === "db") {
+      dbPkgNames.add(m.packageName);
+    }
+  }
+  for (const m of toMetrics) {
+    if (toByName.get(m.packageName)?.kind === "db") {
       dbPkgNames.add(m.packageName);
     }
   }

--- a/dev-site/dev-site-http/get-package.ts
+++ b/dev-site/dev-site-http/get-package.ts
@@ -15,23 +15,20 @@ import {
   exportUsedByKey,
   type ExportUsedBy,
 } from "./assemble-export-used-by.ts";
-import {
-  looksLikeDbPackage,
-  looksLikeHttpPackage,
-  looksLikeSdkPackage,
-  looksLikeSpaPackage,
-  looksLikeSpecPackage,
-} from "./classify.ts";
 import type { RepoReadOptions } from "./get-commit.ts";
 import type { PackageDbInventory } from "./assemble-package-db-inventory.ts";
 import {
   assemblePackageSpecInventory,
-  siblingSpecPackageName,
   type PackageSpecInventory,
 } from "./assemble-package-spec-inventory.ts";
 import type { PackageIssue } from "./package-issues.ts";
 import { annotateSpecInventoryJobEdges } from "./annotate-spec-inventory-jobs.ts";
 import { devSiteHttpStorage } from "./context.ts";
+import {
+  loadPackageManifests,
+  manifestByPackageName,
+  specPackageNamesFromDeps,
+} from "./package-manifests.ts";
 
 import { getByHash } from "@saflib/dev-site-db/queries/analyzed-commits/get-by-hash";
 import { listByCommit } from "@saflib/dev-site-db/queries/package-metrics/list-by-commit";
@@ -185,13 +182,19 @@ export async function getCommitPackage(
   const rawExports = symbols.result?.exports ?? [];
   const testCases = symbols.result?.testCases ?? [];
 
+  const manifestsRes = loadPackageManifests(repo.repoRoot, hash);
+  const manifests = manifestsRes.result ?? [];
+  const byName = manifestByPackageName(manifests);
+  const pkgManifest = byName.get(packageName);
+  const kind = pkgManifest?.kind ?? "other";
+
   let dbInventory: PackageDbInventory | undefined;
   let specInventory: PackageSpecInventory | undefined;
-  const isDb = looksLikeDbPackage(metrics.packageName, metrics.directory);
-  const isSpec = looksLikeSpecPackage(metrics.packageName, metrics.directory);
-  const isHttp = looksLikeHttpPackage(metrics.packageName, metrics.directory);
-  const isSdk = looksLikeSdkPackage(metrics.packageName, metrics.directory);
-  const isSpa = looksLikeSpaPackage(metrics.packageName, metrics.directory);
+  const isDb = kind === "db";
+  const isSpec = kind === "spec";
+  const isHttp = kind === "http";
+  const isSdk = kind === "sdk";
+  const isSpa = kind === "spa";
   const hasVue = symbols.result?.hasVue ?? false;
   if (isDb) {
     const inv = await assemblePackageDbInventory(
@@ -215,9 +218,7 @@ export async function getCommitPackage(
       annotateJobsIfConfigured(specInventory);
     }
   } else if (isHttp || isSdk) {
-    // Join sibling -spec routes so HTTP/SDK panes can show PackageRouteCards
-    // while still presenting handlers/ or requests/ as a normal source package.
-    const specName = siblingSpecPackageName(packageName);
+    const specName = specPackageNamesFromDeps(byName, pkgManifest)[0];
     if (specName) {
       const inv = await assemblePackageSpecInventory(
         dbKey,
@@ -231,13 +232,12 @@ export async function getCommitPackage(
       }
     }
   } else if (isSpa || hasVue) {
-    // Join the product `-spec` whose SDK request modules this SPA/Vue package
-    // actually imports, so bundle views can show loader routes.
     const counts = new Map<string, number>();
     for (const imp of symbols.result?.sdkRequestImports ?? []) {
-      const specName = siblingSpecPackageName(imp.sdkPackageName);
-      if (!specName) continue;
-      counts.set(specName, (counts.get(specName) ?? 0) + 1);
+      const sdkManifest = byName.get(imp.sdkPackageName);
+      for (const specName of specPackageNamesFromDeps(byName, sdkManifest)) {
+        counts.set(specName, (counts.get(specName) ?? 0) + 1);
+      }
     }
     const specName = [...counts.entries()].sort((a, b) => b[1] - a[1])[0]?.[0];
     if (specName) {

--- a/dev-site/dev-site-http/package-manifests.test.ts
+++ b/dev-site/dev-site-http/package-manifests.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import {
+  packagesDependingOn,
+  specPackageNamesFromDeps,
+  type PackageManifest,
+} from "./package-manifests.ts";
+
+function manifest(
+  partial: Pick<PackageManifest, "packageName" | "kind"> &
+    Partial<PackageManifest>,
+): PackageManifest {
+  return {
+    directory: "",
+    json: {},
+    mixedIdentifiers: [],
+    ...partial,
+  };
+}
+
+describe("specPackageNamesFromDeps", () => {
+  it("returns spec-kind dependencies, sorted", () => {
+    const billingSpec = manifest({
+      packageName: "@scope/billing-spec",
+      kind: "spec",
+    });
+    const otherSpec = manifest({
+      packageName: "@scope/other-spec",
+      kind: "spec",
+    });
+    const http = manifest({
+      packageName: "@scope/billing-http",
+      kind: "http",
+      json: {
+        dependencies: {
+          "@scope/other-spec": "*",
+          "@scope/billing-spec": "*",
+          "@saflib/express": "*",
+        },
+      },
+    });
+    const byName = new Map([
+      [billingSpec.packageName, billingSpec],
+      [otherSpec.packageName, otherSpec],
+      [http.packageName, http],
+    ]);
+    expect(specPackageNamesFromDeps(byName, http)).toEqual([
+      "@scope/billing-spec",
+      "@scope/other-spec",
+    ]);
+  });
+});
+
+describe("packagesDependingOn", () => {
+  it("finds packages of a kind that depend on the target", () => {
+    const spec = manifest({ packageName: "@scope/billing-spec", kind: "spec" });
+    const http = manifest({
+      packageName: "@scope/billing-http",
+      kind: "http",
+      json: { dependencies: { "@scope/billing-spec": "*" } },
+    });
+    const otherHttp = manifest({
+      packageName: "@scope/unrelated-http",
+      kind: "http",
+      json: { dependencies: { "@scope/other-spec": "*" } },
+    });
+    const sdk = manifest({
+      packageName: "@scope/billing-sdk",
+      kind: "sdk",
+      json: { dependencies: { "@scope/billing-spec": "*" } },
+    });
+    expect(
+      packagesDependingOn([spec, http, otherHttp, sdk], spec.packageName, "http").map(
+        (m) => m.packageName,
+      ),
+    ).toEqual(["@scope/billing-http"]);
+    expect(
+      packagesDependingOn([spec, http, otherHttp, sdk], spec.packageName, "sdk").map(
+        (m) => m.packageName,
+      ),
+    ).toEqual(["@scope/billing-sdk"]);
+  });
+});

--- a/dev-site/dev-site-http/package-manifests.ts
+++ b/dev-site/dev-site-http/package-manifests.ts
@@ -1,0 +1,117 @@
+/**
+ * Load package.json manifests from a git commit (no checkout).
+ */
+import {
+  classifySafPackage,
+  parseSafPackageJson,
+  type PackageKind,
+  type ReturnsError,
+  type SafPackageJson,
+} from "@saflib/monorepo";
+import { listTree, readBlobs, type GitCommandError } from "@saflib/git";
+import { EXCLUDE_DIRS, packageRootsFromPackageJsonPaths } from "./classify.ts";
+
+export interface PackageManifest {
+  packageName: string;
+  /** Directory relative to repo root (posix, no trailing slash). "" for root. */
+  directory: string;
+  json: SafPackageJson;
+  kind: PackageKind;
+  mixedIdentifiers: string[];
+}
+
+export type LoadPackageManifestsResult = ReturnsError<
+  PackageManifest[],
+  GitCommandError
+>;
+
+/**
+ * Read every package.json at `commitHash` and classify it.
+ */
+export function loadPackageManifests(
+  repoRoot: string,
+  commitHash: string,
+): LoadPackageManifestsResult {
+  const treeResult = listTree(repoRoot, commitHash);
+  if (treeResult.error) return { error: treeResult.error };
+
+  const packageJsonEntries = treeResult.result.filter((e) => {
+    const parts = e.path.split("/");
+    if (parts.some((p) => EXCLUDE_DIRS.has(p))) return false;
+    return e.path === "package.json" || e.path.endsWith("/package.json");
+  });
+
+  const blobs = readBlobs(
+    repoRoot,
+    packageJsonEntries.map((e) => e.blobHash),
+  );
+  if (blobs.error) return { error: blobs.error };
+
+  const nameByPath = new Map<string, string>();
+  const jsonByPath = new Map<string, SafPackageJson>();
+  for (const entry of packageJsonEntries) {
+    const text = blobs.result.get(entry.blobHash);
+    if (text === undefined) continue;
+    const json = parseSafPackageJson(text);
+    if (!json) continue;
+    jsonByPath.set(entry.path, json);
+    if (typeof json.name === "string") nameByPath.set(entry.path, json.name);
+  }
+
+  const roots = packageRootsFromPackageJsonPaths(
+    packageJsonEntries.map((e) => e.path),
+    nameByPath,
+  );
+
+  const manifests: PackageManifest[] = [];
+  for (const root of roots) {
+    const pkgJsonPath = root.directory
+      ? `${root.directory}/package.json`
+      : "package.json";
+    const json = jsonByPath.get(pkgJsonPath) ?? {};
+    const classified = classifySafPackage({ ...json, name: root.packageName });
+    manifests.push({
+      packageName: root.packageName,
+      directory: root.directory,
+      json,
+      kind: classified.kind,
+      mixedIdentifiers: classified.mixedIdentifiers,
+    });
+  }
+  return { result: manifests };
+}
+
+export function manifestByPackageName(
+  manifests: PackageManifest[],
+): Map<string, PackageManifest> {
+  return new Map(manifests.map((m) => [m.packageName, m]));
+}
+
+/** Repo-relative package directory → manifest (productRoot + metrics.directory). */
+export function manifestByRepoDirectory(
+  manifests: PackageManifest[],
+): Map<string, PackageManifest> {
+  return new Map(manifests.map((m) => [m.directory, m]));
+}
+
+export function specPackageNamesFromDeps(
+  manifestsByName: Map<string, PackageManifest>,
+  pkg: PackageManifest | undefined,
+): string[] {
+  if (!pkg) return [];
+  const deps = Object.keys(pkg.json.dependencies ?? {});
+  return deps
+    .filter((name) => manifestsByName.get(name)?.kind === "spec")
+    .sort();
+}
+
+export function packagesDependingOn(
+  manifests: PackageManifest[],
+  packageName: string,
+  kind: PackageKind,
+): PackageManifest[] {
+  return manifests.filter((m) => {
+    if (m.kind !== kind) return false;
+    return Boolean(m.json.dependencies?.[packageName]);
+  });
+}

--- a/dev-site/dev-site-http/package.json
+++ b/dev-site/dev-site-http/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/dev-site-http",
+  "saf": {
+    "kind": "http"
+  },
   "description": "Dev-site orchestration — scan/store/diff static analysis + Express routes + saf-dev-site CLI",
   "type": "module",
   "exports": {

--- a/dev-site/dev-site-http/routes/checkout/checkout.test.ts
+++ b/dev-site/dev-site-http/routes/checkout/checkout.test.ts
@@ -107,6 +107,7 @@ describe("checkout routes", () => {
     expect(response.body.packages.length).toBeGreaterThan(0);
     expect(response.body.packages[0].packageName).toBe("@fixture/root");
     expect(response.body.packages[0]).toMatchObject({
+      kind: "other",
       debtCount: expect.any(Number),
       issueCountsByKind: {
         "dead-code": expect.any(Number),

--- a/dev-site/dev-site-http/routes/checkout/checkout.test.ts
+++ b/dev-site/dev-site-http/routes/checkout/checkout.test.ts
@@ -89,6 +89,7 @@ describe("checkout routes", () => {
       mergeBaseHash: headHash,
       mergeBaseAnalyzed: false,
     });
+    expect(response.body.compare.renames).toEqual([]);
   });
 
   it("GET /api/checkout includes packages after scan", async () => {
@@ -118,6 +119,7 @@ describe("checkout routes", () => {
       mergeBaseHash: headHash,
       mergeBaseAnalyzed: true,
     });
+    expect(response.body.compare.renames).toEqual([]);
   });
 
   it("GET /api/checkout reports merge-base for a feature branch", async () => {
@@ -139,6 +141,23 @@ describe("checkout routes", () => {
       mergeBaseHash: headHash,
       mergeBaseAnalyzed: false,
     });
+    expect(response.body.compare.renames).toEqual([]);
+
+    git(repoRoot, ["checkout", "main"]);
+  });
+
+  it("GET /api/checkout includes git find-renames pairs vs the fork point", async () => {
+    git(repoRoot, ["checkout", "-b", "renames"]);
+    git(repoRoot, ["mv", "src/a.ts", "src/moved.ts"]);
+    git(repoRoot, ["commit", "-m", "move a"]);
+
+    const response = await request(lease.app).get(
+      "/api/checkout?compareRef=main",
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.compare.renames).toEqual([
+      { fromPath: "src/a.ts", toPath: "src/moved.ts", score: 100 },
+    ]);
 
     git(repoRoot, ["checkout", "main"]);
   });

--- a/dev-site/dev-site-http/routes/checkout/checkout.test.ts
+++ b/dev-site/dev-site-http/routes/checkout/checkout.test.ts
@@ -83,6 +83,12 @@ describe("checkout routes", () => {
       branch: "main",
     });
     expect(response.body.message).toContain("init");
+    expect(response.body.compareCandidates).toEqual(["main"]);
+    expect(response.body.compare).toMatchObject({
+      againstRef: "main",
+      mergeBaseHash: headHash,
+      mergeBaseAnalyzed: false,
+    });
   });
 
   it("GET /api/checkout includes packages after scan", async () => {
@@ -107,5 +113,40 @@ describe("checkout routes", () => {
         "package-layout": expect.any(Number),
       },
     });
+    expect(response.body.compare).toMatchObject({
+      againstRef: "main",
+      mergeBaseHash: headHash,
+      mergeBaseAnalyzed: true,
+    });
+  });
+
+  it("GET /api/checkout reports merge-base for a feature branch", async () => {
+    git(repoRoot, ["checkout", "-b", "feature"]);
+    writeFileSync(join(repoRoot, "src/b.ts"), "export const b = 2;\n");
+    git(repoRoot, ["add", "src/b.ts"]);
+    git(repoRoot, ["commit", "-m", "feature"]);
+    const featureHead = git(repoRoot, ["rev-parse", "HEAD"]);
+
+    const response = await request(lease.app).get(
+      "/api/checkout?compareRef=main",
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.hash).toBe(featureHead);
+    expect(response.body.branch).toBe("feature");
+    expect(response.body.compareCandidates).toEqual(["main"]);
+    expect(response.body.compare).toMatchObject({
+      againstRef: "main",
+      mergeBaseHash: headHash,
+      mergeBaseAnalyzed: false,
+    });
+
+    git(repoRoot, ["checkout", "main"]);
+  });
+
+  it("GET /api/checkout returns 400 for an unknown compareRef", async () => {
+    const response = await request(lease.app).get(
+      "/api/checkout?compareRef=no-such-branch",
+    );
+    expect(response.status).toBe(400);
   });
 });

--- a/dev-site/dev-site-http/routes/checkout/get.ts
+++ b/dev-site/dev-site-http/routes/checkout/get.ts
@@ -5,15 +5,24 @@ import { GitCommandError } from "@saflib/git";
 import { getDevSiteHttpContext } from "../../context.ts";
 import { getCheckoutStatus } from "../../checkout.ts";
 
-export const getCheckoutHandler = createHandler(async (_req, res) => {
-  const { dbKey, repoRoot, productRoot } = getDevSiteHttpContext();
+export const getCheckoutHandler = createHandler(async (req, res) => {
+  const { dbKey, repoRoot, productRoot, mainRef } = getDevSiteHttpContext();
+  const compareRef =
+    typeof req.query.compareRef === "string" ? req.query.compareRef : undefined;
   const { result, error } = await getCheckoutStatus(dbKey, {
     repoRoot,
     productRoot,
+    mainRef,
+    compareRef,
   });
   if (error) {
     switch (true) {
       case error instanceof GitCommandError:
+        if (compareRef?.trim()) {
+          throw createError(400, error.message, {
+            code: "COMPARE_REF_NOT_FOUND",
+          });
+        }
         throw createError(500, error.message, { code: "GIT_COMMAND_FAILED" });
       default:
         throw error satisfies never;

--- a/dev-site/dev-site-spec/dist/openapi.d.ts
+++ b/dev-site/dev-site-spec/dist/openapi.d.ts
@@ -619,6 +619,15 @@ export interface components {
              * @description Author date of the fork-point commit.
              */
             mergeBaseAuthoredAt: string;
+            /** @description File rename pairs from the fork point to HEAD (`git diff --find-renames`). Used by Checkout compare to show moved modules instead of remove+add. */
+            renames: {
+                /** @description Path at the fork-point commit. */
+                fromPath: string;
+                /** @description Path at HEAD. */
+                toPath: string;
+                /** @description Git rename similarity (0-100). */
+                score?: number;
+            }[];
         };
         login: {
             /** @enum {string} */

--- a/dev-site/dev-site-spec/dist/openapi.d.ts
+++ b/dev-site/dev-site-spec/dist/openapi.d.ts
@@ -113,7 +113,7 @@ export interface paths {
         };
         /**
          * Current checkout (HEAD) analysis status
-         * @description Resolve git HEAD and report whether that commit has been analyzed, plus package metrics when it has. Used by the Current checkout UI.
+         * @description Resolve git HEAD and report whether that commit has been analyzed, plus package metrics when it has. Also reports local branch compare candidates and the fork-point (merge-base) of HEAD vs `compareRef` (default `main`). Used by the Current checkout UI.
          */
         get: operations["getCheckout"];
         put?: never;
@@ -184,6 +184,7 @@ export interface components {
         IssueCountsByKind: components["schemas"]["issue-counts-by-kind"];
         DbSchemaTable: components["schemas"]["db-schema-table"];
         DbSchemaColumn: components["schemas"]["db-schema-column"];
+        CheckoutCompare: components["schemas"]["checkout-compare"];
         /** @description A branch or tag pointer observed at scan time for a commit. */
         "commit-ref": {
             /**
@@ -603,6 +604,22 @@ export interface components {
             /** @description Repo-relative path for open-source links */
             repoPath: string;
         };
+        /** @description Fork-point (merge-base of HEAD and a chosen branch) for Checkout compare mode. */
+        "checkout-compare": {
+            /** @description Branch/ref HEAD was compared against (e.g. `main`). */
+            againstRef: string;
+            /** @description Full hash of `git merge-base(HEAD, againstRef)`. */
+            mergeBaseHash: string;
+            /** @description True when that fork-point commit has an analysis snapshot. */
+            mergeBaseAnalyzed: boolean;
+            /** @description Subject of the fork-point commit. */
+            mergeBaseMessage: string;
+            /**
+             * Format: date-time
+             * @description Author date of the fork-point commit.
+             */
+            mergeBaseAuthoredAt: string;
+        };
         login: {
             /** @enum {string} */
             event: "login";
@@ -858,7 +875,10 @@ export interface operations {
     };
     getCheckout: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Local branch name to take the merge-base against. Defaults to the server `main` ref. */
+                compareRef?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -882,7 +902,19 @@ export interface operations {
                         /** @description Short branch name for HEAD, or null when detached. */
                         branch: string | null;
                         packages: components["schemas"]["package-metrics"][];
+                        /** @description Local branch names that can be used as `compareRef` (current branch omitted; configured main ref always included when it exists). */
+                        compareCandidates: string[];
+                        compare?: components["schemas"]["checkout-compare"];
                     };
+                };
+            };
+            /** @description compareRef is not a valid git object. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
                 };
             };
             /** @description Git command failed */

--- a/dev-site/dev-site-spec/dist/openapi.d.ts
+++ b/dev-site/dev-site-spec/dist/openapi.d.ts
@@ -73,7 +73,7 @@ export interface paths {
         };
         /**
          * Package-scoped symbols for one analyzed commit
-         * @description Returns metrics, exports, and test cases for a single package at a commit. Prefer this over full commit detail for the checkout Spec panel — assembly only touches that package's source blobs. For db packages, also includes `dbInventory` (drizzle tables + query dirs). For `-spec` packages, also includes `specInventory` (OpenAPI schemas + REST resources). For `-http` packages, `specInventory` is the sibling `-spec` triangle join (route cards) while exports/tests remain the HTTP or SDK package's own source modules. For Vue SPA / `-vue` packages, `specInventory` is the product `-spec` joined through SDK request imports so Spec can show loader routes on a component bundle. `layoutIssues` are live working-tree layout/LoC findings for the package directory (cheap; package-local). Full dead-code workdir scans stay on `saf-dev-site issues --workdir` — not on this Spec package load.
+         * @description Returns metrics, exports, and test cases for a single package at a commit. Prefer this over full commit detail for the checkout Spec panel — assembly only touches that package's source blobs. For db packages, also includes dbInventory (drizzle tables + query dirs). For spec packages, also includes specInventory (OpenAPI schemas + REST resources). For http and sdk packages, specInventory is joined from a spec package this package depends on, while exports/tests remain this package's own source modules. For spa packages, specInventory is joined through SDK request imports so Spec can show loader routes on a component bundle. layoutIssues are live working-tree layout/LoC findings for the package directory (cheap; package-local). Full dead-code workdir scans stay on saf-dev-site issues --workdir — not on this Spec package load.
          */
         get: operations["getCommitPackage"];
         put?: never;
@@ -292,6 +292,11 @@ export interface components {
              * @example saflib/git
              */
             directory: string;
+            /**
+             * @description Package layer kind. From package.json saf.kind when set, otherwise inferred from a unique identifier dependency such as @saflib/drizzle (db), @saflib/express (http), @saflib/openapi (spec), @saflib/sdk (sdk), or @saflib/vue (spa).
+             * @enum {string}
+             */
+            kind?: "db" | "http" | "spec" | "spa" | "sdk" | "lib" | "integration" | "other";
             /** @description Count of source files (excluding tests). */
             sourceFiles: number;
             /** @description Total lines across source files. */
@@ -504,9 +509,9 @@ export interface components {
             /** @description Repo-relative path for source links. */
             repoPath: string;
         };
-        /** @description OpenAPI inventory for one `-spec` package — business objects (schemas/) and/or REST resources (routes/), linked by normalized name stems. Operations include triangle links to sibling `-http` handlers and `-sdk` requests when present. Also attached to `-http` package detail (sibling join) for the HTTP Spec pane. */
+        /** @description OpenAPI inventory for one spec package — business objects (schemas/) and/or REST resources (routes/), linked by normalized name stems. Operations include links to HTTP handlers and SDK requests from packages that depend on this spec. Also attached to http package detail for the HTTP Spec pane. */
         "spec-inventory": {
-            /** @description Repo-relative directory of the `-spec` package this inventory was built from (used for route YAML source links when shown from an `-http` pane). */
+            /** @description Repo-relative directory of the spec package this inventory was built from (used for route YAML source links when shown from an http pane). */
             packageDirectory?: string;
             /** @description Flat alphabetical list of object / both / routes entities. */
             entities: {

--- a/dev-site/dev-site-spec/dist/openapi.json
+++ b/dev-site/dev-site-spec/dist/openapi.json
@@ -1971,7 +1971,8 @@
           "mergeBaseHash",
           "mergeBaseAnalyzed",
           "mergeBaseMessage",
-          "mergeBaseAuthoredAt"
+          "mergeBaseAuthoredAt",
+          "renames"
         ],
         "properties": {
           "againstRef": {
@@ -1994,6 +1995,33 @@
             "type": "string",
             "format": "date-time",
             "description": "Author date of the fork-point commit."
+          },
+          "renames": {
+            "type": "array",
+            "description": "File rename pairs from the fork point to HEAD (`git diff --find-renames`). Used by Checkout compare to show moved modules instead of remove+add.\n",
+            "items": {
+              "type": "object",
+              "required": [
+                "fromPath",
+                "toPath"
+              ],
+              "properties": {
+                "fromPath": {
+                  "type": "string",
+                  "description": "Path at the fork-point commit."
+                },
+                "toPath": {
+                  "type": "string",
+                  "description": "Path at HEAD."
+                },
+                "score": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "Git rename similarity (0-100)."
+                }
+              }
+            }
           }
         }
       },

--- a/dev-site/dev-site-spec/dist/openapi.json
+++ b/dev-site/dev-site-spec/dist/openapi.json
@@ -185,7 +185,7 @@
         "tags": [
           "no-auth"
         ],
-        "description": "Returns metrics, exports, and test cases for a single package at a commit. Prefer this over full commit detail for the checkout Spec panel — assembly only touches that package's source blobs. For db packages, also includes `dbInventory` (drizzle tables + query dirs). For `-spec` packages, also includes `specInventory` (OpenAPI schemas + REST resources). For `-http` packages, `specInventory` is the sibling `-spec` triangle join (route cards) while exports/tests remain the HTTP or SDK package's own source modules. For Vue SPA / `-vue` packages, `specInventory` is the product `-spec` joined through SDK request imports so Spec can show loader routes on a component bundle. `layoutIssues` are live working-tree layout/LoC findings for the package directory (cheap; package-local). Full dead-code workdir scans stay on `saf-dev-site issues --workdir` — not on this Spec package load.\n",
+        "description": "Returns metrics, exports, and test cases for a single package at a commit. Prefer this over full commit detail for the checkout Spec panel — assembly only touches that package's source blobs. For db packages, also includes dbInventory (drizzle tables + query dirs). For spec packages, also includes specInventory (OpenAPI schemas + REST resources). For http and sdk packages, specInventory is joined from a spec package this package depends on, while exports/tests remain this package's own source modules. For spa packages, specInventory is joined through SDK request imports so Spec can show loader routes on a component bundle. layoutIssues are live working-tree layout/LoC findings for the package directory (cheap; package-local). Full dead-code workdir scans stay on saf-dev-site issues --workdir — not on this Spec package load.\n",
         "parameters": [
           {
             "name": "hash",
@@ -1006,6 +1006,20 @@
             "description": "Package directory relative to the analyzed product root.",
             "example": "saflib/git"
           },
+          "kind": {
+            "type": "string",
+            "description": "Package layer kind. From package.json saf.kind when set, otherwise inferred from a unique identifier dependency such as @saflib/drizzle (db), @saflib/express (http), @saflib/openapi (spec), @saflib/sdk (sdk), or @saflib/vue (spa).\n",
+            "enum": [
+              "db",
+              "http",
+              "spec",
+              "spa",
+              "sdk",
+              "lib",
+              "integration",
+              "other"
+            ]
+          },
           "sourceFiles": {
             "type": "integer",
             "minimum": 0,
@@ -1638,14 +1652,14 @@
       },
       "spec-inventory": {
         "type": "object",
-        "description": "OpenAPI inventory for one `-spec` package — business objects (schemas/) and/or REST resources (routes/), linked by normalized name stems. Operations include triangle links to sibling `-http` handlers and `-sdk` requests when present. Also attached to `-http` package detail (sibling join) for the HTTP Spec pane.\n",
+        "description": "OpenAPI inventory for one spec package — business objects (schemas/) and/or REST resources (routes/), linked by normalized name stems. Operations include links to HTTP handlers and SDK requests from packages that depend on this spec. Also attached to http package detail for the HTTP Spec pane.\n",
         "required": [
           "entities"
         ],
         "properties": {
           "packageDirectory": {
             "type": "string",
-            "description": "Repo-relative directory of the `-spec` package this inventory was built from (used for route YAML source links when shown from an `-http` pane).\n"
+            "description": "Repo-relative directory of the spec package this inventory was built from (used for route YAML source links when shown from an http pane).\n"
           },
           "entities": {
             "type": "array",

--- a/dev-site/dev-site-spec/dist/openapi.json
+++ b/dev-site/dev-site-spec/dist/openapi.json
@@ -420,7 +420,18 @@
         "tags": [
           "no-auth"
         ],
-        "description": "Resolve git HEAD and report whether that commit has been analyzed, plus package metrics when it has. Used by the Current checkout UI.\n",
+        "description": "Resolve git HEAD and report whether that commit has been analyzed, plus package metrics when it has. Also reports local branch compare candidates and the fork-point (merge-base) of HEAD vs `compareRef` (default `main`). Used by the Current checkout UI.\n",
+        "parameters": [
+          {
+            "name": "compareRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Local branch name to take the merge-base against. Defaults to the server `main` ref.\n"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Checkout status",
@@ -435,7 +446,8 @@
                     "analyzed",
                     "productRoot",
                     "branch",
-                    "packages"
+                    "packages",
+                    "compareCandidates"
                   ],
                   "properties": {
                     "hash": {
@@ -465,8 +477,28 @@
                       "items": {
                         "$ref": "#/components/schemas/package-metrics"
                       }
+                    },
+                    "compareCandidates": {
+                      "type": "array",
+                      "description": "Local branch names that can be used as `compareRef` (current branch omitted; configured main ref always included when it exists).\n",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "compare": {
+                      "$ref": "#/components/schemas/checkout-compare"
                     }
                   }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "compareRef is not a valid git object.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
                 }
               }
             }
@@ -723,6 +755,9 @@
       },
       "DbSchemaColumn": {
         "$ref": "#/components/schemas/db-schema-column"
+      },
+      "CheckoutCompare": {
+        "$ref": "#/components/schemas/checkout-compare"
       },
       "commit-ref": {
         "type": "object",
@@ -1925,6 +1960,40 @@
           "repoPath": {
             "type": "string",
             "description": "Repo-relative path for open-source links"
+          }
+        }
+      },
+      "checkout-compare": {
+        "type": "object",
+        "description": "Fork-point (merge-base of HEAD and a chosen branch) for Checkout compare mode.\n",
+        "required": [
+          "againstRef",
+          "mergeBaseHash",
+          "mergeBaseAnalyzed",
+          "mergeBaseMessage",
+          "mergeBaseAuthoredAt"
+        ],
+        "properties": {
+          "againstRef": {
+            "type": "string",
+            "description": "Branch/ref HEAD was compared against (e.g. `main`)."
+          },
+          "mergeBaseHash": {
+            "type": "string",
+            "description": "Full hash of `git merge-base(HEAD, againstRef)`."
+          },
+          "mergeBaseAnalyzed": {
+            "type": "boolean",
+            "description": "True when that fork-point commit has an analysis snapshot."
+          },
+          "mergeBaseMessage": {
+            "type": "string",
+            "description": "Subject of the fork-point commit."
+          },
+          "mergeBaseAuthoredAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Author date of the fork-point commit."
           }
         }
       },

--- a/dev-site/dev-site-spec/dist/operations/diffCommits/openapi.d.ts
+++ b/dev-site/dev-site-spec/dist/operations/diffCommits/openapi.d.ts
@@ -78,6 +78,11 @@ export interface components {
              * @example saflib/git
              */
             directory: string;
+            /**
+             * @description Package layer kind. From package.json saf.kind when set, otherwise inferred from a unique identifier dependency such as @saflib/drizzle (db), @saflib/express (http), @saflib/openapi (spec), @saflib/sdk (sdk), or @saflib/vue (spa).
+             * @enum {string}
+             */
+            kind?: "db" | "http" | "spec" | "spa" | "sdk" | "lib" | "integration" | "other";
             /** @description Count of source files (excluding tests). */
             sourceFiles: number;
             /** @description Total lines across source files. */

--- a/dev-site/dev-site-spec/dist/operations/diffCommits/openapi.json
+++ b/dev-site/dev-site-spec/dist/operations/diffCommits/openapi.json
@@ -257,6 +257,20 @@
             "description": "Package directory relative to the analyzed product root.",
             "example": "saflib/git"
           },
+          "kind": {
+            "type": "string",
+            "description": "Package layer kind. From package.json saf.kind when set, otherwise inferred from a unique identifier dependency such as @saflib/drizzle (db), @saflib/express (http), @saflib/openapi (spec), @saflib/sdk (sdk), or @saflib/vue (spa).\n",
+            "enum": [
+              "db",
+              "http",
+              "spec",
+              "spa",
+              "sdk",
+              "lib",
+              "integration",
+              "other"
+            ]
+          },
           "sourceFiles": {
             "type": "integer",
             "minimum": 0,

--- a/dev-site/dev-site-spec/dist/operations/getCheckout/openapi.d.ts
+++ b/dev-site/dev-site-spec/dist/operations/getCheckout/openapi.d.ts
@@ -40,6 +40,11 @@ export interface components {
              * @example saflib/git
              */
             directory: string;
+            /**
+             * @description Package layer kind. From package.json saf.kind when set, otherwise inferred from a unique identifier dependency such as @saflib/drizzle (db), @saflib/express (http), @saflib/openapi (spec), @saflib/sdk (sdk), or @saflib/vue (spa).
+             * @enum {string}
+             */
+            kind?: "db" | "http" | "spec" | "spa" | "sdk" | "lib" | "integration" | "other";
             /** @description Count of source files (excluding tests). */
             sourceFiles: number;
             /** @description Total lines across source files. */

--- a/dev-site/dev-site-spec/dist/operations/getCheckout/openapi.d.ts
+++ b/dev-site/dev-site-spec/dist/operations/getCheckout/openapi.d.ts
@@ -75,6 +75,15 @@ export interface components {
              * @description Author date of the fork-point commit.
              */
             mergeBaseAuthoredAt: string;
+            /** @description File rename pairs from the fork point to HEAD (`git diff --find-renames`). Used by Checkout compare to show moved modules instead of remove+add. */
+            renames: {
+                /** @description Path at the fork-point commit. */
+                fromPath: string;
+                /** @description Path at HEAD. */
+                toPath: string;
+                /** @description Git rename similarity (0-100). */
+                score?: number;
+            }[];
         };
         error: {
             /** @description A short, machine-readable error code, for when HTTP status codes are not sufficient. */

--- a/dev-site/dev-site-spec/dist/operations/getCheckout/openapi.d.ts
+++ b/dev-site/dev-site-spec/dist/operations/getCheckout/openapi.d.ts
@@ -13,7 +13,7 @@ export interface paths {
         };
         /**
          * Current checkout (HEAD) analysis status
-         * @description Resolve git HEAD and report whether that commit has been analyzed, plus package metrics when it has. Used by the Current checkout UI.
+         * @description Resolve git HEAD and report whether that commit has been analyzed, plus package metrics when it has. Also reports local branch compare candidates and the fork-point (merge-base) of HEAD vs `compareRef` (default `main`). Used by the Current checkout UI.
          */
         get: operations["getCheckout"];
         put?: never;
@@ -60,6 +60,22 @@ export interface components {
             "oversized-file": number;
             "package-layout": number;
         };
+        /** @description Fork-point (merge-base of HEAD and a chosen branch) for Checkout compare mode. */
+        "checkout-compare": {
+            /** @description Branch/ref HEAD was compared against (e.g. `main`). */
+            againstRef: string;
+            /** @description Full hash of `git merge-base(HEAD, againstRef)`. */
+            mergeBaseHash: string;
+            /** @description True when that fork-point commit has an analysis snapshot. */
+            mergeBaseAnalyzed: boolean;
+            /** @description Subject of the fork-point commit. */
+            mergeBaseMessage: string;
+            /**
+             * Format: date-time
+             * @description Author date of the fork-point commit.
+             */
+            mergeBaseAuthoredAt: string;
+        };
         error: {
             /** @description A short, machine-readable error code, for when HTTP status codes are not sufficient. */
             code?: string;
@@ -80,7 +96,10 @@ export type $defs = Record<string, never>;
 export interface operations {
     getCheckout: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Local branch name to take the merge-base against. Defaults to the server `main` ref. */
+                compareRef?: string;
+            };
             header?: never;
             path?: never;
             cookie?: never;
@@ -104,7 +123,19 @@ export interface operations {
                         /** @description Short branch name for HEAD, or null when detached. */
                         branch: string | null;
                         packages: components["schemas"]["package-metrics"][];
+                        /** @description Local branch names that can be used as `compareRef` (current branch omitted; configured main ref always included when it exists). */
+                        compareCandidates: string[];
+                        compare?: components["schemas"]["checkout-compare"];
                     };
+                };
+            };
+            /** @description compareRef is not a valid git object. */
+            400: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["error"];
                 };
             };
             /** @description Git command failed */

--- a/dev-site/dev-site-spec/dist/operations/getCheckout/openapi.json
+++ b/dev-site/dev-site-spec/dist/operations/getCheckout/openapi.json
@@ -202,7 +202,8 @@
           "mergeBaseHash",
           "mergeBaseAnalyzed",
           "mergeBaseMessage",
-          "mergeBaseAuthoredAt"
+          "mergeBaseAuthoredAt",
+          "renames"
         ],
         "properties": {
           "againstRef": {
@@ -225,6 +226,33 @@
             "type": "string",
             "format": "date-time",
             "description": "Author date of the fork-point commit."
+          },
+          "renames": {
+            "type": "array",
+            "description": "File rename pairs from the fork point to HEAD (`git diff --find-renames`). Used by Checkout compare to show moved modules instead of remove+add.\n",
+            "items": {
+              "type": "object",
+              "required": [
+                "fromPath",
+                "toPath"
+              ],
+              "properties": {
+                "fromPath": {
+                  "type": "string",
+                  "description": "Path at the fork-point commit."
+                },
+                "toPath": {
+                  "type": "string",
+                  "description": "Path at HEAD."
+                },
+                "score": {
+                  "type": "integer",
+                  "minimum": 0,
+                  "maximum": 100,
+                  "description": "Git rename similarity (0-100)."
+                }
+              }
+            }
           }
         }
       },

--- a/dev-site/dev-site-spec/dist/operations/getCheckout/openapi.json
+++ b/dev-site/dev-site-spec/dist/operations/getCheckout/openapi.json
@@ -12,7 +12,18 @@
         "tags": [
           "no-auth"
         ],
-        "description": "Resolve git HEAD and report whether that commit has been analyzed, plus package metrics when it has. Used by the Current checkout UI.\n",
+        "description": "Resolve git HEAD and report whether that commit has been analyzed, plus package metrics when it has. Also reports local branch compare candidates and the fork-point (merge-base) of HEAD vs `compareRef` (default `main`). Used by the Current checkout UI.\n",
+        "parameters": [
+          {
+            "name": "compareRef",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string"
+            },
+            "description": "Local branch name to take the merge-base against. Defaults to the server `main` ref.\n"
+          }
+        ],
         "responses": {
           "200": {
             "description": "Checkout status",
@@ -27,7 +38,8 @@
                     "analyzed",
                     "productRoot",
                     "branch",
-                    "packages"
+                    "packages",
+                    "compareCandidates"
                   ],
                   "properties": {
                     "hash": {
@@ -57,8 +69,28 @@
                       "items": {
                         "$ref": "#/components/schemas/package-metrics"
                       }
+                    },
+                    "compareCandidates": {
+                      "type": "array",
+                      "description": "Local branch names that can be used as `compareRef` (current branch omitted; configured main ref always included when it exists).\n",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "compare": {
+                      "$ref": "#/components/schemas/checkout-compare"
                     }
                   }
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "compareRef is not a valid git object.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/error"
                 }
               }
             }
@@ -161,6 +193,40 @@
           "oversized-file",
           "package-layout"
         ]
+      },
+      "checkout-compare": {
+        "type": "object",
+        "description": "Fork-point (merge-base of HEAD and a chosen branch) for Checkout compare mode.\n",
+        "required": [
+          "againstRef",
+          "mergeBaseHash",
+          "mergeBaseAnalyzed",
+          "mergeBaseMessage",
+          "mergeBaseAuthoredAt"
+        ],
+        "properties": {
+          "againstRef": {
+            "type": "string",
+            "description": "Branch/ref HEAD was compared against (e.g. `main`)."
+          },
+          "mergeBaseHash": {
+            "type": "string",
+            "description": "Full hash of `git merge-base(HEAD, againstRef)`."
+          },
+          "mergeBaseAnalyzed": {
+            "type": "boolean",
+            "description": "True when that fork-point commit has an analysis snapshot."
+          },
+          "mergeBaseMessage": {
+            "type": "string",
+            "description": "Subject of the fork-point commit."
+          },
+          "mergeBaseAuthoredAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Author date of the fork-point commit."
+          }
+        }
       },
       "error": {
         "type": "object",

--- a/dev-site/dev-site-spec/dist/operations/getCheckout/openapi.json
+++ b/dev-site/dev-site-spec/dist/operations/getCheckout/openapi.json
@@ -125,6 +125,20 @@
             "description": "Package directory relative to the analyzed product root.",
             "example": "saflib/git"
           },
+          "kind": {
+            "type": "string",
+            "description": "Package layer kind. From package.json saf.kind when set, otherwise inferred from a unique identifier dependency such as @saflib/drizzle (db), @saflib/express (http), @saflib/openapi (spec), @saflib/sdk (sdk), or @saflib/vue (spa).\n",
+            "enum": [
+              "db",
+              "http",
+              "spec",
+              "spa",
+              "sdk",
+              "lib",
+              "integration",
+              "other"
+            ]
+          },
           "sourceFiles": {
             "type": "integer",
             "minimum": 0,

--- a/dev-site/dev-site-spec/dist/operations/getCommitPackage/openapi.d.ts
+++ b/dev-site/dev-site-spec/dist/operations/getCommitPackage/openapi.d.ts
@@ -13,7 +13,7 @@ export interface paths {
         };
         /**
          * Package-scoped symbols for one analyzed commit
-         * @description Returns metrics, exports, and test cases for a single package at a commit. Prefer this over full commit detail for the checkout Spec panel — assembly only touches that package's source blobs. For db packages, also includes `dbInventory` (drizzle tables + query dirs). For `-spec` packages, also includes `specInventory` (OpenAPI schemas + REST resources). For `-http` packages, `specInventory` is the sibling `-spec` triangle join (route cards) while exports/tests remain the HTTP or SDK package's own source modules. For Vue SPA / `-vue` packages, `specInventory` is the product `-spec` joined through SDK request imports so Spec can show loader routes on a component bundle. `layoutIssues` are live working-tree layout/LoC findings for the package directory (cheap; package-local). Full dead-code workdir scans stay on `saf-dev-site issues --workdir` — not on this Spec package load.
+         * @description Returns metrics, exports, and test cases for a single package at a commit. Prefer this over full commit detail for the checkout Spec panel — assembly only touches that package's source blobs. For db packages, also includes dbInventory (drizzle tables + query dirs). For spec packages, also includes specInventory (OpenAPI schemas + REST resources). For http and sdk packages, specInventory is joined from a spec package this package depends on, while exports/tests remain this package's own source modules. For spa packages, specInventory is joined through SDK request imports so Spec can show loader routes on a component bundle. layoutIssues are live working-tree layout/LoC findings for the package directory (cheap; package-local). Full dead-code workdir scans stay on saf-dev-site issues --workdir — not on this Spec package load.
          */
         get: operations["getCommitPackage"];
         put?: never;
@@ -148,9 +148,9 @@ export interface components {
                 }[];
             }[];
         };
-        /** @description OpenAPI inventory for one `-spec` package — business objects (schemas/) and/or REST resources (routes/), linked by normalized name stems. Operations include triangle links to sibling `-http` handlers and `-sdk` requests when present. Also attached to `-http` package detail (sibling join) for the HTTP Spec pane. */
+        /** @description OpenAPI inventory for one spec package — business objects (schemas/) and/or REST resources (routes/), linked by normalized name stems. Operations include links to HTTP handlers and SDK requests from packages that depend on this spec. Also attached to http package detail for the HTTP Spec pane. */
         "spec-inventory": {
-            /** @description Repo-relative directory of the `-spec` package this inventory was built from (used for route YAML source links when shown from an `-http` pane). */
+            /** @description Repo-relative directory of the spec package this inventory was built from (used for route YAML source links when shown from an http pane). */
             packageDirectory?: string;
             /** @description Flat alphabetical list of object / both / routes entities. */
             entities: {

--- a/dev-site/dev-site-spec/dist/operations/getCommitPackage/openapi.json
+++ b/dev-site/dev-site-spec/dist/operations/getCommitPackage/openapi.json
@@ -12,7 +12,7 @@
         "tags": [
           "no-auth"
         ],
-        "description": "Returns metrics, exports, and test cases for a single package at a commit. Prefer this over full commit detail for the checkout Spec panel — assembly only touches that package's source blobs. For db packages, also includes `dbInventory` (drizzle tables + query dirs). For `-spec` packages, also includes `specInventory` (OpenAPI schemas + REST resources). For `-http` packages, `specInventory` is the sibling `-spec` triangle join (route cards) while exports/tests remain the HTTP or SDK package's own source modules. For Vue SPA / `-vue` packages, `specInventory` is the product `-spec` joined through SDK request imports so Spec can show loader routes on a component bundle. `layoutIssues` are live working-tree layout/LoC findings for the package directory (cheap; package-local). Full dead-code workdir scans stay on `saf-dev-site issues --workdir` — not on this Spec package load.\n",
+        "description": "Returns metrics, exports, and test cases for a single package at a commit. Prefer this over full commit detail for the checkout Spec panel — assembly only touches that package's source blobs. For db packages, also includes dbInventory (drizzle tables + query dirs). For spec packages, also includes specInventory (OpenAPI schemas + REST resources). For http and sdk packages, specInventory is joined from a spec package this package depends on, while exports/tests remain this package's own source modules. For spa packages, specInventory is joined through SDK request imports so Spec can show loader routes on a component bundle. layoutIssues are live working-tree layout/LoC findings for the package directory (cheap; package-local). Full dead-code workdir scans stay on saf-dev-site issues --workdir — not on this Spec package load.\n",
         "parameters": [
           {
             "name": "hash",
@@ -430,14 +430,14 @@
       },
       "spec-inventory": {
         "type": "object",
-        "description": "OpenAPI inventory for one `-spec` package — business objects (schemas/) and/or REST resources (routes/), linked by normalized name stems. Operations include triangle links to sibling `-http` handlers and `-sdk` requests when present. Also attached to `-http` package detail (sibling join) for the HTTP Spec pane.\n",
+        "description": "OpenAPI inventory for one spec package — business objects (schemas/) and/or REST resources (routes/), linked by normalized name stems. Operations include links to HTTP handlers and SDK requests from packages that depend on this spec. Also attached to http package detail for the HTTP Spec pane.\n",
         "required": [
           "entities"
         ],
         "properties": {
           "packageDirectory": {
             "type": "string",
-            "description": "Repo-relative directory of the `-spec` package this inventory was built from (used for route YAML source links when shown from an `-http` pane).\n"
+            "description": "Repo-relative directory of the spec package this inventory was built from (used for route YAML source links when shown from an http pane).\n"
           },
           "entities": {
             "type": "array",

--- a/dev-site/dev-site-spec/dist/operations/getCommits/openapi.d.ts
+++ b/dev-site/dev-site-spec/dist/operations/getCommits/openapi.d.ts
@@ -102,6 +102,11 @@ export interface components {
              * @example saflib/git
              */
             directory: string;
+            /**
+             * @description Package layer kind. From package.json saf.kind when set, otherwise inferred from a unique identifier dependency such as @saflib/drizzle (db), @saflib/express (http), @saflib/openapi (spec), @saflib/sdk (sdk), or @saflib/vue (spa).
+             * @enum {string}
+             */
+            kind?: "db" | "http" | "spec" | "spa" | "sdk" | "lib" | "integration" | "other";
             /** @description Count of source files (excluding tests). */
             sourceFiles: number;
             /** @description Total lines across source files. */

--- a/dev-site/dev-site-spec/dist/operations/getCommits/openapi.json
+++ b/dev-site/dev-site-spec/dist/operations/getCommits/openapi.json
@@ -201,6 +201,20 @@
             "description": "Package directory relative to the analyzed product root.",
             "example": "saflib/git"
           },
+          "kind": {
+            "type": "string",
+            "description": "Package layer kind. From package.json saf.kind when set, otherwise inferred from a unique identifier dependency such as @saflib/drizzle (db), @saflib/express (http), @saflib/openapi (spec), @saflib/sdk (sdk), or @saflib/vue (spa).\n",
+            "enum": [
+              "db",
+              "http",
+              "spec",
+              "spa",
+              "sdk",
+              "lib",
+              "integration",
+              "other"
+            ]
+          },
           "sourceFiles": {
             "type": "integer",
             "minimum": 0,

--- a/dev-site/dev-site-spec/dist/schemas/CheckoutCompare/index.ts
+++ b/dev-site/dev-site-spec/dist/schemas/CheckoutCompare/index.ts
@@ -1,0 +1,3 @@
+import type { components } from "../../openapi.d.ts";
+
+export type CheckoutCompare = components["schemas"]["CheckoutCompare"];

--- a/dev-site/dev-site-spec/dist/schemas/checkout-compare/index.ts
+++ b/dev-site/dev-site-spec/dist/schemas/checkout-compare/index.ts
@@ -1,0 +1,3 @@
+import type { components } from "../../openapi.d.ts";
+
+export type CheckoutCompare = components["schemas"]["checkout-compare"];

--- a/dev-site/dev-site-spec/openapi.yaml
+++ b/dev-site/dev-site-spec/openapi.yaml
@@ -71,4 +71,6 @@ components:
       $ref: "./schemas/db-schema-table.yaml"
     DbSchemaColumn:
       $ref: "./schemas/db-schema-column.yaml"
+    CheckoutCompare:
+      $ref: "./schemas/checkout-compare.yaml"
     # END WORKFLOW AREA

--- a/dev-site/dev-site-spec/routes/checkout/get.yaml
+++ b/dev-site/dev-site-spec/routes/checkout/get.yaml
@@ -5,7 +5,18 @@ getCheckout:
     - no-auth
   description: >
     Resolve git HEAD and report whether that commit has been analyzed, plus
-    package metrics when it has. Used by the Current checkout UI.
+    package metrics when it has. Also reports local branch compare candidates
+    and the fork-point (merge-base) of HEAD vs `compareRef` (default `main`).
+    Used by the Current checkout UI.
+  parameters:
+    - name: compareRef
+      in: query
+      required: false
+      schema:
+        type: string
+      description: >
+        Local branch name to take the merge-base against. Defaults to the
+        server `main` ref.
   responses:
     "200":
       description: Checkout status
@@ -21,6 +32,7 @@ getCheckout:
               - productRoot
               - branch
               - packages
+              - compareCandidates
             properties:
               hash:
                 type: string
@@ -45,6 +57,22 @@ getCheckout:
                 type: array
                 items:
                   $ref: "../../schemas/package-metrics.yaml"
+              compareCandidates:
+                type: array
+                description: >
+                  Local branch names that can be used as `compareRef` (current
+                  branch omitted; configured main ref always included when it
+                  exists).
+                items:
+                  type: string
+              compare:
+                $ref: "../../schemas/checkout-compare.yaml"
+    "400":
+      description: compareRef is not a valid git object.
+      content:
+        application/json:
+          schema:
+            $ref: "../../schemas/error.yaml"
     "500":
       description: Git command failed
       content:

--- a/dev-site/dev-site-spec/routes/commits/package.yaml
+++ b/dev-site/dev-site-spec/routes/commits/package.yaml
@@ -7,15 +7,15 @@ getCommitPackage:
     Returns metrics, exports, and test cases for a single package at a commit.
     Prefer this over full commit detail for the checkout Spec panel — assembly
     only touches that package's source blobs. For db packages, also includes
-    `dbInventory` (drizzle tables + query dirs). For `-spec` packages, also
-    includes `specInventory` (OpenAPI schemas + REST resources). For `-http`
-    packages, `specInventory` is the sibling `-spec` triangle join (route cards)
-    while exports/tests remain the HTTP or SDK package's own source modules.
-    For Vue SPA / `-vue` packages, `specInventory` is the product `-spec` joined
-    through SDK request imports so Spec can show loader routes on a component
-    bundle. `layoutIssues` are live working-tree layout/LoC findings for the
-    package directory (cheap; package-local). Full dead-code workdir scans stay
-    on `saf-dev-site issues --workdir` — not on this Spec package load.
+    dbInventory (drizzle tables + query dirs). For spec packages, also
+    includes specInventory (OpenAPI schemas + REST resources). For http and
+    sdk packages, specInventory is joined from a spec package this package
+    depends on, while exports/tests remain this package's own source modules.
+    For spa packages, specInventory is joined through SDK request imports so
+    Spec can show loader routes on a component bundle. layoutIssues are live
+    working-tree layout/LoC findings for the package directory (cheap;
+    package-local). Full dead-code workdir scans stay on
+    saf-dev-site issues --workdir — not on this Spec package load.
   parameters:
     - name: hash
       in: path

--- a/dev-site/dev-site-spec/schemas/checkout-compare.yaml
+++ b/dev-site/dev-site-spec/schemas/checkout-compare.yaml
@@ -1,0 +1,26 @@
+type: object
+description: >
+  Fork-point (merge-base of HEAD and a chosen branch) for Checkout compare mode.
+required:
+  - againstRef
+  - mergeBaseHash
+  - mergeBaseAnalyzed
+  - mergeBaseMessage
+  - mergeBaseAuthoredAt
+properties:
+  againstRef:
+    type: string
+    description: Branch/ref HEAD was compared against (e.g. `main`).
+  mergeBaseHash:
+    type: string
+    description: Full hash of `git merge-base(HEAD, againstRef)`.
+  mergeBaseAnalyzed:
+    type: boolean
+    description: True when that fork-point commit has an analysis snapshot.
+  mergeBaseMessage:
+    type: string
+    description: Subject of the fork-point commit.
+  mergeBaseAuthoredAt:
+    type: string
+    format: date-time
+    description: Author date of the fork-point commit.

--- a/dev-site/dev-site-spec/schemas/checkout-compare.yaml
+++ b/dev-site/dev-site-spec/schemas/checkout-compare.yaml
@@ -7,6 +7,7 @@ required:
   - mergeBaseAnalyzed
   - mergeBaseMessage
   - mergeBaseAuthoredAt
+  - renames
 properties:
   againstRef:
     type: string
@@ -24,3 +25,25 @@ properties:
     type: string
     format: date-time
     description: Author date of the fork-point commit.
+  renames:
+    type: array
+    description: >
+      File rename pairs from the fork point to HEAD (`git diff --find-renames`).
+      Used by Checkout compare to show moved modules instead of remove+add.
+    items:
+      type: object
+      required:
+        - fromPath
+        - toPath
+      properties:
+        fromPath:
+          type: string
+          description: Path at the fork-point commit.
+        toPath:
+          type: string
+          description: Path at HEAD.
+        score:
+          type: integer
+          minimum: 0
+          maximum: 100
+          description: Git rename similarity (0-100).

--- a/dev-site/dev-site-spec/schemas/package-metrics.yaml
+++ b/dev-site/dev-site-spec/schemas/package-metrics.yaml
@@ -9,6 +9,22 @@ properties:
     type: string
     description: Package directory relative to the analyzed product root.
     example: "saflib/git"
+  kind:
+    type: string
+    description: >
+      Package layer kind. From package.json saf.kind when set, otherwise
+      inferred from a unique identifier dependency such as @saflib/drizzle
+      (db), @saflib/express (http), @saflib/openapi (spec), @saflib/sdk
+      (sdk), or @saflib/vue (spa).
+    enum:
+      - db
+      - http
+      - spec
+      - spa
+      - sdk
+      - lib
+      - integration
+      - other
   sourceFiles:
     type: integer
     minimum: 0

--- a/dev-site/dev-site-spec/schemas/spec-inventory.yaml
+++ b/dev-site/dev-site-spec/schemas/spec-inventory.yaml
@@ -1,17 +1,17 @@
 type: object
 description: >
-  OpenAPI inventory for one `-spec` package — business objects (schemas/) and/or
+  OpenAPI inventory for one spec package — business objects (schemas/) and/or
   REST resources (routes/), linked by normalized name stems. Operations include
-  triangle links to sibling `-http` handlers and `-sdk` requests when present.
-  Also attached to `-http` package detail (sibling join) for the HTTP Spec pane.
+  links to HTTP handlers and SDK requests from packages that depend on this spec.
+  Also attached to http package detail for the HTTP Spec pane.
 required:
   - entities
 properties:
   packageDirectory:
     type: string
     description: >
-      Repo-relative directory of the `-spec` package this inventory was built
-      from (used for route YAML source links when shown from an `-http` pane).
+      Repo-relative directory of the spec package this inventory was built
+      from (used for route YAML source links when shown from an http pane).
   entities:
     type: array
     description: Flat alphabetical list of object / both / routes entities.

--- a/dev-site/dev-site-vue/components/ChangeChip.vue
+++ b/dev-site/dev-site-vue/components/ChangeChip.vue
@@ -1,0 +1,25 @@
+<template>
+  <v-chip
+    v-if="change"
+    :color="changeColor(change)"
+    size="x-small"
+    variant="tonal"
+    class="change-chip"
+  >
+    {{ change === "modified" ? "changed" : change }}
+  </v-chip>
+</template>
+
+<script setup lang="ts">
+import { changeColor, type ChangeKind } from "../package-change-overlay.ts";
+
+defineProps<{
+  change?: ChangeKind;
+}>();
+</script>
+
+<style scoped>
+.change-chip {
+  flex-shrink: 0;
+}
+</style>

--- a/dev-site/dev-site-vue/components/PackageDbSpecPane.vue
+++ b/dev-site/dev-site-vue/components/PackageDbSpecPane.vue
@@ -209,6 +209,7 @@ import {
   tagSpecTree,
   testIdentityKey,
   unionByKey,
+  type PathRename,
 } from "../package-change-overlay.ts";
 import { scopeDocListPrefix } from "../scope-docs.ts";
 import { repoPathPrefix } from "../repo-paths.ts";
@@ -254,6 +255,7 @@ const props = withDefaults(
     subdomain: string;
     commitHash: string;
     compareFromHash?: string;
+    pathRenames?: PathRename[];
     packageName: string;
     packageDirectory: string;
     productRoot: string;
@@ -291,6 +293,7 @@ const {
   {
     compareFromHash: () => props.compareFromHash,
     productRoot: () => props.productRoot,
+    pathRenames: () => props.pathRenames,
   },
 );
 
@@ -394,7 +397,7 @@ const fileNav = computed(() => {
     props.productRoot ?? "",
   );
   if (!overlay.value) return nav;
-  return filterFileNav(nav, overlay.value.modules);
+  return filterFileNav(nav, overlay.value.modules, overlay.value.movedFrom);
 });
 
 const pkgPrefix = computed(() =>

--- a/dev-site/dev-site-vue/components/PackageDbSpecPane.vue
+++ b/dev-site/dev-site-vue/components/PackageDbSpecPane.vue
@@ -45,7 +45,10 @@
               :key="e.entity"
               class="entity-block"
             >
-              <h3 class="entity-block__title">{{ e.entity }}</h3>
+              <h3 class="entity-block__title">
+                {{ e.entity }}
+                <ChangeChip :change="e.change" />
+              </h3>
 
               <div v-if="e.table" class="table-card">
                 <div class="table-card__head">
@@ -78,10 +81,16 @@
                     v-for="c in e.table.columns"
                     :key="c.sqlName"
                     class="table-card__col"
+                    :class="{
+                      'table-card__col--added': c.change === 'added',
+                      'table-card__col--removed': c.change === 'removed',
+                      'table-card__col--modified': c.change === 'modified',
+                    }"
                   >
                     <div class="table-card__col-main">
                       <code>{{ c.sqlName }}</code>
                       <span class="text-medium-emphasis">{{ c.typeKind }}</span>
+                      <ChangeChip :change="c.change" />
                     </div>
                     <p v-if="c.docstring" class="table-card__col-doc">
                       {{ c.docstring }}
@@ -178,7 +187,8 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { useCommitPackage, useScopeSummary } from "../requests/queries.ts";
+import { useScopeSummary } from "../requests/queries.ts";
+import { useComparedPackageDetail } from "../package-compare.ts";
 import {
   buildDbPackageFileNav,
   buildPackageSpecTree,
@@ -190,12 +200,23 @@ import {
   type TestScope,
   type TestTreeNode,
 } from "../test-tree.ts";
+import {
+  dbColumnKey,
+  exportIdentityKey,
+  filterFileNav,
+  pickChangedItems,
+  pruneEmptySpecTree,
+  tagSpecTree,
+  testIdentityKey,
+  unionByKey,
+} from "../package-change-overlay.ts";
 import { scopeDocListPrefix } from "../scope-docs.ts";
 import { repoPathPrefix } from "../repo-paths.ts";
 import { openSource } from "../source-links.ts";
 import ResizableColumns from "./ResizableColumns.vue";
 import TestFileNav from "./TestFileNav.vue";
 import TestTree from "./TestTree.vue";
+import ChangeChip from "./ChangeChip.vue";
 
 interface DbQuery {
   fileName: string;
@@ -220,16 +241,19 @@ interface DbEntity {
       sqlName: string;
       typeKind: string;
       docstring?: string | null;
+      change?: "added" | "removed" | "modified";
     }>;
   } | null;
   usedByPackages: string[];
   queries: DbQuery[];
+  change?: "added" | "removed" | "modified";
 }
 
 const props = withDefaults(
   defineProps<{
     subdomain: string;
     commitHash: string;
+    compareFromHash?: string;
     packageName: string;
     packageDirectory: string;
     productRoot: string;
@@ -253,16 +277,89 @@ const setScope = (next: TestScope) => {
   emit("update:scope", next);
 };
 
-const { data, isLoading, error } = useCommitPackage(
+const {
+  isLoading,
+  error,
+  overlay,
+  detail,
+  beforeDetail,
+  afterDetail,
+} = useComparedPackageDetail(
   props.subdomain,
   () => props.commitHash,
   () => props.packageName,
+  {
+    compareFromHash: () => props.compareFromHash,
+    productRoot: () => props.productRoot,
+  },
 );
 
-const detail = computed(() => data.value?.packageDetail);
-const entities = computed(
-  () => (detail.value?.dbInventory?.entities ?? []) as DbEntity[],
+const allExports = computed(() =>
+  unionByKey(
+    beforeDetail.value?.exports ?? [],
+    afterDetail.value?.exports ?? detail.value?.exports ?? [],
+    exportIdentityKey,
+  ),
 );
+const allTests = computed(() =>
+  unionByKey(
+    beforeDetail.value?.testCases ?? [],
+    afterDetail.value?.testCases ?? detail.value?.testCases ?? [],
+    testIdentityKey,
+  ),
+);
+const specExports = computed(() => {
+  if (!overlay.value) return allExports.value;
+  return pickChangedItems(
+    beforeDetail.value?.exports ?? [],
+    afterDetail.value?.exports ?? [],
+    exportIdentityKey,
+    overlay.value.exports,
+  );
+});
+const specTests = computed(() => {
+  if (!overlay.value) return allTests.value;
+  return pickChangedItems(
+    beforeDetail.value?.testCases ?? [],
+    afterDetail.value?.testCases ?? [],
+    testIdentityKey,
+    overlay.value.tests,
+  );
+});
+
+const rawEntities = computed(() => {
+  const before = (beforeDetail.value?.dbInventory?.entities ?? []) as DbEntity[];
+  const after = (afterDetail.value?.dbInventory?.entities ??
+    detail.value?.dbInventory?.entities ??
+    []) as DbEntity[];
+  return { before, after };
+});
+
+const entities = computed(() => {
+  const { before, after } = rawEntities.value;
+  if (!overlay.value) return unionByKey(before, after, (e) => e.entity);
+  return pickChangedItems(
+    before,
+    after,
+    (e) => e.entity,
+    overlay.value.dbEntities,
+  ).map((entity) => {
+    const b = before.find((e) => e.entity === entity.entity);
+    const a = after.find((e) => e.entity === entity.entity);
+    const beforeCols = b?.table?.columns ?? [];
+    const afterCols = a?.table?.columns ?? [];
+    const columns = pickChangedItems(
+      beforeCols,
+      afterCols,
+      (c) => dbColumnKey(entity.entity, c.sqlName),
+      overlay.value!.dbColumns,
+    );
+    return {
+      ...entity,
+      table: entity.table ? { ...entity.table, columns } : entity.table,
+    };
+  });
+});
 
 const entitySelection = computed(() =>
   dbEntitySelectionFromScope(scope.value),
@@ -288,16 +385,16 @@ const visibleEntities = computed(() => {
 });
 
 const fileNav = computed(() => {
-  const d = detail.value;
-  if (!d) return [];
-  return buildDbPackageFileNav(
+  const nav = buildDbPackageFileNav(
     entities.value.map((e) => e.entity),
-    d.exports ?? [],
-    d.testCases ?? [],
-    d.packageName,
+    allExports.value,
+    allTests.value,
+    props.packageName,
     props.packageDirectory,
     props.productRoot ?? "",
   );
+  if (!overlay.value) return nav;
+  return filterFileNav(nav, overlay.value.modules);
 });
 
 const pkgPrefix = computed(() =>
@@ -326,7 +423,12 @@ const scopeDocPrefix = computed(() => {
 const { summary: scopeSummary, isLoading: scopeDocLoading } = useScopeSummary(
   props.subdomain,
   () => ({
-    ref: props.commitHash,
+    ref:
+      overlay.value &&
+      scope.value.kind === "file" &&
+      overlay.value.modules[toModuleStem(scope.value.localPath)] === "removed"
+        ? (props.compareFromHash ?? props.commitHash)
+        : props.commitHash,
     prefix: scopeDocPrefix.value,
   }),
 );
@@ -351,17 +453,17 @@ const scopePresenceLabel = computed(() => {
 
 const moduleSpecTree = computed(() => {
   if (!showModulePanel.value) return [];
-  const d = detail.value;
-  if (!d) return [];
-  return buildPackageSpecTree(
-    d.exports ?? [],
-    d.testCases ?? [],
-    d.packageName,
+  const tree = buildPackageSpecTree(
+    specExports.value,
+    specTests.value,
+    props.packageName,
     props.packageDirectory,
     props.productRoot ?? "",
     scope.value,
     { excludeStem: isDbPackageHiddenModuleStem },
   );
+  if (!overlay.value) return tree;
+  return pruneEmptySpecTree(tagSpecTree(tree, overlay.value));
 });
 
 const scopeFileName = computed(() => {
@@ -425,7 +527,7 @@ function queryMatchesTestFile(q: DbQuery, fileNode: TestTreeNode): boolean {
  * suite-shaped cards; orphan suites keep their own cards.
  */
 function specCardsFor(entity: DbEntity): TestTreeNode[] {
-  const cases = (detail.value?.testCases ?? []).filter((t) => {
+  const cases = specTests.value.filter((t) => {
     const needle = `/queries/${entity.entity}/`;
     return (
       t.filePath.includes(needle) ||
@@ -493,7 +595,9 @@ function specCardsFor(entity: DbEntity): TestTreeNode[] {
     cards.push(suite);
   }
 
-  return cards;
+  return overlay.value
+    ? pruneEmptySpecTree(tagSpecTree(cards, overlay.value))
+    : cards;
 }
 
 function openFile(path: string) {
@@ -555,6 +659,10 @@ function openFile(path: string) {
   font-size: 1rem;
   font-weight: 600;
   margin: 0 0 0.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
 }
 .table-card {
   border: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
@@ -612,6 +720,18 @@ function openFile(path: string) {
   margin: 0.15rem 0 0;
   font-size: 0.8125rem;
   color: rgba(var(--v-theme-on-surface), 0.65);
+}
+.table-card__col--added {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-success));
+  padding-left: 0.5rem;
+}
+.table-card__col--removed {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-error));
+  padding-left: 0.5rem;
+}
+.table-card__col--modified {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-warning));
+  padding-left: 0.5rem;
 }
 .scope-header {
   margin-bottom: 0.75rem;

--- a/dev-site/dev-site-vue/components/PackageDirTree.vue
+++ b/dev-site/dev-site-vue/components/PackageDirTree.vue
@@ -11,6 +11,7 @@
           'pkg-tree__row--added': node.change === 'added',
           'pkg-tree__row--removed': node.change === 'removed',
           'pkg-tree__row--modified': node.change === 'modified',
+          'pkg-tree__row--moved': node.change === 'moved',
         }"
         @click="onClick(node)"
       >
@@ -135,6 +136,9 @@ const debtTip = (node: PackageDirNode) =>
 }
 .pkg-tree__row--modified {
   box-shadow: inset 3px 0 0 rgb(var(--v-theme-warning));
+}
+.pkg-tree__row--moved {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-info));
 }
 .pkg-tree__label {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;

--- a/dev-site/dev-site-vue/components/PackageDirTree.vue
+++ b/dev-site/dev-site-vue/components/PackageDirTree.vue
@@ -8,6 +8,9 @@
           'pkg-tree__row--package': node.kind === 'package',
           'pkg-tree__row--selected':
             node.kind === 'package' && node.packageName === selectedPackageName,
+          'pkg-tree__row--added': node.change === 'added',
+          'pkg-tree__row--removed': node.change === 'removed',
+          'pkg-tree__row--modified': node.change === 'modified',
         }"
         @click="onClick(node)"
       >
@@ -22,6 +25,7 @@
           :title="node.kind === 'package' ? node.packageKind : undefined"
         />
         <span class="pkg-tree__label">{{ node.label }}</span>
+        <ChangeChip v-if="node.kind === 'package'" :change="node.change" />
         <span v-if="node.kind === 'package'" class="pkg-tree__meta">
           <v-tooltip location="end">
             <template #activator="{ props: tip }">
@@ -55,6 +59,7 @@ import {
   debtTooltipText,
 } from "../package-debt";
 import { emptyIssueCountsByKind } from "../package-issues";
+import ChangeChip from "./ChangeChip.vue";
 
 defineProps<{
   nodes: PackageDirNode[];
@@ -121,6 +126,15 @@ const debtTip = (node: PackageDirNode) =>
 }
 .pkg-tree__row--selected {
   background: rgba(var(--v-theme-primary), 0.12);
+}
+.pkg-tree__row--added {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-success));
+}
+.pkg-tree__row--removed {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-error));
+}
+.pkg-tree__row--modified {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-warning));
 }
 .pkg-tree__label {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;

--- a/dev-site/dev-site-vue/components/PackageHttpPane.vue
+++ b/dev-site/dev-site-vue/components/PackageHttpPane.vue
@@ -137,6 +137,7 @@ import {
   tagSpecTree,
   testIdentityKey,
   unionByKey,
+  type PathRename,
 } from "../package-change-overlay";
 import { scopeDocListPrefix } from "../scope-docs";
 import { repoPathPrefix } from "../repo-paths";
@@ -189,6 +190,7 @@ const props = withDefaults(
     subdomain: string;
     commitHash: string;
     compareFromHash?: string;
+    pathRenames?: PathRename[];
     packageName: string;
     packageDirectory: string;
     productRoot?: string;
@@ -226,6 +228,7 @@ const {
   {
     compareFromHash: () => props.compareFromHash,
     productRoot: () => props.productRoot,
+    pathRenames: () => props.pathRenames,
   },
 );
 
@@ -287,7 +290,7 @@ const fileNav = computed(() => {
     ),
   );
   if (!overlay.value) return nav;
-  return filterFileNav(nav, overlay.value.modules);
+  return filterFileNav(nav, overlay.value.modules, overlay.value.movedFrom);
 });
 
 /** Prefer `handlers/` when landing with no selection. */

--- a/dev-site/dev-site-vue/components/PackageHttpPane.vue
+++ b/dev-site/dev-site-vue/components/PackageHttpPane.vue
@@ -76,7 +76,13 @@
               <li
                 v-for="op in scopedRoutes"
                 :key="op.operationId + op.method + op.path"
+                :class="{
+                  'routes-block__item--added': op.change === 'added',
+                  'routes-block__item--removed': op.change === 'removed',
+                  'routes-block__item--modified': op.change === 'modified',
+                }"
               >
+                <ChangeChip :change="op.change" />
                 <PackageRouteCard
                   :operation="normalizeOp(op)"
                   :route-repo-path="routeRepoPath(op.yamlPath)"
@@ -112,7 +118,8 @@
 
 <script setup lang="ts">
 import { computed, watch } from "vue";
-import { useCommitPackage, useScopeSummary } from "../requests/queries";
+import { useScopeSummary } from "../requests/queries";
+import { useComparedPackageDetail } from "../package-compare";
 import {
   buildModuleFileNav,
   buildPackageSpecTree,
@@ -121,6 +128,16 @@ import {
   type TestFileNavNode,
   type TestScope,
 } from "../test-tree";
+import {
+  exportIdentityKey,
+  filterFileNav,
+  pickChangedItems,
+  pruneEmptySpecTree,
+  specOperationKey,
+  tagSpecTree,
+  testIdentityKey,
+  unionByKey,
+} from "../package-change-overlay";
 import { scopeDocListPrefix } from "../scope-docs";
 import { repoPathPrefix } from "../repo-paths";
 import { openSource } from "../source-links";
@@ -130,6 +147,7 @@ import PackageRouteCard, {
   type RouteCardOperation,
 } from "./PackageRouteCard.vue";
 import ResizableColumns from "./ResizableColumns.vue";
+import ChangeChip from "./ChangeChip.vue";
 
 interface SpecFileRef {
   filePath: string;
@@ -163,12 +181,14 @@ interface SpecOperation {
   usedBy: SpecUsedBy[];
   enqueues?: string[];
   enqueuedBy?: string[];
+  change?: "added" | "removed" | "modified";
 }
 
 const props = withDefaults(
   defineProps<{
     subdomain: string;
     commitHash: string;
+    compareFromHash?: string;
     packageName: string;
     packageDirectory: string;
     productRoot?: string;
@@ -192,38 +212,82 @@ const setScope = (next: TestScope) => {
   emit("update:scope", next);
 };
 
-const { data, isLoading, error } = useCommitPackage(
+const {
+  isLoading,
+  error,
+  overlay,
+  detail,
+  beforeDetail,
+  afterDetail,
+} = useComparedPackageDetail(
   props.subdomain,
   () => props.commitHash,
   () => props.packageName,
+  {
+    compareFromHash: () => props.compareFromHash,
+    productRoot: () => props.productRoot,
+  },
 );
-
-const detail = computed(() => data.value?.packageDetail);
 
 const pkgPrefix = computed(() =>
   repoPathPrefix(props.productRoot, props.packageDirectory),
 );
 
 const specPkgPrefix = computed(() => {
-  const dir = detail.value?.specInventory?.packageDirectory as
-    | string
-    | undefined;
+  const dir = (
+    afterDetail.value?.specInventory ??
+    beforeDetail.value?.specInventory ??
+    detail.value?.specInventory
+  )?.packageDirectory as string | undefined;
   if (!dir) return "";
   return repoPathPrefix(props.productRoot, dir);
 });
 
+const allExports = computed(() =>
+  unionByKey(
+    beforeDetail.value?.exports ?? [],
+    afterDetail.value?.exports ?? detail.value?.exports ?? [],
+    exportIdentityKey,
+  ),
+);
+const allTests = computed(() =>
+  unionByKey(
+    beforeDetail.value?.testCases ?? [],
+    afterDetail.value?.testCases ?? detail.value?.testCases ?? [],
+    testIdentityKey,
+  ),
+);
+const specExports = computed(() => {
+  if (!overlay.value) return allExports.value;
+  return pickChangedItems(
+    beforeDetail.value?.exports ?? [],
+    afterDetail.value?.exports ?? [],
+    exportIdentityKey,
+    overlay.value.exports,
+  );
+});
+const specTests = computed(() => {
+  if (!overlay.value) return allTests.value;
+  return pickChangedItems(
+    beforeDetail.value?.testCases ?? [],
+    afterDetail.value?.testCases ?? [],
+    testIdentityKey,
+    overlay.value.tests,
+  );
+});
+
 const fileNav = computed(() => {
-  const d = detail.value;
-  if (!d) return [];
-  return pruneEmptyIndexModules(
+  const nav = pruneEmptyIndexModules(
     buildModuleFileNav(
-      d.exports ?? [],
-      d.testCases,
-      d.packageName,
+      allExports.value,
+      allTests.value,
+      props.packageName,
       props.packageDirectory,
       props.productRoot ?? "",
     ),
   );
+  if (!overlay.value) return nav;
+  return filterFileNav(nav, overlay.value.modules);
 });
 
 /** Prefer `handlers/` when landing with no selection. */
@@ -274,10 +338,18 @@ const scopeDocPrefix = computed(() =>
   }),
 );
 
+const scopeDocRef = computed(() => {
+  if (!overlay.value || scope.value.kind !== "file") return props.commitHash;
+  const stem = toModuleStem(scope.value.localPath);
+  return overlay.value.modules[stem] === "removed"
+    ? (props.compareFromHash ?? props.commitHash)
+    : props.commitHash;
+});
+
 const { summary: scopeSummary, isLoading: scopeDocLoading } = useScopeSummary(
   props.subdomain,
   () => ({
-    ref: props.commitHash,
+    ref: scopeDocRef.value,
     prefix: scopeDocPrefix.value,
   }),
 );
@@ -301,27 +373,38 @@ const scopePresenceLabel = computed(() => {
 });
 
 const specTree = computed(() => {
-  const d = detail.value;
-  if (!d) return [];
-  return buildPackageSpecTree(
-    d.exports ?? [],
-    d.testCases,
-    d.packageName,
+  const tree = buildPackageSpecTree(
+    specExports.value,
+    specTests.value,
+    props.packageName,
     props.packageDirectory,
     props.productRoot ?? "",
     scope.value,
   );
+  if (!overlay.value) return tree;
+  return pruneEmptySpecTree(tagSpecTree(tree, overlay.value));
 });
 
 const allOperations = computed((): SpecOperation[] => {
-  const entities = detail.value?.specInventory?.entities ?? [];
-  const ops: SpecOperation[] = [];
-  for (const e of entities) {
-    for (const op of e.operations ?? []) {
-      ops.push(op as SpecOperation);
-    }
+  const beforeOps: SpecOperation[] = [];
+  const afterOps: SpecOperation[] = [];
+  for (const e of beforeDetail.value?.specInventory?.entities ?? []) {
+    for (const op of e.operations ?? []) beforeOps.push(op as SpecOperation);
   }
-  return ops.sort((a, b) => {
+  for (const e of afterDetail.value?.specInventory?.entities ??
+    detail.value?.specInventory?.entities ??
+    []) {
+    for (const op of e.operations ?? []) afterOps.push(op as SpecOperation);
+  }
+  const merged = overlay.value
+    ? pickChangedItems(
+        beforeOps,
+        afterOps,
+        specOperationKey,
+        overlay.value.specOperations,
+      )
+    : unionByKey(beforeOps, afterOps, specOperationKey);
+  return merged.sort((a, b) => {
     const ha = a.handler?.filePath ?? a.routeStem ?? a.path;
     const hb = b.handler?.filePath ?? b.routeStem ?? b.path;
     return (
@@ -501,5 +584,21 @@ function openFile(path: string) {
   padding: 0;
   display: grid;
   gap: 0.65rem;
+}
+.routes-block__item--added,
+.routes-block__item--removed,
+.routes-block__item--modified {
+  display: grid;
+  gap: 0.35rem;
+  padding-left: 0.5rem;
+}
+.routes-block__item--added {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-success));
+}
+.routes-block__item--removed {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-error));
+}
+.routes-block__item--modified {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-warning));
 }
 </style>

--- a/dev-site/dev-site-vue/components/PackageSdkPane.vue
+++ b/dev-site/dev-site-vue/components/PackageSdkPane.vue
@@ -138,6 +138,7 @@ import {
   tagSpecTree,
   testIdentityKey,
   unionByKey,
+  type PathRename,
 } from "../package-change-overlay";
 import { scopeDocListPrefix } from "../scope-docs";
 import { repoPathPrefix } from "../repo-paths";
@@ -190,6 +191,7 @@ const props = withDefaults(
     subdomain: string;
     commitHash: string;
     compareFromHash?: string;
+    pathRenames?: PathRename[];
     packageName: string;
     packageDirectory: string;
     productRoot?: string;
@@ -227,6 +229,7 @@ const {
   {
     compareFromHash: () => props.compareFromHash,
     productRoot: () => props.productRoot,
+    pathRenames: () => props.pathRenames,
   },
 );
 
@@ -289,7 +292,7 @@ const fileNav = computed(() => {
     ),
   );
   if (!overlay.value) return nav;
-  return filterFileNav(nav, overlay.value.modules);
+  return filterFileNav(nav, overlay.value.modules, overlay.value.movedFrom);
 });
 
 /** Prefer `requests/` when landing with no selection. */

--- a/dev-site/dev-site-vue/components/PackageSdkPane.vue
+++ b/dev-site/dev-site-vue/components/PackageSdkPane.vue
@@ -76,7 +76,13 @@
               <li
                 v-for="op in scopedRoutes"
                 :key="op.operationId + op.method + op.path"
+                :class="{
+                  'routes-block__item--added': op.change === 'added',
+                  'routes-block__item--removed': op.change === 'removed',
+                  'routes-block__item--modified': op.change === 'modified',
+                }"
               >
+                <ChangeChip :change="op.change" />
                 <PackageRouteCard
                   :operation="normalizeOp(op)"
                   :route-repo-path="routeRepoPath(op.yamlPath)"
@@ -112,7 +118,8 @@
 
 <script setup lang="ts">
 import { computed, watch } from "vue";
-import { useCommitPackage, useScopeSummary } from "../requests/queries";
+import { useScopeSummary } from "../requests/queries";
+import { useComparedPackageDetail } from "../package-compare";
 import {
   buildModuleFileNav,
   buildPackageSpecTree,
@@ -122,6 +129,16 @@ import {
   type TestFileNavNode,
   type TestScope,
 } from "../test-tree";
+import {
+  exportIdentityKey,
+  filterFileNav,
+  pickChangedItems,
+  pruneEmptySpecTree,
+  specOperationKey,
+  tagSpecTree,
+  testIdentityKey,
+  unionByKey,
+} from "../package-change-overlay";
 import { scopeDocListPrefix } from "../scope-docs";
 import { repoPathPrefix } from "../repo-paths";
 import { openSource } from "../source-links";
@@ -131,6 +148,7 @@ import PackageRouteCard, {
   type RouteCardOperation,
 } from "./PackageRouteCard.vue";
 import ResizableColumns from "./ResizableColumns.vue";
+import ChangeChip from "./ChangeChip.vue";
 
 interface SpecFileRef {
   filePath: string;
@@ -164,12 +182,14 @@ interface SpecOperation {
   usedBy: SpecUsedBy[];
   enqueues?: string[];
   enqueuedBy?: string[];
+  change?: "added" | "removed" | "modified";
 }
 
 const props = withDefaults(
   defineProps<{
     subdomain: string;
     commitHash: string;
+    compareFromHash?: string;
     packageName: string;
     packageDirectory: string;
     productRoot?: string;
@@ -193,39 +213,83 @@ const setScope = (next: TestScope) => {
   emit("update:scope", next);
 };
 
-const { data, isLoading, error } = useCommitPackage(
+const {
+  isLoading,
+  error,
+  overlay,
+  detail,
+  beforeDetail,
+  afterDetail,
+} = useComparedPackageDetail(
   props.subdomain,
   () => props.commitHash,
   () => props.packageName,
+  {
+    compareFromHash: () => props.compareFromHash,
+    productRoot: () => props.productRoot,
+  },
 );
-
-const detail = computed(() => data.value?.packageDetail);
 
 const pkgPrefix = computed(() =>
   repoPathPrefix(props.productRoot, props.packageDirectory),
 );
 
 const specPkgPrefix = computed(() => {
-  const dir = detail.value?.specInventory?.packageDirectory as
-    | string
-    | undefined;
+  const dir = (
+    afterDetail.value?.specInventory ??
+    beforeDetail.value?.specInventory ??
+    detail.value?.specInventory
+  )?.packageDirectory as string | undefined;
   if (!dir) return "";
   return repoPathPrefix(props.productRoot, dir);
 });
 
+const allExports = computed(() =>
+  unionByKey(
+    beforeDetail.value?.exports ?? [],
+    afterDetail.value?.exports ?? detail.value?.exports ?? [],
+    exportIdentityKey,
+  ),
+);
+const allTests = computed(() =>
+  unionByKey(
+    beforeDetail.value?.testCases ?? [],
+    afterDetail.value?.testCases ?? detail.value?.testCases ?? [],
+    testIdentityKey,
+  ),
+);
+const specExports = computed(() => {
+  if (!overlay.value) return allExports.value;
+  return pickChangedItems(
+    beforeDetail.value?.exports ?? [],
+    afterDetail.value?.exports ?? [],
+    exportIdentityKey,
+    overlay.value.exports,
+  );
+});
+const specTests = computed(() => {
+  if (!overlay.value) return allTests.value;
+  return pickChangedItems(
+    beforeDetail.value?.testCases ?? [],
+    afterDetail.value?.testCases ?? [],
+    testIdentityKey,
+    overlay.value.tests,
+  );
+});
+
 const fileNav = computed(() => {
-  const d = detail.value;
-  if (!d) return [];
-  return pruneEmptyIndexModules(
+  const nav = pruneEmptyIndexModules(
     buildModuleFileNav(
-      d.exports ?? [],
-      d.testCases,
-      d.packageName,
+      allExports.value,
+      allTests.value,
+      props.packageName,
       props.packageDirectory,
       props.productRoot ?? "",
       { excludeStem: isSdkPackageHiddenModuleStem },
     ),
   );
+  if (!overlay.value) return nav;
+  return filterFileNav(nav, overlay.value.modules);
 });
 
 /** Prefer `requests/` when landing with no selection. */
@@ -276,10 +340,18 @@ const scopeDocPrefix = computed(() =>
   }),
 );
 
+const scopeDocRef = computed(() => {
+  if (!overlay.value || scope.value.kind !== "file") return props.commitHash;
+  const stem = toModuleStem(scope.value.localPath);
+  return overlay.value.modules[stem] === "removed"
+    ? (props.compareFromHash ?? props.commitHash)
+    : props.commitHash;
+});
+
 const { summary: scopeSummary, isLoading: scopeDocLoading } = useScopeSummary(
   props.subdomain,
   () => ({
-    ref: props.commitHash,
+    ref: scopeDocRef.value,
     prefix: scopeDocPrefix.value,
   }),
 );
@@ -303,28 +375,39 @@ const scopePresenceLabel = computed(() => {
 });
 
 const specTree = computed(() => {
-  const d = detail.value;
-  if (!d) return [];
-  return buildPackageSpecTree(
-    d.exports ?? [],
-    d.testCases,
-    d.packageName,
+  const tree = buildPackageSpecTree(
+    specExports.value,
+    specTests.value,
+    props.packageName,
     props.packageDirectory,
     props.productRoot ?? "",
     scope.value,
     { excludeStem: isSdkPackageHiddenModuleStem },
   );
+  if (!overlay.value) return tree;
+  return pruneEmptySpecTree(tagSpecTree(tree, overlay.value));
 });
 
 const allOperations = computed((): SpecOperation[] => {
-  const entities = detail.value?.specInventory?.entities ?? [];
-  const ops: SpecOperation[] = [];
-  for (const e of entities) {
-    for (const op of e.operations ?? []) {
-      ops.push(op as SpecOperation);
-    }
+  const beforeOps: SpecOperation[] = [];
+  const afterOps: SpecOperation[] = [];
+  for (const e of beforeDetail.value?.specInventory?.entities ?? []) {
+    for (const op of e.operations ?? []) beforeOps.push(op as SpecOperation);
   }
-  return ops.sort((a, b) => {
+  for (const e of afterDetail.value?.specInventory?.entities ??
+    detail.value?.specInventory?.entities ??
+    []) {
+    for (const op of e.operations ?? []) afterOps.push(op as SpecOperation);
+  }
+  const merged = overlay.value
+    ? pickChangedItems(
+        beforeOps,
+        afterOps,
+        specOperationKey,
+        overlay.value.specOperations,
+      )
+    : unionByKey(beforeOps, afterOps, specOperationKey);
+  return merged.sort((a, b) => {
     const ra = a.request?.filePath ?? a.routeStem ?? a.path;
     const rb = b.request?.filePath ?? b.routeStem ?? b.path;
     return (
@@ -504,5 +587,21 @@ function openFile(path: string) {
   padding: 0;
   display: grid;
   gap: 0.65rem;
+}
+.routes-block__item--added,
+.routes-block__item--removed,
+.routes-block__item--modified {
+  display: grid;
+  gap: 0.35rem;
+  padding-left: 0.5rem;
+}
+.routes-block__item--added {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-success));
+}
+.routes-block__item--removed {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-error));
+}
+.routes-block__item--modified {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-warning));
 }
 </style>

--- a/dev-site/dev-site-vue/components/PackageSpecPane.vue
+++ b/dev-site/dev-site-vue/components/PackageSpecPane.vue
@@ -239,6 +239,7 @@ import {
   tagSpecTree,
   testIdentityKey,
   unionByKey,
+  type PathRename,
 } from "../package-change-overlay";
 import { scopeDocListPrefix } from "../scope-docs";
 import { repoPathPrefix } from "../repo-paths";
@@ -257,6 +258,7 @@ const props = withDefaults(
     commitHash: string;
     /** Merge-base commit when Checkout compare mode is on. */
     compareFromHash?: string;
+    pathRenames?: PathRename[];
     packageName: string;
     packageDirectory: string;
     productRoot?: string;
@@ -296,6 +298,7 @@ const {
   {
     compareFromHash: () => props.compareFromHash,
     productRoot: () => props.productRoot,
+    pathRenames: () => props.pathRenames,
   },
 );
 
@@ -350,7 +353,7 @@ const fileNav = computed(() => {
     { vueBundles: vueBundles.value },
   );
   if (!overlay.value) return nav;
-  return filterFileNav(nav, overlay.value.modules);
+  return filterFileNav(nav, overlay.value.modules, overlay.value.movedFrom);
 });
 
 const selectedModule = computed(() => {

--- a/dev-site/dev-site-vue/components/PackageSpecPane.vue
+++ b/dev-site/dev-site-vue/components/PackageSpecPane.vue
@@ -96,9 +96,18 @@
               <h5 class="surface-block__subtitle">Models</h5>
               <table class="surface-table">
                 <tbody>
-                  <tr v-for="m in vueModels" :key="'model-' + m.name">
+                  <tr
+                    v-for="m in vueModels"
+                    :key="'model-' + m.name"
+                    :class="{
+                      'surface-table__row--added': m.change === 'added',
+                      'surface-table__row--removed': m.change === 'removed',
+                      'surface-table__row--modified': m.change === 'modified',
+                    }"
+                  >
                     <th>{{ m.name }}</th>
                     <td>
+                      <ChangeChip :change="m.change" />
                       <code v-if="m.signature">{{ m.signature }}</code>
                       <span v-if="m.docstring" class="surface-table__doc">{{
                         m.docstring
@@ -112,9 +121,18 @@
               <h5 class="surface-block__subtitle">Props</h5>
               <table class="surface-table">
                 <tbody>
-                  <tr v-for="p in vueProps" :key="'prop-' + p.name">
+                  <tr
+                    v-for="p in vueProps"
+                    :key="'prop-' + p.name"
+                    :class="{
+                      'surface-table__row--added': p.change === 'added',
+                      'surface-table__row--removed': p.change === 'removed',
+                      'surface-table__row--modified': p.change === 'modified',
+                    }"
+                  >
                     <th>{{ p.name }}</th>
                     <td>
+                      <ChangeChip :change="p.change" />
                       <code v-if="p.signature">{{ p.signature }}</code>
                       <span v-if="p.docstring" class="surface-table__doc">{{
                         p.docstring
@@ -128,9 +146,18 @@
               <h5 class="surface-block__subtitle">Emits</h5>
               <table class="surface-table">
                 <tbody>
-                  <tr v-for="e in vueEmits" :key="'emit-' + e.name">
+                  <tr
+                    v-for="e in vueEmits"
+                    :key="'emit-' + e.name"
+                    :class="{
+                      'surface-table__row--added': e.change === 'added',
+                      'surface-table__row--removed': e.change === 'removed',
+                      'surface-table__row--modified': e.change === 'modified',
+                    }"
+                  >
                     <th>{{ e.name }}</th>
                     <td>
+                      <ChangeChip :change="e.change" />
                       <code v-if="e.signature">{{ e.signature }}</code>
                       <span v-if="e.docstring" class="surface-table__doc">{{
                         e.docstring
@@ -151,7 +178,13 @@
               <li
                 v-for="op in scopedRoutes"
                 :key="op.operationId + op.method + op.path"
+                :class="{
+                  'routes-block__item--added': op.change === 'added',
+                  'routes-block__item--removed': op.change === 'removed',
+                  'routes-block__item--modified': op.change === 'modified',
+                }"
               >
+                <ChangeChip :change="op.change" />
                 <PackageRouteCard
                   :operation="normalizeOp(op)"
                   :route-repo-path="routeRepoPath(op.yamlPath)"
@@ -185,7 +218,8 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { useCommitPackage, useScopeSummary } from "../requests/queries";
+import { useScopeSummary } from "../requests/queries";
+import { useComparedPackageDetail } from "../package-compare";
 import {
   buildModuleFileNav,
   buildPackageSpecTree,
@@ -196,6 +230,16 @@ import {
   toVueBundleStem,
   type TestScope,
 } from "../test-tree";
+import {
+  exportIdentityKey,
+  filterFileNav,
+  pickChangedItems,
+  pruneEmptySpecTree,
+  specOperationKey,
+  tagSpecTree,
+  testIdentityKey,
+  unionByKey,
+} from "../package-change-overlay";
 import { scopeDocListPrefix } from "../scope-docs";
 import { repoPathPrefix } from "../repo-paths";
 import { openSource } from "../source-links";
@@ -205,11 +249,14 @@ import PackageRouteCard, {
   type RouteCardOperation,
 } from "./PackageRouteCard.vue";
 import ResizableColumns from "./ResizableColumns.vue";
+import ChangeChip from "./ChangeChip.vue";
 
 const props = withDefaults(
   defineProps<{
     subdomain: string;
     commitHash: string;
+    /** Merge-base commit when Checkout compare mode is on. */
+    compareFromHash?: string;
     packageName: string;
     packageDirectory: string;
     productRoot?: string;
@@ -235,35 +282,75 @@ const setScope = (next: TestScope) => {
   emit("update:scope", next);
 };
 
-const { data, isLoading, error } = useCommitPackage(
+const {
+  isLoading,
+  error,
+  overlay,
+  detail,
+  beforeDetail,
+  afterDetail,
+} = useComparedPackageDetail(
   props.subdomain,
   () => props.commitHash,
   () => props.packageName,
+  {
+    compareFromHash: () => props.compareFromHash,
+    productRoot: () => props.productRoot,
+  },
 );
-
-const detail = computed(() => data.value?.packageDetail);
 
 const pkgPrefix = computed(() =>
   repoPathPrefix(props.productRoot, props.packageDirectory),
 );
 
-const vueBundles = computed(() => {
-  const d = detail.value;
-  if (!d) return false;
-  return packageHasVueFiles(d.exports ?? [], d.testCases, d.packageName);
+const allExports = computed(() =>
+  unionByKey(
+    beforeDetail.value?.exports ?? [],
+    afterDetail.value?.exports ?? detail.value?.exports ?? [],
+    exportIdentityKey,
+  ),
+);
+const allTests = computed(() =>
+  unionByKey(
+    beforeDetail.value?.testCases ?? [],
+    afterDetail.value?.testCases ?? detail.value?.testCases ?? [],
+    testIdentityKey,
+  ),
+);
+const specExports = computed(() => {
+  if (!overlay.value) return allExports.value;
+  return pickChangedItems(
+    beforeDetail.value?.exports ?? [],
+    afterDetail.value?.exports ?? [],
+    exportIdentityKey,
+    overlay.value.exports,
+  );
+});
+const specTests = computed(() => {
+  if (!overlay.value) return allTests.value;
+  return pickChangedItems(
+    beforeDetail.value?.testCases ?? [],
+    afterDetail.value?.testCases ?? [],
+    testIdentityKey,
+    overlay.value.tests,
+  );
 });
 
+const vueBundles = computed(() =>
+  packageHasVueFiles(allExports.value, allTests.value, props.packageName),
+);
+
 const fileNav = computed(() => {
-  const d = detail.value;
-  if (!d) return [];
-  return buildModuleFileNav(
-    d.exports ?? [],
-    d.testCases,
-    d.packageName,
+  const nav = buildModuleFileNav(
+    allExports.value,
+    allTests.value,
+    props.packageName,
     props.packageDirectory,
     props.productRoot ?? "",
     { vueBundles: vueBundles.value },
   );
+  if (!overlay.value) return nav;
+  return filterFileNav(nav, overlay.value.modules);
 });
 
 const selectedModule = computed(() => {
@@ -289,10 +376,20 @@ const scopeDocPrefix = computed(() =>
   }),
 );
 
+const scopeDocRef = computed(() => {
+  if (!overlay.value || scope.value.kind !== "file") return props.commitHash;
+  const stem = vueBundles.value
+    ? toVueBundleStem(scope.value.localPath)
+    : toModuleStem(scope.value.localPath);
+  return overlay.value.modules[stem] === "removed"
+    ? (props.compareFromHash ?? props.commitHash)
+    : props.commitHash;
+});
+
 const { summary: scopeSummary, isLoading: scopeDocLoading } = useScopeSummary(
   props.subdomain,
   () => ({
-    ref: props.commitHash,
+    ref: scopeDocRef.value,
     prefix: scopeDocPrefix.value,
   }),
 );
@@ -319,26 +416,25 @@ const scopePresenceLabel = computed(() => {
 });
 
 const specTree = computed(() => {
-  const d = detail.value;
-  if (!d) return [];
-  return buildPackageSpecTree(
-    d.exports ?? [],
-    d.testCases,
-    d.packageName,
+  const tree = buildPackageSpecTree(
+    specExports.value,
+    specTests.value,
+    props.packageName,
     props.packageDirectory,
     props.productRoot ?? "",
     scope.value,
     { vueBundles: vueBundles.value },
   );
+  if (!overlay.value) return tree;
+  return pruneEmptySpecTree(tagSpecTree(tree, overlay.value));
 });
 
 const bundleExports = computed(() => {
-  const d = detail.value;
-  if (!d || !vueBundles.value || scope.value.kind === "all") return [];
+  if (!vueBundles.value || scope.value.kind === "all") return [];
   const s = scope.value;
   const wanted =
     s.kind === "file" ? toVueBundleStem(s.localPath) : s.localPath.replace(/\/+$/, "");
-  return (d.exports ?? []).filter((e) => {
+  return specExports.value.filter((e) => {
     const local = packageLocalPath(
       e.filePath,
       props.packageDirectory,
@@ -409,25 +505,39 @@ interface SpecOperation {
   usedBy: SpecUsedBy[];
   enqueues?: string[];
   enqueuedBy?: string[];
+  change?: "added" | "removed" | "modified";
 }
 
 const specPkgPrefix = computed(() => {
-  const dir = detail.value?.specInventory?.packageDirectory as
-    | string
-    | undefined;
+  const dir = (
+    afterDetail.value?.specInventory ??
+    beforeDetail.value?.specInventory ??
+    detail.value?.specInventory
+  )?.packageDirectory as string | undefined;
   if (!dir) return "";
   return repoPathPrefix(props.productRoot, dir);
 });
 
 const allOperations = computed((): SpecOperation[] => {
-  const entities = detail.value?.specInventory?.entities ?? [];
-  const ops: SpecOperation[] = [];
-  for (const e of entities) {
-    for (const op of e.operations ?? []) {
-      ops.push(op as SpecOperation);
-    }
+  const beforeOps: SpecOperation[] = [];
+  const afterOps: SpecOperation[] = [];
+  for (const e of beforeDetail.value?.specInventory?.entities ?? []) {
+    for (const op of e.operations ?? []) beforeOps.push(op as SpecOperation);
   }
-  return ops;
+  for (const e of afterDetail.value?.specInventory?.entities ??
+    detail.value?.specInventory?.entities ??
+    []) {
+    for (const op of e.operations ?? []) afterOps.push(op as SpecOperation);
+  }
+  if (!overlay.value) {
+    return unionByKey(beforeOps, afterOps, specOperationKey);
+  }
+  return pickChangedItems(
+    beforeOps,
+    afterOps,
+    specOperationKey,
+    overlay.value.specOperations,
+  );
 });
 
 const scopedRoutes = computed(() => {
@@ -670,5 +780,32 @@ const openFile = (path: string) => {
   margin-top: 0.15rem;
   font-size: 0.75rem;
   color: rgba(var(--v-theme-on-surface), 0.55);
+}
+.surface-table__row--added th {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-success));
+}
+.surface-table__row--removed th {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-error));
+}
+.surface-table__row--modified th {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-warning));
+}
+.routes-block__item--added,
+.routes-block__item--removed,
+.routes-block__item--modified {
+  display: grid;
+  gap: 0.35rem;
+}
+.routes-block__item--added {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-success));
+  padding-left: 0.5rem;
+}
+.routes-block__item--removed {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-error));
+  padding-left: 0.5rem;
+}
+.routes-block__item--modified {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-warning));
+  padding-left: 0.5rem;
 }
 </style>

--- a/dev-site/dev-site-vue/components/PackageSpecRoutesPane.vue
+++ b/dev-site/dev-site-vue/components/PackageSpecRoutesPane.vue
@@ -217,6 +217,7 @@ import {
   specOperationKey,
   specPropertyKey,
   unionByKey,
+  type PathRename,
 } from "../package-change-overlay.ts";
 
 type SpecPresence = "object" | "routes" | "both";
@@ -281,6 +282,7 @@ const props = defineProps<{
   subdomain: string;
   commitHash: string;
   compareFromHash?: string;
+  pathRenames?: PathRename[];
   packageName: string;
   packageDirectory: string;
   productRoot: string;
@@ -305,6 +307,7 @@ const {
   {
     compareFromHash: () => props.compareFromHash,
     productRoot: () => props.productRoot,
+    pathRenames: () => props.pathRenames,
   },
 );
 

--- a/dev-site/dev-site-vue/components/PackageSpecRoutesPane.vue
+++ b/dev-site/dev-site-vue/components/PackageSpecRoutesPane.vue
@@ -30,11 +30,20 @@
             <span>All</span>
           </button>
           <ul class="entity-nav">
-            <li v-for="e in entities" :key="e.key" class="entity-nav__item">
+            <li
+              v-for="e in entities"
+              :key="e.key"
+              class="entity-nav__item"
+            >
               <button
                 type="button"
                 class="entity-nav__row"
-                :class="{ 'entity-nav__row--selected': selectedKey === e.key }"
+                :class="{
+                  'entity-nav__row--selected': selectedKey === e.key,
+                  'entity-nav__row--added': e.change === 'added',
+                  'entity-nav__row--removed': e.change === 'removed',
+                  'entity-nav__row--modified': e.change === 'modified',
+                }"
                 :title="presenceTitle(e.presence)"
                 @click="selectedKey = e.key"
               >
@@ -44,6 +53,7 @@
                   class="entity-nav__icon"
                 />
                 <span class="entity-nav__label">{{ e.label }}</span>
+                <ChangeChip :change="e.change" />
               </button>
             </li>
           </ul>
@@ -58,6 +68,7 @@
         >
           <h3 class="entity-block__title">
             {{ e.label }}
+            <ChangeChip :change="e.change" />
             <span class="entity-block__presence">{{ presenceTitle(e.presence) }}</span>
           </h3>
 
@@ -121,10 +132,16 @@
                 v-for="c in e.schema.properties"
                 :key="c.name"
                 class="table-card__col"
+                :class="{
+                  'table-card__col--added': c.change === 'added',
+                  'table-card__col--removed': c.change === 'removed',
+                  'table-card__col--modified': c.change === 'modified',
+                }"
               >
                 <div class="table-card__col-main">
                   <code>{{ c.name }}</code>
                   <span class="text-medium-emphasis">{{ c.typeKind }}</span>
+                  <ChangeChip :change="c.change" />
                 </div>
                 <p v-if="c.docstring" class="table-card__col-doc">
                   {{ c.docstring }}
@@ -158,7 +175,13 @@
             <li
               v-for="op in e.operations"
               :key="op.operationId + op.method + op.path"
+              :class="{
+                'op-list__item--added': op.change === 'added',
+                'op-list__item--removed': op.change === 'removed',
+                'op-list__item--modified': op.change === 'modified',
+              }"
             >
+              <ChangeChip :change="op.change" />
               <PackageRouteCard
                 :operation="normalizeOp(op)"
                 :route-repo-path="repoPath(op.yamlPath)"
@@ -185,9 +208,16 @@ import PackageRouteCard, {
   type RouteCardOperation,
 } from "./PackageRouteCard.vue";
 import ResizableColumns from "./ResizableColumns.vue";
-import { useCommitPackage } from "../requests/queries.ts";
+import ChangeChip from "./ChangeChip.vue";
+import { useComparedPackageDetail } from "../package-compare.ts";
 import { openSource } from "../source-links.ts";
 import { repoPathPrefix } from "../repo-paths.ts";
+import {
+  pickChangedItems,
+  specOperationKey,
+  specPropertyKey,
+  unionByKey,
+} from "../package-change-overlay.ts";
 
 type SpecPresence = "object" | "routes" | "both";
 
@@ -219,6 +249,7 @@ interface SpecEntity {
       name: string;
       typeKind: string;
       docstring?: string | null;
+      change?: "added" | "removed" | "modified";
     }>;
     usedBy: SpecUsedBy[];
     referencedByOperations: string[];
@@ -241,12 +272,15 @@ interface SpecEntity {
     usedBy: SpecUsedBy[];
     enqueues?: string[];
     enqueuedBy?: string[];
+    change?: "added" | "removed" | "modified";
   }>;
+  change?: "added" | "removed" | "modified";
 }
 
 const props = defineProps<{
   subdomain: string;
   commitHash: string;
+  compareFromHash?: string;
   packageName: string;
   packageDirectory: string;
   productRoot: string;
@@ -257,16 +291,70 @@ const props = defineProps<{
 
 const selectedKey = ref<string | null>(null);
 
-const { data, isLoading, error } = useCommitPackage(
+const {
+  isLoading,
+  error,
+  overlay,
+  detail,
+  beforeDetail,
+  afterDetail,
+} = useComparedPackageDetail(
   props.subdomain,
   () => props.commitHash,
   () => props.packageName,
+  {
+    compareFromHash: () => props.compareFromHash,
+    productRoot: () => props.productRoot,
+  },
 );
 
-const detail = computed(() => data.value?.packageDetail);
-const entities = computed(
-  () => (detail.value?.specInventory?.entities ?? []) as SpecEntity[],
-);
+const rawEntities = computed(() => {
+  const before = (beforeDetail.value?.specInventory?.entities ??
+    []) as SpecEntity[];
+  const after = (afterDetail.value?.specInventory?.entities ??
+    detail.value?.specInventory?.entities ??
+    []) as SpecEntity[];
+  return { before, after };
+});
+
+const entities = computed(() => {
+  const { before, after } = rawEntities.value;
+  if (!overlay.value) return unionByKey(before, after, (e) => e.key);
+  return pickChangedItems(
+    before,
+    after,
+    (e) => e.key,
+    overlay.value.specEntities,
+  ).map((entity) => {
+    const b = before.find((e) => e.key === entity.key);
+    const a = after.find((e) => e.key === entity.key);
+    const beforeProps = b?.schema?.properties ?? [];
+    const afterProps = a?.schema?.properties ?? [];
+    const properties = overlay.value
+      ? pickChangedItems(
+          beforeProps,
+          afterProps,
+          (p) => specPropertyKey(entity.key, p.name),
+          overlay.value.specProperties,
+        )
+      : afterProps;
+    const operations = overlay.value
+      ? pickChangedItems(
+          b?.operations ?? [],
+          a?.operations ?? [],
+          specOperationKey,
+          overlay.value.specOperations,
+        )
+      : entity.operations;
+    return {
+      ...entity,
+      schema: entity.schema
+        ? { ...entity.schema, properties }
+        : entity.schema,
+      operations,
+    };
+  });
+});
 
 const visibleEntities = computed(() => {
   if (selectedKey.value == null) return entities.value;
@@ -394,6 +482,15 @@ function openFile(path: string) {
 .entity-nav__row--selected {
   background: rgba(var(--v-theme-primary), 0.12);
 }
+.entity-nav__row--added {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-success));
+}
+.entity-nav__row--removed {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-error));
+}
+.entity-nav__row--modified {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-warning));
+}
 .entity-nav__label {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
   font-size: 0.75rem;
@@ -492,6 +589,18 @@ function openFile(path: string) {
   font-size: 0.8125rem;
   color: rgba(var(--v-theme-on-surface), 0.65);
 }
+.table-card__col--added {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-success));
+  padding-left: 0.5rem;
+}
+.table-card__col--removed {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-error));
+  padding-left: 0.5rem;
+}
+.table-card__col--modified {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-warning));
+  padding-left: 0.5rem;
+}
 .resource-hint {
   font-size: 0.8125rem;
   color: rgba(var(--v-theme-on-surface), 0.6);
@@ -503,5 +612,21 @@ function openFile(path: string) {
   padding: 0;
   display: grid;
   gap: 0.65rem;
+}
+.op-list__item--added,
+.op-list__item--removed,
+.op-list__item--modified {
+  display: grid;
+  gap: 0.35rem;
+  padding-left: 0.5rem;
+}
+.op-list__item--added {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-success));
+}
+.op-list__item--removed {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-error));
+}
+.op-list__item--modified {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-warning));
 }
 </style>

--- a/dev-site/dev-site-vue/components/TestFileNav.vue
+++ b/dev-site/dev-site-vue/components/TestFileNav.vue
@@ -27,6 +27,7 @@
             'file-nav__row--added': node.change === 'added',
             'file-nav__row--removed': node.change === 'removed',
             'file-nav__row--modified': node.change === 'modified',
+            'file-nav__row--moved': node.change === 'moved',
           }"
           @click="$emit('select', { kind: node.kind, localPath: node.localPath })"
         >
@@ -172,20 +173,21 @@ const navIcon = (node: TestFileNavNode): string => {
 };
 
 const navTitle = (node: TestFileNavNode): string => {
-  if (node.kind === "dir") return "Directory";
-  if (node.hasVueComponent) {
-    return node.loadableAsync
+  let title = "Source only";
+  if (node.kind === "dir") title = "Directory";
+  else if (node.hasVueComponent) {
+    title = node.loadableAsync
       ? "Vue component (async)"
       : "Vue component";
-  }
-  if (node.presence === "test") return "Test only";
-  if (!node.hasCardExports) {
-    return node.presence === "both"
-      ? "Types/constants + colocated test"
-      : "Source only (no functions)";
-  }
-  if (node.presence === "both") return "Source + colocated test";
-  return "Source only";
+  } else if (node.presence === "test") title = "Test only";
+  else if (!node.hasCardExports) {
+    title =
+      node.presence === "both"
+        ? "Types/constants + colocated test"
+        : "Source only (no functions)";
+  } else if (node.presence === "both") title = "Source + colocated test";
+  if (node.movedFrom) return `Moved from ${node.movedFrom} · ${title}`;
+  return title;
 };
 </script>
 
@@ -257,6 +259,9 @@ const navTitle = (node: TestFileNavNode): string => {
 }
 .file-nav__row--modified {
   box-shadow: inset 3px 0 0 rgb(var(--v-theme-warning));
+}
+.file-nav__row--moved {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-info));
 }
 .file-nav__label {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;

--- a/dev-site/dev-site-vue/components/TestFileNav.vue
+++ b/dev-site/dev-site-vue/components/TestFileNav.vue
@@ -24,6 +24,9 @@
           class="file-nav__row"
           :class="{
             'file-nav__row--selected': isSelected(node),
+            'file-nav__row--added': node.change === 'added',
+            'file-nav__row--removed': node.change === 'removed',
+            'file-nav__row--modified': node.change === 'modified',
           }"
           @click="$emit('select', { kind: node.kind, localPath: node.localPath })"
         >
@@ -34,6 +37,7 @@
             :title="navTitle(node)"
           />
           <span class="file-nav__label">{{ node.label }}</span>
+          <ChangeChip :change="node.change" />
         </button>
       </div>
       <TestFileNav
@@ -55,6 +59,7 @@ import {
   type TestFileNavNode,
   type TestScope,
 } from "../test-tree";
+import ChangeChip from "./ChangeChip.vue";
 
 const COLLAPSE_KEY = Symbol("test-file-nav-collapse");
 
@@ -243,6 +248,15 @@ const navTitle = (node: TestFileNavNode): string => {
 }
 .file-nav__row--selected {
   background: rgba(var(--v-theme-primary), 0.12);
+}
+.file-nav__row--added {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-success));
+}
+.file-nav__row--removed {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-error));
+}
+.file-nav__row--modified {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-warning));
 }
 .file-nav__label {
   font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;

--- a/dev-site/dev-site-vue/components/TestTree.vue
+++ b/dev-site/dev-site-vue/components/TestTree.vue
@@ -1,7 +1,15 @@
 <template>
   <ul class="test-tree" :class="{ 'test-tree--root': depth === 0 }">
     <li v-for="node in nodes" :key="node.id" class="test-tree__item">
-      <article v-if="node.kind === 'suite'" class="suite-card">
+      <article
+        v-if="node.kind === 'suite'"
+        class="suite-card"
+        :class="{
+          'suite-card--added': node.change === 'added',
+          'suite-card--removed': node.change === 'removed',
+          'suite-card--modified': node.change === 'modified',
+        }"
+      >
         <header class="suite-card__head">
           <a
             v-if="node.subjectFilePath"
@@ -12,6 +20,7 @@
             {{ node.label }}
           </a>
           <span v-else class="suite-card__name">{{ node.label }}</span>
+          <ChangeChip :change="node.change" />
           <span
             v-if="isUnusedExport(node)"
             class="suite-card__unused"
@@ -52,13 +61,19 @@
 
         <div class="suite-card__tests">
           <ul v-if="testLeaves(node).length" class="suite-card__cases">
-            <li
-              v-for="t in testLeaves(node)"
-              :key="t.id"
-              class="suite-card__case"
-            >
-              {{ t.label }}
-            </li>
+              <li
+                v-for="t in testLeaves(node)"
+                :key="t.id"
+                class="suite-card__case"
+                :class="{
+                  'suite-card__case--added': t.change === 'added',
+                  'suite-card__case--removed': t.change === 'removed',
+                  'suite-card__case--modified': t.change === 'modified',
+                }"
+              >
+                {{ t.label }}
+                <ChangeChip :change="t.change" />
+              </li>
           </ul>
           <TestTree
             v-if="nestedSuites(node).length"
@@ -108,6 +123,7 @@
 
 <script setup lang="ts">
 import type { TestTreeNode } from "../test-tree";
+import ChangeChip from "./ChangeChip.vue";
 
 withDefaults(
   defineProps<{
@@ -189,13 +205,14 @@ const isUnusedExport = (node: TestTreeNode) =>
   padding-left: 0.5rem;
 }
 
-.suite-card {
-  border: 1px solid rgba(var(--v-theme-on-surface), 0.14);
-  border-radius: 8px;
-  background: rgba(var(--v-theme-surface), 1);
-  overflow: hidden;
-  max-width: 44rem;
-  margin-bottom: 0.65rem;
+.suite-card--added {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-success));
+}
+.suite-card--removed {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-error));
+}
+.suite-card--modified {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-warning));
 }
 .suite-card__head {
   display: flex;
@@ -279,10 +296,22 @@ const isUnusedExport = (node: TestTreeNode) =>
 }
 .suite-card__case {
   position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
   padding: 0.28rem 0 0.28rem 0.9rem;
   font-size: 0.875rem;
   line-height: 1.35;
   border-bottom: 1px solid rgba(var(--v-theme-on-surface), 0.06);
+}
+.suite-card__case--added {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-success));
+}
+.suite-card__case--removed {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-error));
+}
+.suite-card__case--modified {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-warning));
 }
 .suite-card__case:last-child {
   border-bottom: 0;

--- a/dev-site/dev-site-vue/components/TestTree.vue
+++ b/dev-site/dev-site-vue/components/TestTree.vue
@@ -8,6 +8,7 @@
           'suite-card--added': node.change === 'added',
           'suite-card--removed': node.change === 'removed',
           'suite-card--modified': node.change === 'modified',
+          'suite-card--moved': node.change === 'moved',
         }"
       >
         <header class="suite-card__head">
@@ -69,6 +70,7 @@
                   'suite-card__case--added': t.change === 'added',
                   'suite-card__case--removed': t.change === 'removed',
                   'suite-card__case--modified': t.change === 'modified',
+                  'suite-card__case--moved': t.change === 'moved',
                 }"
               >
                 {{ t.label }}
@@ -214,6 +216,9 @@ const isUnusedExport = (node: TestTreeNode) =>
 .suite-card--modified {
   box-shadow: inset 3px 0 0 rgb(var(--v-theme-warning));
 }
+.suite-card--moved {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-info));
+}
 .suite-card__head {
   display: flex;
   align-items: center;
@@ -312,6 +317,9 @@ const isUnusedExport = (node: TestTreeNode) =>
 }
 .suite-card__case--modified {
   box-shadow: inset 3px 0 0 rgb(var(--v-theme-warning));
+}
+.suite-card__case--moved {
+  box-shadow: inset 3px 0 0 rgb(var(--v-theme-info));
 }
 .suite-card__case:last-child {
   border-bottom: 0;

--- a/dev-site/dev-site-vue/format-loc.test.ts
+++ b/dev-site/dev-site-vue/format-loc.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { formatLoc, formatLocPair } from "./format-loc.ts";
+import { formatLoc, formatLocChangePair, formatLocPair, formatLocSigned } from "./format-loc.ts";
 
 describe("formatLoc", () => {
   it("keeps values under 1000 exact", () => {
@@ -22,5 +22,15 @@ describe("formatLocPair", () => {
     expect(formatLocPair(432, 80)).toBe("432/80");
     expect(formatLocPair(32_000, 4_200)).toBe("32k/4k");
     expect(formatLocPair(12_000, 400)).toBe("12k/400");
+  });
+});
+
+describe("formatLocChangePair", () => {
+  it("signs source and test deltas independently", () => {
+    expect(formatLocSigned(12)).toBe("+12");
+    expect(formatLocSigned(-4)).toBe("−4");
+    expect(formatLocSigned(0)).toBe("0");
+    expect(formatLocChangePair(10, 5)).toBe("+10/+5");
+    expect(formatLocChangePair(-8, 0)).toBe("−8/0");
   });
 });

--- a/dev-site/dev-site-vue/format-loc.ts
+++ b/dev-site/dev-site-vue/format-loc.ts
@@ -12,3 +12,15 @@ export function formatLoc(n: number): string {
 export function formatLocPair(sourceLines: number, testLines: number): string {
   return `${formatLoc(sourceLines)}/${formatLoc(testLines)}`;
 }
+
+/** Signed delta for compare mode (`+12`, `−4`, `0`). */
+export function formatLocSigned(delta: number): string {
+  if (delta === 0) return "0";
+  const mag = formatLoc(Math.abs(delta));
+  return delta > 0 ? `+${mag}` : `−${mag}`;
+}
+
+/** Checkout compare pair: `+12/−2` source/test vs fork. */
+export function formatLocChangePair(sourceDelta: number, testDelta: number): string {
+  return `${formatLocSigned(sourceDelta)}/${formatLocSigned(testDelta)}`;
+}

--- a/dev-site/dev-site-vue/package-change-overlay.test.ts
+++ b/dev-site/dev-site-vue/package-change-overlay.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it } from "vitest";
+import { buildPackageDirTree } from "./package-dir-tree.ts";
+import {
+  dbColumnKey,
+  diffPackageDetails,
+  exportIdentityKey,
+  filterFileNav,
+  filterPackageDirTree,
+  packageChangesFromDiff,
+  pickChangedItems,
+  specPropertyKey,
+  testIdentityKey,
+  type CommitDiffLike,
+  type OverlayPackageDetail,
+} from "./package-change-overlay.ts";
+import type { TestFileNavNode } from "./test-tree.ts";
+
+const pkg = "@demo/lib";
+
+function detail(
+  partial: Partial<OverlayPackageDetail> = {},
+): OverlayPackageDetail {
+  return {
+    packageName: pkg,
+    directory: "lib",
+    exports: [],
+    testCases: [],
+    ...partial,
+  };
+}
+
+describe("diffPackageDetails", () => {
+  it("marks added, removed, and signature/docstring-modified exports", () => {
+    const overlay = diffPackageDetails(
+      detail({
+        exports: [
+          {
+            packageName: pkg,
+            filePath: "lib/a.ts",
+            name: "keep",
+            kind: "function",
+            signature: "(): void",
+            docstring: "same",
+          },
+          {
+            packageName: pkg,
+            filePath: "lib/a.ts",
+            name: "gone",
+            kind: "function",
+            signature: "(): void",
+          },
+          {
+            packageName: pkg,
+            filePath: "lib/a.ts",
+            name: "tweaked",
+            kind: "function",
+            signature: "(): void",
+            docstring: "old",
+          },
+        ],
+      }),
+      detail({
+        exports: [
+          {
+            packageName: pkg,
+            filePath: "lib/a.ts",
+            name: "keep",
+            kind: "function",
+            signature: "(): void",
+            docstring: "same",
+          },
+          {
+            packageName: pkg,
+            filePath: "lib/a.ts",
+            name: "fresh",
+            kind: "function",
+            signature: "(): number",
+          },
+          {
+            packageName: pkg,
+            filePath: "lib/a.ts",
+            name: "tweaked",
+            kind: "function",
+            signature: "(): string",
+            docstring: "new",
+          },
+        ],
+      }),
+    );
+    expect(overlay.packageChange).toBe("modified");
+    expect(overlay.exports[exportIdentityKey({
+      filePath: "lib/a.ts",
+      name: "fresh",
+      kind: "function",
+    })]).toBe("added");
+    expect(overlay.exports[exportIdentityKey({
+      filePath: "lib/a.ts",
+      name: "gone",
+      kind: "function",
+    })]).toBe("removed");
+    expect(overlay.exports[exportIdentityKey({
+      filePath: "lib/a.ts",
+      name: "tweaked",
+      kind: "function",
+    })]).toBe("modified");
+    expect(
+      overlay.exports[exportIdentityKey({
+        filePath: "lib/a.ts",
+        name: "keep",
+        kind: "function",
+      })],
+    ).toBeUndefined();
+    expect(overlay.modules["a"]).toBe("modified");
+  });
+
+  it("marks tests added/removed and modified when subject fields change", () => {
+    const overlay = diffPackageDetails(
+      detail({
+        testCases: [
+          {
+            packageName: pkg,
+            filePath: "lib/a.test.ts",
+            fullName: "a > stays",
+            subjectName: "a",
+            subjectSignature: "(): void",
+          },
+          {
+            packageName: pkg,
+            filePath: "lib/a.test.ts",
+            fullName: "a > gone",
+          },
+          {
+            packageName: pkg,
+            filePath: "lib/a.test.ts",
+            fullName: "a > docs",
+            subjectName: "a",
+            subjectDocstring: "old",
+          },
+        ],
+      }),
+      detail({
+        testCases: [
+          {
+            packageName: pkg,
+            filePath: "lib/a.test.ts",
+            fullName: "a > stays",
+            subjectName: "a",
+            subjectSignature: "(): void",
+          },
+          {
+            packageName: pkg,
+            filePath: "lib/a.test.ts",
+            fullName: "a > new",
+          },
+          {
+            packageName: pkg,
+            filePath: "lib/a.test.ts",
+            fullName: "a > docs",
+            subjectName: "a",
+            subjectDocstring: "new",
+          },
+        ],
+      }),
+    );
+    expect(
+      overlay.tests[testIdentityKey({
+        filePath: "lib/a.test.ts",
+        fullName: "a > new",
+      })],
+    ).toBe("added");
+    expect(
+      overlay.tests[testIdentityKey({
+        filePath: "lib/a.test.ts",
+        fullName: "a > gone",
+      })],
+    ).toBe("removed");
+    expect(
+      overlay.tests[testIdentityKey({
+        filePath: "lib/a.test.ts",
+        fullName: "a > docs",
+      })],
+    ).toBe("modified");
+  });
+
+  it("marks schema properties added/removed/modified on typeKind or docstring", () => {
+    const overlay = diffPackageDetails(
+      detail({
+        specInventory: {
+          entities: [
+            {
+              key: "object:Matter",
+              presence: "object",
+              schema: {
+                description: "Matter",
+                properties: [
+                  { name: "id", typeKind: "string", docstring: "id" },
+                  { name: "title", typeKind: "string", docstring: "old" },
+                ],
+              },
+              operations: [],
+            },
+          ],
+        },
+      }),
+      detail({
+        specInventory: {
+          entities: [
+            {
+              key: "object:Matter",
+              presence: "object",
+              schema: {
+                description: "Matter",
+                properties: [
+                  { name: "id", typeKind: "string", docstring: "id" },
+                  { name: "title", typeKind: "string", docstring: "new" },
+                  { name: "status", typeKind: "string" },
+                ],
+              },
+              operations: [],
+            },
+          ],
+        },
+      }),
+    );
+    expect(
+      overlay.specProperties[specPropertyKey("object:Matter", "status")],
+    ).toBe("added");
+    expect(
+      overlay.specProperties[specPropertyKey("object:Matter", "title")],
+    ).toBe("modified");
+    expect(
+      overlay.specProperties[specPropertyKey("object:Matter", "id")],
+    ).toBeUndefined();
+    expect(overlay.specEntities["object:Matter"]).toBe("modified");
+  });
+
+  it("rolls module stems and treats a brand-new package as added", () => {
+    const overlay = diffPackageDetails(null, detail({
+      exports: [
+        {
+          packageName: pkg,
+          filePath: "lib/dir/b.ts",
+          name: "b",
+          kind: "const",
+        },
+      ],
+    }));
+    expect(overlay.packageChange).toBe("added");
+    expect(overlay.modules["dir/b"]).toBe("added");
+  });
+});
+
+describe("filterPackageDirTree", () => {
+  it("keeps changed packages and drops empty dirs", () => {
+    const tree = buildPackageDirTree([
+      { packageName: "@a/keep", directory: "products/a/keep" },
+      { packageName: "@a/hide", directory: "products/a/hide" },
+      { packageName: "@b/gone", directory: "products/b/gone" },
+    ]);
+    const filtered = filterPackageDirTree(tree, {
+      "@a/keep": "modified",
+      "@b/gone": "removed",
+    });
+    expect(filtered.map((n) => n.label)).toEqual(["products"]);
+    const products = filtered[0]!;
+    expect(products.children.map((n) => n.label).sort()).toEqual(["a", "b"]);
+    const a = products.children.find((n) => n.label === "a")!;
+    expect(a.children).toHaveLength(1);
+    expect(a.children[0]?.packageName).toBe("@a/keep");
+    expect(a.children[0]?.change).toBe("modified");
+  });
+});
+
+describe("filterFileNav", () => {
+  it("keeps changed stems and ancestor dirs", () => {
+    const nav: TestFileNavNode[] = [
+      {
+        id: "dir:src",
+        label: "src",
+        kind: "dir",
+        localPath: "src",
+        children: [
+          {
+            id: "file:src/a",
+            label: "a",
+            kind: "file",
+            localPath: "src/a",
+            children: [],
+          },
+          {
+            id: "file:src/b",
+            label: "b",
+            kind: "file",
+            localPath: "src/b",
+            children: [],
+          },
+        ],
+      },
+      {
+        id: "file:root",
+        label: "root",
+        kind: "file",
+        localPath: "root",
+        children: [],
+      },
+    ];
+    const filtered = filterFileNav(nav, { "src/a": "added" });
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]?.localPath).toBe("src");
+    expect(filtered[0]?.children.map((c) => c.localPath)).toEqual(["src/a"]);
+    expect(filtered[0]?.children[0]?.change).toBe("added");
+  });
+});
+
+describe("packageChangesFromDiff", () => {
+  it("unions metric deltas with export/test/db symbol hits", () => {
+    const diff: CommitDiffLike = {
+      packageMetrics: {
+        added: [{ packageName: "@new/pkg" }],
+        removed: [{ packageName: "@old/pkg" }],
+        changed: [{ after: { packageName: "@chg/pkg" } }],
+      },
+      exports: {
+        added: [{ packageName: "@doc/pkg" }],
+        removed: [],
+      },
+      testCases: { added: [], removed: [] },
+      dbSchemas: {
+        tables: { added: [], removed: [] },
+        columns: { added: [], removed: [], changed: [] },
+      },
+    };
+    expect(packageChangesFromDiff(diff)).toEqual({
+      "@new/pkg": "added",
+      "@old/pkg": "removed",
+      "@chg/pkg": "modified",
+      "@doc/pkg": "modified",
+    });
+  });
+});
+
+describe("pickChangedItems", () => {
+  it("takes removed items from before and added/modified from after", () => {
+    const picked = pickChangedItems(
+      [
+        { filePath: "a.ts", name: "gone", kind: "const" },
+        { filePath: "a.ts", name: "tweaked", kind: "const", signature: "old" },
+      ],
+      [
+        { filePath: "a.ts", name: "fresh", kind: "const" },
+        { filePath: "a.ts", name: "tweaked", kind: "const", signature: "new" },
+        { filePath: "a.ts", name: "keep", kind: "const" },
+      ],
+      exportIdentityKey,
+      {
+        [exportIdentityKey({ filePath: "a.ts", name: "gone", kind: "const" })]:
+          "removed",
+        [exportIdentityKey({ filePath: "a.ts", name: "fresh", kind: "const" })]:
+          "added",
+        [exportIdentityKey({
+          filePath: "a.ts",
+          name: "tweaked",
+          kind: "const",
+        })]: "modified",
+      },
+    );
+    expect(picked.map((p) => p.name).sort()).toEqual([
+      "fresh",
+      "gone",
+      "tweaked",
+    ]);
+    expect(picked.find((p) => p.name === "tweaked")?.signature).toBe("new");
+  });
+});
+
+describe("dbColumnKey", () => {
+  it("is stable per entity + sql name", () => {
+    expect(dbColumnKey("matter", "id")).toBe("matter\0id");
+  });
+});

--- a/dev-site/dev-site-vue/package-change-overlay.test.ts
+++ b/dev-site/dev-site-vue/package-change-overlay.test.ts
@@ -182,6 +182,122 @@ describe("diffPackageDetails", () => {
     ).toBe("modified");
   });
 
+  it("collapses git path renames into moved instead of remove+add", () => {
+    const overlay = diffPackageDetails(
+      detail({
+        exports: [
+          {
+            packageName: pkg,
+            filePath: "lib/a.ts",
+            name: "foo",
+            kind: "function",
+            signature: "(): void",
+            docstring: "same",
+          },
+        ],
+        testCases: [
+          {
+            packageName: pkg,
+            filePath: "lib/a.test.ts",
+            fullName: "foo > works",
+          },
+        ],
+      }),
+      detail({
+        exports: [
+          {
+            packageName: pkg,
+            filePath: "lib/b.ts",
+            name: "foo",
+            kind: "function",
+            signature: "(): void",
+            docstring: "same",
+          },
+        ],
+        testCases: [
+          {
+            packageName: pkg,
+            filePath: "lib/b.test.ts",
+            fullName: "foo > works",
+          },
+        ],
+      }),
+      {
+        pathRenames: [
+          { fromPath: "lib/a.ts", toPath: "lib/b.ts" },
+          { fromPath: "lib/a.test.ts", toPath: "lib/b.test.ts" },
+        ],
+      },
+    );
+    expect(
+      overlay.exports[exportIdentityKey({
+        filePath: "lib/a.ts",
+        name: "foo",
+        kind: "function",
+      })],
+    ).toBeUndefined();
+    expect(
+      overlay.exports[exportIdentityKey({
+        filePath: "lib/b.ts",
+        name: "foo",
+        kind: "function",
+      })],
+    ).toBe("moved");
+    expect(
+      overlay.tests[testIdentityKey({
+        filePath: "lib/a.test.ts",
+        fullName: "foo > works",
+      })],
+    ).toBeUndefined();
+    expect(
+      overlay.tests[testIdentityKey({
+        filePath: "lib/b.test.ts",
+        fullName: "foo > works",
+      })],
+    ).toBe("moved");
+    expect(overlay.modules["a"]).toBeUndefined();
+    expect(overlay.modules["b"]).toBe("moved");
+    expect(overlay.movedFrom["b"]).toBe("a");
+  });
+
+  it("marks a renamed export modified when its signature also changed", () => {
+    const overlay = diffPackageDetails(
+      detail({
+        exports: [
+          {
+            packageName: pkg,
+            filePath: "lib/a.ts",
+            name: "foo",
+            kind: "function",
+            signature: "(): void",
+          },
+        ],
+      }),
+      detail({
+        exports: [
+          {
+            packageName: pkg,
+            filePath: "lib/b.ts",
+            name: "foo",
+            kind: "function",
+            signature: "(): number",
+          },
+        ],
+      }),
+      { pathRenames: [{ fromPath: "lib/a.ts", toPath: "lib/b.ts" }] },
+    );
+    expect(
+      overlay.exports[exportIdentityKey({
+        filePath: "lib/b.ts",
+        name: "foo",
+        kind: "function",
+      })],
+    ).toBe("modified");
+    expect(overlay.modules["a"]).toBeUndefined();
+    expect(overlay.modules["b"]).toBe("modified");
+    expect(overlay.movedFrom["b"]).toBeUndefined();
+  });
+
   it("marks schema properties added/removed/modified on typeKind or docstring", () => {
     const overlay = diffPackageDetails(
       detail({
@@ -309,6 +425,34 @@ describe("filterFileNav", () => {
     expect(filtered[0]?.localPath).toBe("src");
     expect(filtered[0]?.children.map((c) => c.localPath)).toEqual(["src/a"]);
     expect(filtered[0]?.children[0]?.change).toBe("added");
+  });
+
+  it("attaches movedFrom on renamed stems", () => {
+    const nav: TestFileNavNode[] = [
+      {
+        id: "file:src/a",
+        label: "a",
+        kind: "file",
+        localPath: "src/a",
+        children: [],
+      },
+      {
+        id: "file:src/b",
+        label: "b",
+        kind: "file",
+        localPath: "src/b",
+        children: [],
+      },
+    ];
+    const filtered = filterFileNav(
+      nav,
+      { "src/b": "moved" },
+      { "src/b": "src/a" },
+    );
+    expect(filtered).toHaveLength(1);
+    expect(filtered[0]?.localPath).toBe("src/b");
+    expect(filtered[0]?.change).toBe("moved");
+    expect(filtered[0]?.movedFrom).toBe("src/a");
   });
 });
 

--- a/dev-site/dev-site-vue/package-change-overlay.ts
+++ b/dev-site/dev-site-vue/package-change-overlay.ts
@@ -1,0 +1,573 @@
+import type { PackageDirNode } from "./package-dir-tree.ts";
+import {
+  packageHasVueFiles,
+  packageLocalPath,
+  toModuleStem,
+  toVueBundleStem,
+  type ExportLike,
+  type TestCaseLike,
+  type TestFileNavNode,
+  type TestTreeNode,
+} from "./test-tree.ts";
+
+export type ChangeKind = "added" | "removed" | "modified";
+
+export function changeColor(kind: ChangeKind): "success" | "error" | "warning" {
+  if (kind === "added") return "success";
+  if (kind === "removed") return "error";
+  return "warning";
+}
+
+export interface OverlaySpecProperty {
+  name: string;
+  typeKind: string;
+  docstring?: string | null;
+}
+
+export interface OverlaySpecOperation {
+  operationId: string;
+  method: string;
+  path: string;
+}
+
+export interface OverlaySpecEntity {
+  key: string;
+  presence?: string;
+  schema?: {
+    description?: string | null;
+    properties: OverlaySpecProperty[];
+  } | null;
+  operations: OverlaySpecOperation[];
+}
+
+export interface OverlayDbColumn {
+  sqlName: string;
+  typeKind: string;
+  propName?: string;
+  docstring?: string | null;
+}
+
+export interface OverlayDbEntity {
+  entity: string;
+  table?: {
+    tableName?: string;
+    docstring?: string | null;
+    columns: OverlayDbColumn[];
+  } | null;
+}
+
+export interface OverlayPackageDetail {
+  packageName: string;
+  directory?: string;
+  exports?: ExportLike[];
+  testCases?: TestCaseLike[];
+  specInventory?: {
+    packageDirectory?: string;
+    entities: OverlaySpecEntity[];
+  } | null;
+  dbInventory?: { entities: OverlayDbEntity[] } | null;
+}
+
+export interface PackageChangeOverlay {
+  packageChange?: ChangeKind;
+  modules: Record<string, ChangeKind>;
+  exports: Record<string, ChangeKind>;
+  tests: Record<string, ChangeKind>;
+  specEntities: Record<string, ChangeKind>;
+  specOperations: Record<string, ChangeKind>;
+  specProperties: Record<string, ChangeKind>;
+  dbEntities: Record<string, ChangeKind>;
+  dbColumns: Record<string, ChangeKind>;
+}
+
+export interface CommitDiffLike {
+  packageMetrics: {
+    added: Array<{ packageName: string }>;
+    removed: Array<{ packageName: string }>;
+    changed: Array<{ after: { packageName: string } }>;
+  };
+  exports: {
+    added: Array<{ packageName: string }>;
+    removed: Array<{ packageName: string }>;
+  };
+  testCases: {
+    added: Array<{ packageName: string }>;
+    removed: Array<{ packageName: string }>;
+  };
+  dbSchemas: {
+    tables: {
+      added: Array<{ packageName: string }>;
+      removed: Array<{ packageName: string }>;
+    };
+    columns: {
+      added: Array<{ packageName: string }>;
+      removed: Array<{ packageName: string }>;
+      changed: Array<{ after: { packageName: string } }>;
+    };
+  };
+}
+
+export function emptyOverlay(): PackageChangeOverlay {
+  return {
+    modules: {},
+    exports: {},
+    tests: {},
+    specEntities: {},
+    specOperations: {},
+    specProperties: {},
+    dbEntities: {},
+    dbColumns: {},
+  };
+}
+
+export function exportIdentityKey(e: {
+  filePath: string;
+  name: string;
+  kind: string;
+}): string {
+  return `${e.filePath}\0${e.name}\0${e.kind}`;
+}
+
+export function testIdentityKey(t: {
+  filePath: string;
+  fullName: string;
+}): string {
+  return `${t.filePath}\0${t.fullName}`;
+}
+
+export function specOperationKey(op: OverlaySpecOperation): string {
+  return `${op.operationId}\0${op.method}\0${op.path}`;
+}
+
+export function specPropertyKey(entityKey: string, propName: string): string {
+  return `${entityKey}\0${propName}`;
+}
+
+export function dbColumnKey(entity: string, sqlName: string): string {
+  return `${entity}\0${sqlName}`;
+}
+
+function sameText(a: string | null | undefined, b: string | null | undefined): boolean {
+  return (a ?? null) === (b ?? null);
+}
+
+function identityDiff<T>(
+  before: T[],
+  after: T[],
+  keyOf: (item: T) => string,
+  isModified?: (before: T, after: T) => boolean,
+): Record<string, ChangeKind> {
+  const out: Record<string, ChangeKind> = {};
+  const beforeMap = new Map(before.map((item) => [keyOf(item), item]));
+  const afterMap = new Map(after.map((item) => [keyOf(item), item]));
+  for (const [key, afterItem] of afterMap) {
+    const beforeItem = beforeMap.get(key);
+    if (!beforeItem) out[key] = "added";
+    else if (isModified?.(beforeItem, afterItem)) out[key] = "modified";
+  }
+  for (const key of beforeMap.keys()) {
+    if (!afterMap.has(key)) out[key] = "removed";
+  }
+  return out;
+}
+
+function rollupChange(
+  current: ChangeKind | undefined,
+  next: ChangeKind,
+): ChangeKind {
+  if (!current) return next;
+  if (current === next) return current;
+  return "modified";
+}
+
+/** Child add/remove on a parent that already exists is a modification. */
+function rollupChildIntoParent(
+  parent: ChangeKind | undefined,
+  child: ChangeKind,
+): ChangeKind {
+  if (parent === "added" || parent === "removed") {
+    return rollupChange(parent, child);
+  }
+  return "modified";
+}
+
+function isEmptyDetail(detail: OverlayPackageDetail | null | undefined): boolean {
+  if (!detail) return true;
+  return (
+    !(detail.exports ?? []).length &&
+    !(detail.testCases ?? []).length &&
+    !(detail.specInventory?.entities ?? []).length &&
+    !(detail.dbInventory?.entities ?? []).length
+  );
+}
+
+export function lookupExportChange(
+  overlay: PackageChangeOverlay,
+  filePath: string | null | undefined,
+  name: string | null | undefined,
+): ChangeKind | undefined {
+  if (!filePath || !name) return undefined;
+  const prefix = `${filePath}\0${name}\0`;
+  const hits: ChangeKind[] = [];
+  for (const [key, kind] of Object.entries(overlay.exports)) {
+    if (key.startsWith(prefix)) hits.push(kind);
+  }
+  if (!hits.length) return undefined;
+  return hits.reduce((acc, kind) => rollupChange(acc, kind));
+}
+
+export function packageChangesFromDiff(
+  diff: CommitDiffLike,
+): Record<string, ChangeKind> {
+  const out: Record<string, ChangeKind> = {};
+  for (const pkg of diff.packageMetrics.added) {
+    out[pkg.packageName] = "added";
+  }
+  for (const pkg of diff.packageMetrics.removed) {
+    out[pkg.packageName] = "removed";
+  }
+  const bumpModified = (packageName: string) => {
+    if (!out[packageName]) out[packageName] = "modified";
+  };
+  for (const chg of diff.packageMetrics.changed) {
+    bumpModified(chg.after.packageName);
+  }
+  for (const item of [
+    ...diff.exports.added,
+    ...diff.exports.removed,
+    ...diff.testCases.added,
+    ...diff.testCases.removed,
+    ...diff.dbSchemas.tables.added,
+    ...diff.dbSchemas.tables.removed,
+    ...diff.dbSchemas.columns.added,
+    ...diff.dbSchemas.columns.removed,
+    ...diff.dbSchemas.columns.changed.map((c) => c.after),
+  ]) {
+    bumpModified(item.packageName);
+  }
+  return out;
+}
+
+export function diffPackageDetails(
+  before: OverlayPackageDetail | null | undefined,
+  after: OverlayPackageDetail | null | undefined,
+  options: { productRoot?: string } = {},
+): PackageChangeOverlay {
+  const overlay = emptyOverlay();
+  const emptyBefore = isEmptyDetail(before);
+  const emptyAfter = isEmptyDetail(after);
+  if (emptyBefore && emptyAfter) return overlay;
+
+  const packageName =
+    after?.packageName ?? before?.packageName ?? "";
+  const directory = after?.directory ?? before?.directory ?? "";
+  const productRoot = options.productRoot ?? "";
+  const beforeExports = before?.exports ?? [];
+  const afterExports = after?.exports ?? [];
+  const beforeTests = before?.testCases ?? [];
+  const afterTests = after?.testCases ?? [];
+
+  overlay.exports = identityDiff(
+    beforeExports,
+    afterExports,
+    exportIdentityKey,
+    (b, a) =>
+      !sameText(b.signature, a.signature) || !sameText(b.docstring, a.docstring),
+  );
+  overlay.tests = identityDiff(
+    beforeTests,
+    afterTests,
+    testIdentityKey,
+    (b, a) =>
+      !sameText(b.subjectName, a.subjectName) ||
+      !sameText(b.subjectSignature, a.subjectSignature) ||
+      !sameText(b.subjectDocstring, a.subjectDocstring) ||
+      !sameText(b.subjectFilePath, a.subjectFilePath) ||
+      !sameText(b.subjectConfidence, a.subjectConfidence),
+  );
+
+  const vueBundles = packageHasVueFiles(
+    [...beforeExports, ...afterExports],
+    [...beforeTests, ...afterTests],
+    packageName,
+  );
+  const stemOf = (filePath: string) => {
+    const local = packageLocalPath(filePath, directory, productRoot);
+    return vueBundles ? toVueBundleStem(local) : toModuleStem(local);
+  };
+
+  const stemKeys = new Map<string, Set<string>>();
+  const addStemKey = (filePath: string, key: string, mapName: "exports" | "tests") => {
+    const stem = stemOf(filePath);
+    let set = stemKeys.get(stem);
+    if (!set) {
+      set = new Set();
+      stemKeys.set(stem, set);
+    }
+    set.add(`${mapName}:${key}`);
+  };
+  for (const e of [...beforeExports, ...afterExports]) {
+    addStemKey(e.filePath, exportIdentityKey(e), "exports");
+  }
+  for (const t of [...beforeTests, ...afterTests]) {
+    addStemKey(t.filePath, testIdentityKey(t), "tests");
+  }
+  for (const [stem, keys] of stemKeys) {
+    let change: ChangeKind | undefined;
+    for (const token of keys) {
+      const [mapName, ...rest] = token.split(":");
+      const key = rest.join(":");
+      const hit =
+        mapName === "tests" ? overlay.tests[key] : overlay.exports[key];
+      if (hit) change = rollupChange(change, hit);
+    }
+    if (change) overlay.modules[stem] = change;
+  }
+
+  const beforeSpec = before?.specInventory?.entities ?? [];
+  const afterSpec = after?.specInventory?.entities ?? [];
+  overlay.specOperations = identityDiff(
+    beforeSpec.flatMap((e) => e.operations),
+    afterSpec.flatMap((e) => e.operations),
+    specOperationKey,
+  );
+  overlay.specProperties = identityDiff(
+    beforeSpec.flatMap((e) =>
+      (e.schema?.properties ?? []).map((p) => ({
+        entityKey: e.key,
+        ...p,
+      })),
+    ),
+    afterSpec.flatMap((e) =>
+      (e.schema?.properties ?? []).map((p) => ({
+        entityKey: e.key,
+        ...p,
+      })),
+    ),
+    (p) => specPropertyKey(p.entityKey, p.name),
+    (b, a) =>
+      b.typeKind !== a.typeKind || !sameText(b.docstring, a.docstring),
+  );
+  overlay.specEntities = identityDiff(
+    beforeSpec,
+    afterSpec,
+    (e) => e.key,
+    (b, a) =>
+      b.presence !== a.presence ||
+      !sameText(b.schema?.description, a.schema?.description),
+  );
+  for (const [key, kind] of Object.entries(overlay.specProperties)) {
+    const entityKey = key.split("\0")[0] ?? "";
+    if (!entityKey) continue;
+    overlay.specEntities[entityKey] = rollupChildIntoParent(
+      overlay.specEntities[entityKey],
+      kind,
+    );
+  }
+  for (const e of [...beforeSpec, ...afterSpec]) {
+    for (const op of e.operations) {
+      const kind = overlay.specOperations[specOperationKey(op)];
+      if (kind) {
+        overlay.specEntities[e.key] = rollupChildIntoParent(
+          overlay.specEntities[e.key],
+          kind,
+        );
+      }
+    }
+  }
+
+  const beforeDb = before?.dbInventory?.entities ?? [];
+  const afterDb = after?.dbInventory?.entities ?? [];
+  overlay.dbColumns = identityDiff(
+    beforeDb.flatMap((e) =>
+      (e.table?.columns ?? []).map((c) => ({ entity: e.entity, ...c })),
+    ),
+    afterDb.flatMap((e) =>
+      (e.table?.columns ?? []).map((c) => ({ entity: e.entity, ...c })),
+    ),
+    (c) => dbColumnKey(c.entity, c.sqlName),
+    (b, a) =>
+      b.typeKind !== a.typeKind ||
+      !sameText(b.propName, a.propName) ||
+      !sameText(b.docstring, a.docstring),
+  );
+  overlay.dbEntities = identityDiff(
+    beforeDb,
+    afterDb,
+    (e) => e.entity,
+    (b, a) =>
+      Boolean(b.table) !== Boolean(a.table) ||
+      !sameText(b.table?.docstring, a.table?.docstring) ||
+      !sameText(b.table?.tableName, a.table?.tableName),
+  );
+  for (const [key, kind] of Object.entries(overlay.dbColumns)) {
+    const entity = key.split("\0")[0] ?? "";
+    if (entity) {
+      overlay.dbEntities[entity] = rollupChildIntoParent(
+        overlay.dbEntities[entity],
+        kind,
+      );
+    }
+  }
+  for (const [stem, kind] of Object.entries(overlay.modules)) {
+    const queryMatch = /^queries\/([^/]+)/.exec(stem);
+    const schemaMatch = /^schemas\/([^/]+)/.exec(stem);
+    const entity = queryMatch?.[1] ?? schemaMatch?.[1];
+    if (entity) {
+      overlay.dbEntities[entity] = rollupChange(
+        overlay.dbEntities[entity],
+        kind,
+      );
+    }
+  }
+  for (const [entity, kind] of Object.entries(overlay.dbEntities)) {
+    overlay.modules[`entities/${entity}`] = rollupChange(
+      overlay.modules[`entities/${entity}`],
+      kind,
+    );
+  }
+
+  if (emptyBefore && !emptyAfter) overlay.packageChange = "added";
+  else if (!emptyBefore && emptyAfter) overlay.packageChange = "removed";
+  else if (overlayHasHits(overlay)) overlay.packageChange = "modified";
+
+  return overlay;
+}
+
+export function overlayHasHits(overlay: PackageChangeOverlay): boolean {
+  return (
+    Object.keys(overlay.modules).length > 0 ||
+    Object.keys(overlay.exports).length > 0 ||
+    Object.keys(overlay.tests).length > 0 ||
+    Object.keys(overlay.specEntities).length > 0 ||
+    Object.keys(overlay.specOperations).length > 0 ||
+    Object.keys(overlay.specProperties).length > 0 ||
+    Object.keys(overlay.dbEntities).length > 0 ||
+    Object.keys(overlay.dbColumns).length > 0
+  );
+}
+
+export function unionByKey<T>(
+  before: T[],
+  after: T[],
+  keyOf: (item: T) => string,
+): T[] {
+  const map = new Map<string, T>();
+  for (const item of before) map.set(keyOf(item), item);
+  for (const item of after) map.set(keyOf(item), item);
+  return [...map.values()];
+}
+
+export function pickChangedItems<T>(
+  before: T[],
+  after: T[],
+  keyOf: (item: T) => string,
+  changes: Record<string, ChangeKind>,
+): Array<T & { change: ChangeKind }> {
+  const beforeMap = new Map(before.map((item) => [keyOf(item), item]));
+  const afterMap = new Map(after.map((item) => [keyOf(item), item]));
+  const keys = new Set([...beforeMap.keys(), ...afterMap.keys()]);
+  const out: Array<T & { change: ChangeKind }> = [];
+  for (const key of keys) {
+    const change = changes[key];
+    if (!change) continue;
+    const item = change === "removed" ? beforeMap.get(key) : afterMap.get(key);
+    if (!item) continue;
+    out.push({ ...item, change });
+  }
+  return out;
+}
+
+export function filterPackageDirTree(
+  nodes: PackageDirNode[],
+  changeByPackage: Record<string, ChangeKind>,
+): PackageDirNode[] {
+  const out: PackageDirNode[] = [];
+  for (const node of nodes) {
+    if (node.kind === "package") {
+      const change = node.packageName
+        ? changeByPackage[node.packageName]
+        : undefined;
+      if (!change) continue;
+      out.push({ ...node, change, children: [] });
+      continue;
+    }
+    const children = filterPackageDirTree(node.children, changeByPackage);
+    if (children.length) out.push({ ...node, children });
+  }
+  return out;
+}
+
+export function filterFileNav(
+  nodes: TestFileNavNode[],
+  changeByStem: Record<string, ChangeKind>,
+): TestFileNavNode[] {
+  const out: TestFileNavNode[] = [];
+  for (const node of nodes) {
+    if (node.kind === "file") {
+      const change = changeByStem[node.localPath];
+      if (!change) continue;
+      out.push({ ...node, change, children: [] });
+      continue;
+    }
+    const children = filterFileNav(node.children, changeByStem);
+    const self = changeByStem[node.localPath];
+    if (!children.length && !self) continue;
+    out.push({ ...node, change: self, children });
+  }
+  return out;
+}
+
+export function tagSpecTree(
+  nodes: TestTreeNode[],
+  overlay: PackageChangeOverlay,
+  suiteParts: string[] = [],
+): TestTreeNode[] {
+  return nodes.map((node) => {
+    if (node.kind === "test") {
+      const fullName = [...suiteParts, node.label].join(" > ");
+      const filePath = node.sourcePath ?? "";
+      const change = filePath
+        ? overlay.tests[testIdentityKey({ filePath, fullName })]
+        : undefined;
+      return { ...node, change };
+    }
+    if (node.kind === "suite") {
+      const children = tagSpecTree(node.children, overlay, [
+        ...suiteParts,
+        node.label,
+      ]);
+      const exportChange = lookupExportChange(
+        overlay,
+        node.subjectFilePath,
+        node.subjectName ?? node.label,
+      );
+      let change = exportChange;
+      for (const child of children) {
+        if (child.change) change = rollupChange(change, child.change);
+      }
+      return { ...node, change, children };
+    }
+    return { ...node, children: tagSpecTree(node.children, overlay, suiteParts) };
+  });
+}
+
+export function pruneEmptySpecTree(nodes: TestTreeNode[]): TestTreeNode[] {
+  const out: TestTreeNode[] = [];
+  for (const node of nodes) {
+    if (node.kind === "test" || node.kind === "suite") {
+      if (node.kind === "suite") {
+        const children = pruneEmptySpecTree(node.children);
+        if (node.change || children.length) {
+          out.push({ ...node, children });
+        }
+      } else if (node.change) {
+        out.push(node);
+      }
+      continue;
+    }
+    const children = pruneEmptySpecTree(node.children);
+    if (children.length) out.push({ ...node, children });
+  }
+  return out;
+}

--- a/dev-site/dev-site-vue/package-change-overlay.ts
+++ b/dev-site/dev-site-vue/package-change-overlay.ts
@@ -10,11 +10,14 @@ import {
   type TestTreeNode,
 } from "./test-tree.ts";
 
-export type ChangeKind = "added" | "removed" | "modified";
+export type ChangeKind = "added" | "removed" | "modified" | "moved";
 
-export function changeColor(kind: ChangeKind): "success" | "error" | "warning" {
+export function changeColor(
+  kind: ChangeKind,
+): "success" | "error" | "warning" | "info" {
   if (kind === "added") return "success";
   if (kind === "removed") return "error";
+  if (kind === "moved") return "info";
   return "warning";
 }
 
@@ -78,6 +81,13 @@ export interface PackageChangeOverlay {
   specProperties: Record<string, ChangeKind>;
   dbEntities: Record<string, ChangeKind>;
   dbColumns: Record<string, ChangeKind>;
+  /** New module stem → old stem when git renamed the file(s). */
+  movedFrom: Record<string, string>;
+}
+
+export interface PathRename {
+  fromPath: string;
+  toPath: string;
 }
 
 export interface CommitDiffLike {
@@ -117,6 +127,7 @@ export function emptyOverlay(): PackageChangeOverlay {
     specProperties: {},
     dbEntities: {},
     dbColumns: {},
+    movedFrom: {},
   };
 }
 
@@ -149,6 +160,51 @@ export function dbColumnKey(entity: string, sqlName: string): string {
 
 function sameText(a: string | null | undefined, b: string | null | undefined): boolean {
   return (a ?? null) === (b ?? null);
+}
+
+function renameMap(renames: PathRename[]): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const r of renames) {
+    if (r.fromPath && r.toPath && r.fromPath !== r.toPath) {
+      map.set(r.fromPath, r.toPath);
+    }
+  }
+  return map;
+}
+
+function findOldPath(
+  oldToNew: Map<string, string>,
+  newPath: string,
+): string | undefined {
+  for (const [from, to] of oldToNew) {
+    if (to === newPath) return from;
+  }
+  return undefined;
+}
+
+function collapsePathRenames<T extends { filePath: string }>(
+  overlayMap: Record<string, ChangeKind>,
+  before: T[],
+  after: T[],
+  keyOf: (item: T) => string,
+  oldToNew: Map<string, string>,
+  isModified?: (before: T, after: T) => boolean,
+): void {
+  if (!oldToNew.size) return;
+  const afterByKey = new Map(after.map((item) => [keyOf(item), item]));
+  for (const beforeItem of before) {
+    const newPath = oldToNew.get(beforeItem.filePath);
+    if (!newPath) continue;
+    const oldKey = keyOf(beforeItem);
+    const rewritten = { ...beforeItem, filePath: newPath };
+    const newKey = keyOf(rewritten);
+    const afterItem = afterByKey.get(newKey);
+    if (!afterItem) continue;
+    delete overlayMap[oldKey];
+    overlayMap[newKey] = isModified?.(beforeItem, afterItem)
+      ? "modified"
+      : "moved";
+  }
 }
 
 function identityDiff<T>(
@@ -251,7 +307,7 @@ export function packageChangesFromDiff(
 export function diffPackageDetails(
   before: OverlayPackageDetail | null | undefined,
   after: OverlayPackageDetail | null | undefined,
-  options: { productRoot?: string } = {},
+  options: { productRoot?: string; pathRenames?: PathRename[] } = {},
 ): PackageChangeOverlay {
   const overlay = emptyOverlay();
   const emptyBefore = isEmptyDetail(before);
@@ -266,6 +322,7 @@ export function diffPackageDetails(
   const afterExports = after?.exports ?? [];
   const beforeTests = before?.testCases ?? [];
   const afterTests = after?.testCases ?? [];
+  const oldToNew = renameMap(options.pathRenames ?? []);
 
   overlay.exports = identityDiff(
     beforeExports,
@@ -278,6 +335,28 @@ export function diffPackageDetails(
     beforeTests,
     afterTests,
     testIdentityKey,
+    (b, a) =>
+      !sameText(b.subjectName, a.subjectName) ||
+      !sameText(b.subjectSignature, a.subjectSignature) ||
+      !sameText(b.subjectDocstring, a.subjectDocstring) ||
+      !sameText(b.subjectFilePath, a.subjectFilePath) ||
+      !sameText(b.subjectConfidence, a.subjectConfidence),
+  );
+  collapsePathRenames(
+    overlay.exports,
+    beforeExports,
+    afterExports,
+    exportIdentityKey,
+    oldToNew,
+    (b, a) =>
+      !sameText(b.signature, a.signature) || !sameText(b.docstring, a.docstring),
+  );
+  collapsePathRenames(
+    overlay.tests,
+    beforeTests,
+    afterTests,
+    testIdentityKey,
+    oldToNew,
     (b, a) =>
       !sameText(b.subjectName, a.subjectName) ||
       !sameText(b.subjectSignature, a.subjectSignature) ||
@@ -322,6 +401,18 @@ export function diffPackageDetails(
       if (hit) change = rollupChange(change, hit);
     }
     if (change) overlay.modules[stem] = change;
+  }
+  for (const [newKey, kind] of Object.entries(overlay.exports)) {
+    if (kind !== "moved" && kind !== "modified") continue;
+    const parts = newKey.split("\0");
+    const newPath = parts[0] ?? "";
+    const oldPath = findOldPath(oldToNew, newPath);
+    if (!oldPath) continue;
+    const newStem = stemOf(newPath);
+    const oldStem = stemOf(oldPath);
+    if (newStem !== oldStem && overlay.modules[newStem] === "moved") {
+      overlay.movedFrom[newStem] = oldStem;
+    }
   }
 
   const beforeSpec = before?.specInventory?.entities ?? [];
@@ -501,16 +592,22 @@ export function filterPackageDirTree(
 export function filterFileNav(
   nodes: TestFileNavNode[],
   changeByStem: Record<string, ChangeKind>,
+  movedFrom: Record<string, string> = {},
 ): TestFileNavNode[] {
   const out: TestFileNavNode[] = [];
   for (const node of nodes) {
     if (node.kind === "file") {
       const change = changeByStem[node.localPath];
       if (!change) continue;
-      out.push({ ...node, change, children: [] });
+      out.push({
+        ...node,
+        change,
+        movedFrom: change === "moved" ? movedFrom[node.localPath] : undefined,
+        children: [],
+      });
       continue;
     }
-    const children = filterFileNav(node.children, changeByStem);
+    const children = filterFileNav(node.children, changeByStem, movedFrom);
     const self = changeByStem[node.localPath];
     if (!children.length && !self) continue;
     out.push({ ...node, change: self, children });

--- a/dev-site/dev-site-vue/package-compare.ts
+++ b/dev-site/dev-site-vue/package-compare.ts
@@ -1,0 +1,87 @@
+import { computed, toValue, type MaybeRefOrGetter } from "vue";
+import { TanstackError } from "@saflib/sdk";
+import { useCommitPackage } from "./requests/queries.ts";
+import {
+  diffPackageDetails,
+  emptyOverlay,
+  type OverlayPackageDetail,
+  type PackageChangeOverlay,
+} from "./package-change-overlay.ts";
+
+/**
+ * Fetch HEAD (or the given hash) plus an optional merge-base snapshot and
+ * compute the per-symbol overlay. 404 on either side is treated as "package
+ * missing at that commit" when compare is on.
+ */
+export function useComparedPackageDetail(
+  subdomain: string,
+  commitHash: MaybeRefOrGetter<string>,
+  packageName: MaybeRefOrGetter<string>,
+  options: {
+    compareFromHash?: MaybeRefOrGetter<string | undefined>;
+    productRoot?: MaybeRefOrGetter<string | undefined>;
+  } = {},
+) {
+  const compareFromHash = () => toValue(options.compareFromHash);
+  const comparing = () => Boolean(compareFromHash());
+
+  const after = useCommitPackage(
+    subdomain,
+    commitHash,
+    packageName,
+    { allowMissing: comparing },
+  );
+  const before = useCommitPackage(
+    subdomain,
+    () => compareFromHash() ?? "",
+    packageName,
+    { allowMissing: true },
+  );
+
+  const isLoading = computed(
+    () => after.isLoading.value || (comparing() && before.isLoading.value),
+  );
+
+  const error = computed(() => {
+    if (after.error.value && !(comparing() && isMissing(after.error.value))) {
+      return after.error.value;
+    }
+    if (comparing() && before.error.value && !isMissing(before.error.value)) {
+      return before.error.value;
+    }
+    return null;
+  });
+
+  const beforeDetail = computed(
+    () => (before.data.value?.packageDetail ?? null) as OverlayPackageDetail | null,
+  );
+  const afterDetail = computed(
+    () => (after.data.value?.packageDetail ?? null) as OverlayPackageDetail | null,
+  );
+
+  const overlay = computed((): PackageChangeOverlay | null => {
+    if (!comparing()) return null;
+    if (isLoading.value) return emptyOverlay();
+    return diffPackageDetails(beforeDetail.value, afterDetail.value, {
+      productRoot: toValue(options.productRoot) ?? "",
+    });
+  });
+
+  const detail = computed(
+    () => afterDetail.value ?? beforeDetail.value,
+  );
+
+  return {
+    isLoading,
+    error,
+    overlay,
+    detail,
+    beforeDetail,
+    afterDetail,
+    comparing: computed(() => comparing()),
+  };
+}
+
+function isMissing(error: TanstackError): boolean {
+  return error.status === 404;
+}

--- a/dev-site/dev-site-vue/package-compare.ts
+++ b/dev-site/dev-site-vue/package-compare.ts
@@ -6,6 +6,7 @@ import {
   emptyOverlay,
   type OverlayPackageDetail,
   type PackageChangeOverlay,
+  type PathRename,
 } from "./package-change-overlay.ts";
 
 /**
@@ -20,6 +21,7 @@ export function useComparedPackageDetail(
   options: {
     compareFromHash?: MaybeRefOrGetter<string | undefined>;
     productRoot?: MaybeRefOrGetter<string | undefined>;
+    pathRenames?: MaybeRefOrGetter<PathRename[] | undefined>;
   } = {},
 ) {
   const compareFromHash = () => toValue(options.compareFromHash);
@@ -64,6 +66,7 @@ export function useComparedPackageDetail(
     if (isLoading.value) return emptyOverlay();
     return diffPackageDetails(beforeDetail.value, afterDetail.value, {
       productRoot: toValue(options.productRoot) ?? "",
+      pathRenames: toValue(options.pathRenames) ?? [],
     });
   });
 

--- a/dev-site/dev-site-vue/package-dir-tree.test.ts
+++ b/dev-site/dev-site-vue/package-dir-tree.test.ts
@@ -10,6 +10,7 @@ describe("buildPackageDirTree", () => {
       {
         packageName: "@example/billing-db",
         directory: "products/billing/service/db",
+        kind: "db",
         debtCount: 2,
         issueCountsByKind: {
           "dead-code": 2,

--- a/dev-site/dev-site-vue/package-dir-tree.ts
+++ b/dev-site/dev-site-vue/package-dir-tree.ts
@@ -28,6 +28,7 @@ export interface PackageDirNode {
 export interface PackageDirInput {
   packageName: string;
   directory: string;
+  kind?: PackageKind | string;
   sourceLines?: number;
   testLines?: number;
   testFiles?: number;
@@ -60,7 +61,7 @@ export function buildPackageDirTree(
 
     const packageFields = {
       packageName: pkg.packageName,
-      packageKind: classifyPackageKind(pkg.packageName, pkg.directory),
+      packageKind: classifyPackageKind(pkg.kind),
       packageSize: classifyPackageSize({
         sourceLines: pkg.sourceLines ?? 0,
         testFiles: pkg.testFiles,

--- a/dev-site/dev-site-vue/package-dir-tree.ts
+++ b/dev-site/dev-site-vue/package-dir-tree.ts
@@ -20,6 +20,8 @@ export interface PackageDirNode {
   sourceLines?: number;
   testLines?: number;
   directory?: string;
+  /** Present in Checkout compare mode for package nodes. */
+  change?: "added" | "removed" | "modified";
   children: PackageDirNode[];
 }
 

--- a/dev-site/dev-site-vue/package-dir-tree.ts
+++ b/dev-site/dev-site-vue/package-dir-tree.ts
@@ -21,7 +21,7 @@ export interface PackageDirNode {
   testLines?: number;
   directory?: string;
   /** Present in Checkout compare mode for package nodes. */
-  change?: "added" | "removed" | "modified";
+  change?: "added" | "removed" | "modified" | "moved";
   children: PackageDirNode[];
 }
 

--- a/dev-site/dev-site-vue/package-kind.test.ts
+++ b/dev-site/dev-site-vue/package-kind.test.ts
@@ -3,23 +3,16 @@ import { classifyPackageKind, PACKAGE_KIND_SURFACES } from "./package-kind.ts";
 import { buildPackageTestTree, buildTestFileNav } from "./test-tree.ts";
 
 describe("classifyPackageKind", () => {
-  it("classifies common saflib suffixes", () => {
-    expect(classifyPackageKind("@saflib/dev-site-db", "saflib/dev-site/dev-site-db")).toBe(
-      "db",
-    );
-    expect(
-      classifyPackageKind("@saflib/dev-site-http", "saflib/dev-site/dev-site-http"),
-    ).toBe("http");
-    expect(
-      classifyPackageKind("@saflib/dev-site-spec", "saflib/dev-site/dev-site-spec"),
-    ).toBe("spec");
-    expect(
-      classifyPackageKind("@saflib/dev-site-vue", "saflib/dev-site/dev-site-vue"),
-    ).toBe("spa");
-    expect(classifyPackageKind("@saflib/backup-sdk", "saflib/backup/backup-sdk")).toBe(
-      "sdk",
-    );
-    expect(classifyPackageKind("@saflib/git", "saflib/git")).toBe("lib");
+  it("coerces API kind strings", () => {
+    expect(classifyPackageKind("db")).toBe("db");
+    expect(classifyPackageKind("http")).toBe("http");
+    expect(classifyPackageKind("spec")).toBe("spec");
+    expect(classifyPackageKind("sdk")).toBe("sdk");
+    expect(classifyPackageKind("spa")).toBe("spa");
+    expect(classifyPackageKind("lib")).toBe("lib");
+    expect(classifyPackageKind("integration")).toBe("integration");
+    expect(classifyPackageKind(undefined)).toBe("other");
+    expect(classifyPackageKind("nope")).toBe("other");
   });
 
   it("lists future surfaces per kind", () => {

--- a/dev-site/dev-site-vue/package-kind.ts
+++ b/dev-site/dev-site-vue/package-kind.ts
@@ -8,6 +8,17 @@ export type PackageKind =
   | "integration"
   | "other";
 
+const PACKAGE_KINDS: readonly PackageKind[] = [
+  "db",
+  "http",
+  "spec",
+  "spa",
+  "sdk",
+  "lib",
+  "integration",
+  "other",
+];
+
 /** Surfaces this kind will eventually show (besides universal Tests). */
 export const PACKAGE_KIND_SURFACES: Record<PackageKind, string[]> = {
   db: ["Schemas / queries"],
@@ -21,70 +32,14 @@ export const PACKAGE_KIND_SURFACES: Record<PackageKind, string[]> = {
 };
 
 /**
- * Heuristic package kind from npm name + directory (refine later).
+ * Coerce an API/package.json kind string. Unknown or missing values are `other`.
+ * Server-side classification lives in `@saflib/monorepo` (`saf.kind` / identifier deps).
  */
 export function classifyPackageKind(
-  packageName: string,
-  directory: string = "",
+  kind: string | null | undefined,
 ): PackageKind {
-  const name = packageName.toLowerCase();
-  const dir = directory.replace(/\\/g, "/").toLowerCase();
-
-  if (dir.includes("/integrations/") || dir.includes("service/integrations")) {
-    return "integration";
+  if (kind && (PACKAGE_KINDS as readonly string[]).includes(kind)) {
+    return kind as PackageKind;
   }
-  if (name.endsWith("-db") || name.includes("-db-") || /\/[^/]*-db$/.test(dir)) {
-    return "db";
-  }
-  if (
-    name.endsWith("-http") ||
-    name.includes("-http-") ||
-    /\/[^/]*-http$/.test(dir)
-  ) {
-    return "http";
-  }
-  if (
-    name.endsWith("-spec") ||
-    name.includes("-spec-") ||
-    /\/[^/]*-spec$/.test(dir)
-  ) {
-    return "spec";
-  }
-  if (
-    name.endsWith("-vue") ||
-    name.endsWith("-spa") ||
-    dir.includes("/clients/") ||
-    dir.includes("clients/")
-  ) {
-    return "spa";
-  }
-  if (name.endsWith("-sdk") || name.includes("-sdk-")) {
-    return "sdk";
-  }
-  if (
-    name.startsWith("@saflib/") &&
-    !name.includes("-db") &&
-    !name.includes("-http") &&
-    !name.includes("-spec") &&
-    !name.includes("-vue") &&
-    !name.includes("-sdk")
-  ) {
-    // Shared primitives: git, parser, express utils, etc.
-    if (
-      ["git", "parser", "utils", "node", "env", "drizzle", "openapi"].some(
-        (s) => name === `@saflib/${s}` || name.endsWith(`/${s}`),
-      )
-    ) {
-      return "lib";
-    }
-  }
-  if (
-    name.includes("/git") ||
-    name.endsWith("/parser") ||
-    name.endsWith("/utils")
-  ) {
-    return "lib";
-  }
-
   return "other";
 }

--- a/dev-site/dev-site-vue/pages/CheckoutPage.test.ts
+++ b/dev-site/dev-site-vue/pages/CheckoutPage.test.ts
@@ -1,0 +1,195 @@
+import { describe, it, expect, vi } from "vitest";
+import { stubGlobals } from "@saflib/vue/testing";
+import { setupMockServer } from "@saflib/sdk/testing/mock";
+import { http, HttpResponse, type PathParams } from "msw";
+import type { DevSiteResponseBody } from "@saflib/dev-site-spec";
+import CheckoutPage from "./CheckoutPage.vue";
+import { router } from "./test_router";
+import { mountTestApp } from "../test-app";
+import { packageMetricsFixture } from "../test-fixtures.ts";
+
+type CheckoutResponse = DevSiteResponseBody["getCheckout"][200];
+type DiffResponse = DevSiteResponseBody["diffCommits"][200];
+type ScanResponse = DevSiteResponseBody["executeScan"][200];
+type PackageResponse = DevSiteResponseBody["getCommitPackage"][200];
+
+const HEAD = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const BASE = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+function checkoutFixture(
+  partial: Partial<CheckoutResponse> = {},
+): CheckoutResponse {
+  return {
+    hash: HEAD,
+    message: "feature work",
+    authoredAt: "2026-01-02T00:00:00.000Z",
+    analyzed: true,
+    productRoot: "",
+    branch: "feature",
+    packages: [
+      packageMetricsFixture({
+        packageName: "@demo/keep",
+        directory: "products/keep",
+        sourceLines: 20,
+        testFiles: 1,
+        testLines: 5,
+      }),
+    ],
+    compareCandidates: ["main", "other"],
+    compare: {
+      againstRef: "main",
+      mergeBaseHash: BASE,
+      mergeBaseAnalyzed: false,
+      mergeBaseMessage: "fork parent",
+      mergeBaseAuthoredAt: "2026-01-01T00:00:00.000Z",
+    },
+    ...partial,
+  };
+}
+
+const emptyPackage: PackageResponse = {
+  packageDetail: {
+    commitHash: HEAD,
+    packageName: "@demo/keep",
+    directory: "products/keep",
+    sourceFiles: 1,
+    sourceLines: 20,
+    prodLines: 15,
+    testLines: 5,
+    testFiles: 1,
+    exports: [],
+    testCases: [],
+  },
+};
+
+const packageAndRepoHandlers = [
+  http.get("http://test.localhost:3000/api/commits/:hash/packages/:pkg", () =>
+    HttpResponse.json(emptyPackage),
+  ),
+  http.get("http://test.localhost:3000/api/repo/files", () =>
+    HttpResponse.json({ files: [] }),
+  ),
+  http.get("http://test.localhost:3000/api/repo/file", () =>
+    HttpResponse.json({ path: "package.json", content: "{}" }),
+  ),
+];
+
+describe("CheckoutPage compare query param", () => {
+  stubGlobals();
+  setupMockServer([
+    http.get<PathParams, never, CheckoutResponse>(
+      "http://test.localhost:3000/api/checkout",
+      () => HttpResponse.json(checkoutFixture()),
+    ),
+    http.post<PathParams, { commitHash?: string }, ScanResponse>(
+      "http://test.localhost:3000/api/scan",
+      async ({ request }) => {
+        const body = (await request.json()) as { commitHash?: string };
+        expect(body.commitHash).toBe(BASE);
+        return HttpResponse.json({
+          scanned: [BASE],
+          skipped: [],
+          failed: [],
+        });
+      },
+    ),
+    ...packageAndRepoHandlers,
+  ]);
+
+  it("offers Scan fork point when the merge-base is unscanned", async () => {
+    await router.push({ path: "/checkout", query: { compare: "main" } });
+    const wrapper = mountTestApp(CheckoutPage, {
+      propsData: { subdomain: "test" },
+    });
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain("Scan fork point");
+    });
+    expect(wrapper.text()).toContain("fork parent");
+    expect(wrapper.text()).toContain("Compare");
+
+    const scanBtn = wrapper
+      .findAllComponents({ name: "v-btn" })
+      .find((b) => b.text() === "Scan fork point");
+    expect(scanBtn).toBeDefined();
+    await scanBtn!.trigger("click");
+  });
+});
+
+describe("CheckoutPage compare package tree", () => {
+  stubGlobals();
+  setupMockServer([
+    http.get<PathParams, never, CheckoutResponse>(
+      "http://test.localhost:3000/api/checkout",
+      () =>
+        HttpResponse.json(
+          checkoutFixture({
+            compare: {
+              againstRef: "main",
+              mergeBaseHash: BASE,
+              mergeBaseAnalyzed: true,
+              mergeBaseMessage: "fork parent",
+              mergeBaseAuthoredAt: "2026-01-01T00:00:00.000Z",
+            },
+          }),
+        ),
+    ),
+    http.get<PathParams, never, DiffResponse>(
+      `http://test.localhost:3000/api/commits/${BASE}/diff/${HEAD}`,
+      () =>
+        HttpResponse.json({
+          commitDiff: {
+            fromHash: BASE,
+            toHash: HEAD,
+            packageMetrics: {
+              added: [],
+              removed: [
+                packageMetricsFixture({
+                  packageName: "@demo/gone",
+                  directory: "products/gone",
+                  sourceLines: 8,
+                  testFiles: 0,
+                  testLines: 0,
+                }),
+              ],
+              changed: [
+                {
+                  before: packageMetricsFixture({
+                    packageName: "@demo/keep",
+                    directory: "products/keep",
+                    sourceLines: 10,
+                  }),
+                  after: packageMetricsFixture({
+                    packageName: "@demo/keep",
+                    directory: "products/keep",
+                    sourceLines: 20,
+                    testFiles: 1,
+                    testLines: 5,
+                  }),
+                },
+              ],
+            },
+            exports: { added: [], removed: [] },
+            testCases: { added: [], removed: [] },
+            dbSchemas: {
+              tables: { added: [], removed: [] },
+              columns: { added: [], removed: [], changed: [] },
+            },
+          },
+        }),
+    ),
+    ...packageAndRepoHandlers,
+  ]);
+
+  it("lists removed packages after both commits are analyzed", async () => {
+    await router.push({ path: "/checkout", query: { compare: "main" } });
+    const wrapper = mountTestApp(CheckoutPage, {
+      propsData: { subdomain: "test" },
+    });
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain("gone");
+      expect(wrapper.text()).toContain("keep");
+    });
+    expect(wrapper.text()).toContain("removed");
+    expect(wrapper.text()).toContain("changed");
+  });
+});

--- a/dev-site/dev-site-vue/pages/CheckoutPage.test.ts
+++ b/dev-site/dev-site-vue/pages/CheckoutPage.test.ts
@@ -42,6 +42,7 @@ function checkoutFixture(
       mergeBaseAnalyzed: false,
       mergeBaseMessage: "fork parent",
       mergeBaseAuthoredAt: "2026-01-01T00:00:00.000Z",
+      renames: [],
     },
     ...partial,
   };
@@ -129,6 +130,7 @@ describe("CheckoutPage compare package tree", () => {
               mergeBaseAnalyzed: true,
               mergeBaseMessage: "fork parent",
               mergeBaseAuthoredAt: "2026-01-01T00:00:00.000Z",
+              renames: [],
             },
           }),
         ),
@@ -191,5 +193,19 @@ describe("CheckoutPage compare package tree", () => {
     });
     expect(wrapper.text()).toContain("removed");
     expect(wrapper.text()).toContain("changed");
+  });
+
+  it("shows source/test LOC delta next to the selected package name", async () => {
+    await router.push({
+      path: "/checkout",
+      query: { compare: "main", package: "@demo/keep" },
+    });
+    const wrapper = mountTestApp(CheckoutPage, {
+      propsData: { subdomain: "test" },
+    });
+    await vi.waitFor(() => {
+      expect(wrapper.text()).toContain("+10/+5 LOC");
+    });
+    expect(wrapper.get(".pkg-head__name").text()).toBe("@demo/keep");
   });
 });

--- a/dev-site/dev-site-vue/pages/CheckoutPage.vue
+++ b/dev-site/dev-site-vue/pages/CheckoutPage.vue
@@ -432,6 +432,7 @@ const mapPackageRow = (
   p: {
     packageName: string;
     directory: string;
+    kind?: string;
     sourceLines: number;
     testLines: number;
     testFiles: number;
@@ -448,7 +449,7 @@ const mapPackageRow = (
   locDelta?: { source: number; test: number },
 ) => ({
   ...p,
-  kind: classifyPackageKind(p.packageName, p.directory),
+  kind: classifyPackageKind(p.kind),
   size: classifyPackageSize({
     sourceLines: p.sourceLines,
     testFiles: p.testFiles,

--- a/dev-site/dev-site-vue/pages/CheckoutPage.vue
+++ b/dev-site/dev-site-vue/pages/CheckoutPage.vue
@@ -24,9 +24,59 @@
         >
           {{ checkout.analyzed ? "analyzed" : "not analyzed" }}
         </v-chip>
+        <v-switch
+          :model-value="compareMode"
+          hide-details
+          density="compact"
+          color="primary"
+          class="checkout-strip__compare"
+          label="Compare"
+          @update:model-value="toggleCompare"
+        />
+        <v-select
+          v-if="compareMode"
+          :model-value="compareRef"
+          :items="checkout.compareCandidates"
+          density="compact"
+          hide-details
+          variant="outlined"
+          class="checkout-strip__ref"
+          @update:model-value="setCompareRef"
+        />
+        <v-chip
+          v-if="compareMode && checkout.compare"
+          size="x-small"
+          variant="tonal"
+          :color="checkout.compare.mergeBaseAnalyzed ? 'success' : 'warning'"
+          class="checkout-strip__chip"
+        >
+          fork {{ shortHash(checkout.compare.mergeBaseHash) }}
+          ·
+          {{ checkout.compare.mergeBaseAnalyzed ? "analyzed" : "not analyzed" }}
+        </v-chip>
+        <v-btn
+          v-if="compareMode && checkout.compare && !checkout.compare.mergeBaseAnalyzed"
+          color="primary"
+          size="small"
+          variant="flat"
+          :loading="isScanning"
+          :disabled="isScanning"
+          @click="scanForkPoint"
+        >
+          Scan fork point
+        </v-btn>
       </div>
 
-      <div v-if="checkout.analyzed" class="checkout-body">
+      <div v-if="checkout.analyzed && isEmptyCompare" class="checkout-unscanned">
+        <p class="checkout-unscanned__title">Nothing unique on this checkout</p>
+        <p class="checkout-unscanned__body">
+          HEAD is the fork point of
+          <code>{{ checkout.compare?.againstRef }}</code>
+          — there are no commits unique to this branch to compare.
+        </p>
+      </div>
+
+      <div v-else-if="checkout.analyzed" class="checkout-body">
         <ResizableColumns
           storage-key="dev-site.checkout.packagesWidth"
           :default-left="200"
@@ -35,6 +85,19 @@
         >
           <template #left>
             <div class="checkout-col checkout-col--packages">
+              <v-alert
+                v-if="compareMode && checkout.compare && !checkout.compare.mergeBaseAnalyzed"
+                type="info"
+                density="compact"
+                variant="tonal"
+                class="mb-2"
+              >
+                Scan the fork point
+                <code>{{ shortHash(checkout.compare.mergeBaseHash) }}</code>
+                ({{ firstLine(checkout.compare.mergeBaseMessage) }})
+                to filter this tree to added, removed, and modified packages.
+              </v-alert>
+              <v-progress-linear v-if="isLoadingDiff" indeterminate class="mb-2" />
               <PackageDirTree
                 :nodes="dirTree"
                 :selected-package-name="selectedPackageName"
@@ -54,6 +117,7 @@
                   <span class="pkg-head__name" :title="selectedPkg.packageName">
                     {{ selectedPkg.packageName }}
                   </span>
+                  <ChangeChip :change="selectedPkg.change" />
                   <v-chip
                     size="x-small"
                     variant="tonal"
@@ -106,6 +170,7 @@
                     v-if="tab === 'spec' && selectedPkg.kind === 'db'"
                     :subdomain="subdomain"
                     :commit-hash="checkout.hash"
+                    :compare-from-hash="compareFromHash"
                     :package-name="selectedPkg.packageName"
                     :package-directory="selectedPkg.directory"
                     :product-root="checkout.productRoot"
@@ -119,6 +184,7 @@
                     v-else-if="tab === 'spec' && selectedPkg.kind === 'spec'"
                     :subdomain="subdomain"
                     :commit-hash="checkout.hash"
+                    :compare-from-hash="compareFromHash"
                     :package-name="selectedPkg.packageName"
                     :package-directory="selectedPkg.directory"
                     :product-root="checkout.productRoot"
@@ -130,6 +196,7 @@
                     v-else-if="tab === 'spec' && selectedPkg.kind === 'http'"
                     :subdomain="subdomain"
                     :commit-hash="checkout.hash"
+                    :compare-from-hash="compareFromHash"
                     :package-name="selectedPkg.packageName"
                     :package-directory="selectedPkg.directory"
                     :product-root="checkout.productRoot"
@@ -143,6 +210,7 @@
                     v-else-if="tab === 'spec' && selectedPkg.kind === 'sdk'"
                     :subdomain="subdomain"
                     :commit-hash="checkout.hash"
+                    :compare-from-hash="compareFromHash"
                     :package-name="selectedPkg.packageName"
                     :package-directory="selectedPkg.directory"
                     :product-root="checkout.productRoot"
@@ -156,6 +224,7 @@
                     v-else-if="tab === 'spec'"
                     :subdomain="subdomain"
                     :commit-hash="checkout.hash"
+                    :compare-from-hash="compareFromHash"
                     :package-name="selectedPkg.packageName"
                     :package-directory="selectedPkg.directory"
                     :product-root="checkout.productRoot"
@@ -169,7 +238,7 @@
                     v-else-if="tab === 'docs'"
                     ref="docsPane"
                     :subdomain="subdomain"
-                    :commit-hash="checkout.hash"
+                    :commit-hash="paneCommitHash"
                     :package-directory="selectedPkg.directory"
                     :package-name="selectedPkg.packageName"
                     :product-root="checkout.productRoot"
@@ -182,7 +251,7 @@
                   <PackageIssuesPane
                     v-else
                     :subdomain="subdomain"
-                    :commit-hash="checkout.hash"
+                    :commit-hash="paneCommitHash"
                     :package-name="selectedPkg.packageName"
                     :package-directory="selectedPkg.directory"
                     :product-root="checkout.productRoot"
@@ -192,6 +261,12 @@
                   />
                 </div>
               </template>
+              <p
+                v-else-if="compareReady && !visibleRows.length"
+                class="text-body-2 text-medium-emphasis pa-3"
+              >
+                No package changes versus the fork point.
+              </p>
               <p v-else class="text-body-2 text-medium-emphasis pa-3">
                 Select a package.
               </p>
@@ -224,7 +299,13 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
-import { useCheckout, useCommitPackage, useRepoFile, useScanMutation } from "../requests/queries";
+import {
+  useCheckout,
+  useCommitDiff,
+  useCommitPackage,
+  useRepoFile,
+  useScanMutation,
+} from "../requests/queries";
 import { classifyPackageKind } from "../package-kind";
 import {
   buildPackageDirTree,
@@ -241,6 +322,11 @@ import { repoPathPrefix } from "../repo-paths";
 import { formatLocPair } from "../format-loc";
 import type { TestScope } from "../test-tree";
 import { toModuleStem } from "../test-tree";
+import {
+  filterPackageDirTree,
+  packageChangesFromDiff,
+  type ChangeKind,
+} from "../package-change-overlay";
 import PackageDirTree from "../components/PackageDirTree.vue";
 import PackageDocsPane from "../components/PackageDocsPane.vue";
 import PackageSpecPane from "../components/PackageSpecPane.vue";
@@ -250,6 +336,7 @@ import PackageHttpPane from "../components/PackageHttpPane.vue";
 import PackageSdkPane from "../components/PackageSdkPane.vue";
 import PackageIssuesPane from "../components/PackageIssuesPane.vue";
 import ResizableColumns from "../components/ResizableColumns.vue";
+import ChangeChip from "../components/ChangeChip.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -270,12 +357,18 @@ const router = useRouter();
 
 const docsPane = ref<{ openDoc: (path: string) => void } | null>(null);
 
+const compareRef = computed(() => {
+  const q = route.query.compare;
+  return typeof q === "string" && q ? q : undefined;
+});
+const compareMode = computed(() => Boolean(compareRef.value));
+
 const {
   data: checkout,
   isLoading,
   error,
   refetch,
-} = useCheckout(props.subdomain);
+} = useCheckout(props.subdomain, compareRef);
 
 const {
   mutate: scan,
@@ -283,18 +376,94 @@ const {
   error: scanError,
 } = useScanMutation(props.subdomain);
 
-const packageRows = computed(() =>
-  (checkout.value?.packages ?? []).map((p) => ({
-    ...p,
-    kind: classifyPackageKind(p.packageName, p.directory),
-    size: classifyPackageSize({
-      sourceLines: p.sourceLines,
-      testFiles: p.testFiles,
-    }),
-  })),
+const compareReady = computed(() => {
+  const c = checkout.value;
+  return Boolean(
+    compareMode.value &&
+      c?.analyzed &&
+      c.compare?.mergeBaseAnalyzed &&
+      c.compare.mergeBaseHash !== c.hash,
+  );
+});
+
+const isEmptyCompare = computed(() => {
+  const c = checkout.value;
+  return Boolean(
+    compareMode.value && c?.compare && c.compare.mergeBaseHash === c.hash,
+  );
+});
+
+const compareFromHash = computed(() =>
+  compareReady.value ? checkout.value?.compare?.mergeBaseHash : undefined,
 );
 
-const dirTree = computed(() => buildPackageDirTree(packageRows.value));
+const {
+  data: diffData,
+  isLoading: isLoadingDiff,
+} = useCommitDiff(
+  props.subdomain,
+  () => (compareReady.value ? checkout.value?.compare?.mergeBaseHash ?? "" : ""),
+  () => (compareReady.value ? checkout.value?.hash ?? "" : ""),
+);
+
+const changeByPackage = computed((): Record<string, ChangeKind> => {
+  const diff = diffData.value?.commitDiff;
+  if (!compareReady.value || !diff) return {};
+  return packageChangesFromDiff(diff);
+});
+
+const mapPackageRow = (
+  p: {
+    packageName: string;
+    directory: string;
+    sourceLines: number;
+    testLines: number;
+    testFiles: number;
+    debtCount?: number;
+    issueCountsByKind?: {
+      "dead-code": number;
+      "oversized-file": number;
+      "package-layout": number;
+    };
+    sourceFiles?: number;
+    prodLines?: number;
+  },
+  change?: ChangeKind,
+) => ({
+  ...p,
+  kind: classifyPackageKind(p.packageName, p.directory),
+  size: classifyPackageSize({
+    sourceLines: p.sourceLines,
+    testFiles: p.testFiles,
+  }),
+  change,
+});
+
+const headRows = computed(() =>
+  (checkout.value?.packages ?? []).map((p) => mapPackageRow(p)),
+);
+
+const visibleRows = computed(() => {
+  if (!compareReady.value) return headRows.value;
+  const changes = changeByPackage.value;
+  const byName = new Map(headRows.value.map((p) => [p.packageName, p]));
+  const removed = diffData.value?.commitDiff?.packageMetrics.removed ?? [];
+  const rows = [];
+  for (const [name, change] of Object.entries(changes)) {
+    const head = byName.get(name);
+    const gone = removed.find((p) => p.packageName === name);
+    const src = head ?? gone;
+    if (!src) continue;
+    rows.push(mapPackageRow(src, change));
+  }
+  return rows.sort((a, b) => a.directory.localeCompare(b.directory));
+});
+
+const dirTree = computed(() => {
+  const tree = buildPackageDirTree(visibleRows.value);
+  if (!compareReady.value) return tree;
+  return filterPackageDirTree(tree, changeByPackage.value);
+});
 
 const selectedPackageName = computed(() => {
   const q = route.query.package;
@@ -302,12 +471,19 @@ const selectedPackageName = computed(() => {
 });
 
 const selectedPkg = computed(() =>
-  packageRows.value.find((p) => p.packageName === selectedPackageName.value),
+  visibleRows.value.find((p) => p.packageName === selectedPackageName.value),
 );
+
+const paneCommitHash = computed(() => {
+  if (selectedPkg.value?.change === "removed") {
+    return checkout.value?.compare?.mergeBaseHash ?? "";
+  }
+  return checkout.value?.analyzed ? checkout.value.hash : "";
+});
 
 const { data: packageDetailData } = useCommitPackage(
   props.subdomain,
-  () => (checkout.value?.analyzed ? checkout.value.hash : ""),
+  paneCommitHash,
   () => selectedPackageName.value,
 );
 
@@ -373,16 +549,16 @@ const setSpecScope = (scope: TestScope) => {
 };
 
 const packageJsonPath = computed(() => {
-  if (!selectedPkg.value || !checkout.value?.analyzed) return "";
+  if (!selectedPkg.value || !paneCommitHash.value) return "";
   const prefix = repoPathPrefix(
-    checkout.value.productRoot,
+    checkout.value?.productRoot ?? "",
     selectedPkg.value.directory,
   );
   return prefix ? `${prefix}/package.json` : "package.json";
 });
 
 const { data: packageJsonFile } = useRepoFile(props.subdomain, () => ({
-  ref: checkout.value?.analyzed ? checkout.value.hash : "",
+  ref: paneCommitHash.value,
   path: packageJsonPath.value,
 }));
 
@@ -393,16 +569,17 @@ const packageDescription = computed(() => {
 });
 
 watch(
-  [checkout, selectedPackageName],
+  [checkout, selectedPackageName, visibleRows, isEmptyCompare],
   () => {
-    if (!checkout.value?.analyzed || !packageRows.value.length) return;
+    if (!checkout.value?.analyzed || isEmptyCompare.value) return;
+    if (!visibleRows.value.length) return;
     if (
       selectedPackageName.value &&
-      packageRows.value.some((p) => p.packageName === selectedPackageName.value)
+      visibleRows.value.some((p) => p.packageName === selectedPackageName.value)
     ) {
       return;
     }
-    const first = packageRows.value[0];
+    const first = visibleRows.value[0];
     if (first) {
       replaceQuery({ package: first.packageName });
     }
@@ -439,6 +616,31 @@ const scanThisCommit = () => {
   );
 };
 
+const scanForkPoint = () => {
+  const hash = checkout.value?.compare?.mergeBaseHash;
+  if (!hash) return;
+  scan({ commitHash: hash }, { onSuccess: () => refetch() });
+};
+
+const toggleCompare = (on: unknown) => {
+  if (!on) {
+    replaceQuery({ compare: undefined });
+    return;
+  }
+  const ref =
+    compareRef.value ||
+    checkout.value?.compare?.againstRef ||
+    checkout.value?.compareCandidates?.[0] ||
+    "main";
+  replaceQuery({ compare: ref });
+};
+
+const setCompareRef = (value: unknown) => {
+  if (typeof value === "string" && value) {
+    replaceQuery({ compare: value });
+  }
+};
+
 const shortHash = (hash: string) => hash.slice(0, 10);
 const firstLine = (message: string) => message.split("\n")[0] ?? message;
 const formatDateTime = (dateTimeString: string): string => {
@@ -468,11 +670,19 @@ const formatDateTime = (dateTimeString: string): string => {
   flex: 0 0 auto;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: 0.65rem;
   padding: 0.35rem 0.75rem;
   border-bottom: 1px solid rgba(var(--v-theme-on-surface), 0.12);
   font-size: 0.75rem;
   min-width: 0;
+}
+.checkout-strip__compare {
+  flex: 0 0 auto;
+  margin: 0;
+}
+.checkout-strip__ref {
+  flex: 0 0 9rem;
 }
 .checkout-strip__hash {
   flex: 0 0 auto;

--- a/dev-site/dev-site-vue/pages/CheckoutPage.vue
+++ b/dev-site/dev-site-vue/pages/CheckoutPage.vue
@@ -117,6 +117,13 @@
                   <span class="pkg-head__name" :title="selectedPkg.packageName">
                     {{ selectedPkg.packageName }}
                   </span>
+                  <span
+                    v-if="locDeltaText"
+                    class="pkg-head__delta"
+                    :title="'Source/test LOC vs fork point'"
+                  >
+                    {{ locDeltaText }}
+                  </span>
                   <ChangeChip :change="selectedPkg.change" />
                   <v-chip
                     size="x-small"
@@ -171,6 +178,7 @@
                     :subdomain="subdomain"
                     :commit-hash="checkout.hash"
                     :compare-from-hash="compareFromHash"
+                    :path-renames="pathRenames"
                     :package-name="selectedPkg.packageName"
                     :package-directory="selectedPkg.directory"
                     :product-root="checkout.productRoot"
@@ -185,6 +193,7 @@
                     :subdomain="subdomain"
                     :commit-hash="checkout.hash"
                     :compare-from-hash="compareFromHash"
+                    :path-renames="pathRenames"
                     :package-name="selectedPkg.packageName"
                     :package-directory="selectedPkg.directory"
                     :product-root="checkout.productRoot"
@@ -197,6 +206,7 @@
                     :subdomain="subdomain"
                     :commit-hash="checkout.hash"
                     :compare-from-hash="compareFromHash"
+                    :path-renames="pathRenames"
                     :package-name="selectedPkg.packageName"
                     :package-directory="selectedPkg.directory"
                     :product-root="checkout.productRoot"
@@ -211,6 +221,7 @@
                     :subdomain="subdomain"
                     :commit-hash="checkout.hash"
                     :compare-from-hash="compareFromHash"
+                    :path-renames="pathRenames"
                     :package-name="selectedPkg.packageName"
                     :package-directory="selectedPkg.directory"
                     :product-root="checkout.productRoot"
@@ -225,6 +236,7 @@
                     :subdomain="subdomain"
                     :commit-hash="checkout.hash"
                     :compare-from-hash="compareFromHash"
+                    :path-renames="pathRenames"
                     :package-name="selectedPkg.packageName"
                     :package-directory="selectedPkg.directory"
                     :product-root="checkout.productRoot"
@@ -319,7 +331,7 @@ import {
 import { parsePackageDescription } from "../scope-docs";
 import { collectPackageIssues } from "../package-issues";
 import { repoPathPrefix } from "../repo-paths";
-import { formatLocPair } from "../format-loc";
+import { formatLocChangePair, formatLocPair } from "../format-loc";
 import type { TestScope } from "../test-tree";
 import { toModuleStem } from "../test-tree";
 import {
@@ -397,6 +409,10 @@ const compareFromHash = computed(() =>
   compareReady.value ? checkout.value?.compare?.mergeBaseHash : undefined,
 );
 
+const pathRenames = computed(
+  () => checkout.value?.compare?.renames ?? [],
+);
+
 const {
   data: diffData,
   isLoading: isLoadingDiff,
@@ -429,6 +445,7 @@ const mapPackageRow = (
     prodLines?: number;
   },
   change?: ChangeKind,
+  locDelta?: { source: number; test: number },
 ) => ({
   ...p,
   kind: classifyPackageKind(p.packageName, p.directory),
@@ -437,6 +454,7 @@ const mapPackageRow = (
     testFiles: p.testFiles,
   }),
   change,
+  locDelta,
 });
 
 const headRows = computed(() =>
@@ -448,13 +466,28 @@ const visibleRows = computed(() => {
   const changes = changeByPackage.value;
   const byName = new Map(headRows.value.map((p) => [p.packageName, p]));
   const removed = diffData.value?.commitDiff?.packageMetrics.removed ?? [];
+  const changed = diffData.value?.commitDiff?.packageMetrics.changed ?? [];
   const rows = [];
   for (const [name, change] of Object.entries(changes)) {
     const head = byName.get(name);
     const gone = removed.find((p) => p.packageName === name);
     const src = head ?? gone;
     if (!src) continue;
-    rows.push(mapPackageRow(src, change));
+    let locDelta: { source: number; test: number } | undefined;
+    if (change === "added") {
+      locDelta = { source: src.sourceLines, test: src.testLines };
+    } else if (change === "removed") {
+      locDelta = { source: -src.sourceLines, test: -src.testLines };
+    } else {
+      const pair = changed.find((c) => c.after.packageName === name);
+      locDelta = pair
+        ? {
+            source: pair.after.sourceLines - pair.before.sourceLines,
+            test: pair.after.testLines - pair.before.testLines,
+          }
+        : { source: 0, test: 0 };
+    }
+    rows.push(mapPackageRow(src, change, locDelta));
   }
   return rows.sort((a, b) => a.directory.localeCompare(b.directory));
 });
@@ -473,6 +506,12 @@ const selectedPackageName = computed(() => {
 const selectedPkg = computed(() =>
   visibleRows.value.find((p) => p.packageName === selectedPackageName.value),
 );
+
+const locDeltaText = computed(() => {
+  const d = selectedPkg.value?.locDelta;
+  if (!d || (d.source === 0 && d.test === 0)) return "";
+  return `${formatLocChangePair(d.source, d.test)} LOC`;
+});
 
 const paneCommitHash = computed(() => {
   if (selectedPkg.value?.change === "removed") {
@@ -763,6 +802,13 @@ const formatDateTime = (dateTimeString: string): string => {
   text-overflow: ellipsis;
   white-space: nowrap;
   max-width: min(28rem, 55vw);
+}
+.pkg-head__delta {
+  flex: 0 0 auto;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: rgba(var(--v-theme-on-surface), 0.7);
 }
 .pkg-head__meta {
   font-size: 0.7rem;

--- a/dev-site/dev-site-vue/pages/PackageMapPage.vue
+++ b/dev-site/dev-site-vue/pages/PackageMapPage.vue
@@ -62,10 +62,7 @@ const pkgMeta = computed(() =>
 
 const kind = computed<PackageKind | null>(() => {
   if (!pkgMeta.value) return null;
-  return classifyPackageKind(
-    pkgMeta.value.packageName,
-    pkgMeta.value.directory,
-  );
+  return classifyPackageKind(pkgMeta.value.kind);
 });
 
 const upcomingSurfaces = computed(() =>

--- a/dev-site/dev-site-vue/pages/TimelinePage.test.ts
+++ b/dev-site/dev-site-vue/pages/TimelinePage.test.ts
@@ -73,6 +73,7 @@ const mockCheckout: CheckoutResponse = {
   productRoot: "",
   branch: "main",
   packages: [],
+  compareCandidates: ["main"],
 };
 
 const handlers = [

--- a/dev-site/dev-site-vue/requests/queries.ts
+++ b/dev-site/dev-site-vue/requests/queries.ts
@@ -86,22 +86,37 @@ export function useCommitPackage(
   subdomain: string,
   hash: MaybeRefOrGetter<string>,
   packageName: MaybeRefOrGetter<string>,
+  options: { allowMissing?: MaybeRefOrGetter<boolean> } = {},
 ) {
   const client = createDevSiteClient(subdomain);
-  return useQuery<DevSiteResponseBody["getCommitPackage"][200], TanstackError>({
+  return useQuery<
+    DevSiteResponseBody["getCommitPackage"][200] | null,
+    TanstackError
+  >({
     queryKey: ["dev-site", "commit-package", hash, packageName],
     enabled: () => Boolean(toValue(hash) && toValue(packageName)),
-    queryFn: () => {
-      return handleClientMethod(
-        client.GET("/api/commits/{hash}/packages/{packageName}", {
-          params: {
-            path: {
-              hash: toValue(hash),
-              packageName: toValue(packageName),
+    queryFn: async () => {
+      try {
+        return await handleClientMethod(
+          client.GET("/api/commits/{hash}/packages/{packageName}", {
+            params: {
+              path: {
+                hash: toValue(hash),
+                packageName: toValue(packageName),
+              },
             },
-          },
-        }),
-      );
+          }),
+        );
+      } catch (err) {
+        if (
+          toValue(options.allowMissing) &&
+          err instanceof TanstackError &&
+          err.status === 404
+        ) {
+          return null;
+        }
+        throw err;
+      }
     },
   });
 }
@@ -146,15 +161,28 @@ export function useScanMutation(subdomain: string) {
       queryClient.invalidateQueries({ queryKey: ["dev-site", "checkout"] });
       queryClient.invalidateQueries({ queryKey: ["dev-site", "commit"] });
       queryClient.invalidateQueries({ queryKey: ["dev-site", "commit-package"] });
+      queryClient.invalidateQueries({ queryKey: ["dev-site", "diff"] });
     },
   });
 }
 
-export function useCheckout(subdomain: string) {
+export function useCheckout(
+  subdomain: string,
+  compareRef: MaybeRefOrGetter<string | undefined> = undefined,
+) {
   const client = createDevSiteClient(subdomain);
   return useQuery<DevSiteResponseBody["getCheckout"][200], TanstackError>({
-    queryKey: ["dev-site", "checkout"],
-    queryFn: () => handleClientMethod(client.GET("/api/checkout")),
+    queryKey: ["dev-site", "checkout", compareRef],
+    queryFn: () => {
+      const ref = toValue(compareRef);
+      return handleClientMethod(
+        client.GET("/api/checkout", {
+          params: {
+            query: ref ? { compareRef: ref } : {},
+          },
+        }),
+      );
+    },
   });
 }
 

--- a/dev-site/dev-site-vue/test-tree.ts
+++ b/dev-site/dev-site-vue/test-tree.ts
@@ -34,7 +34,7 @@ export interface TestTreeNode {
     repoPath: string;
   }> | null;
   /** Present in Checkout compare mode. */
-  change?: "added" | "removed" | "modified";
+  change?: "added" | "removed" | "modified" | "moved";
 }
 
 /** Colocated source/test pairing for Spec nav. */
@@ -66,7 +66,9 @@ export interface TestFileNavNode {
   /** Repo path to the colocated test file when present. */
   testRepoPath?: string | null;
   /** Present in Checkout compare mode for file (module) nodes. */
-  change?: "added" | "removed" | "modified";
+  change?: "added" | "removed" | "modified" | "moved";
+  /** Previous module stem when `change` is `moved`. */
+  movedFrom?: string;
 }
 
 export type TestScope =
@@ -86,7 +88,7 @@ export interface ExportLike {
     filePath: string;
     repoPath: string;
   }> | null;
-  change?: "added" | "removed" | "modified";
+  change?: "added" | "removed" | "modified" | "moved";
 }
 
 const TEST_SUFFIX_RE = /\.(test|spec)\.(tsx?|jsx?|mjs|cjs)$/i;

--- a/dev-site/dev-site-vue/test-tree.ts
+++ b/dev-site/dev-site-vue/test-tree.ts
@@ -33,6 +33,8 @@ export interface TestTreeNode {
     filePath: string;
     repoPath: string;
   }> | null;
+  /** Present in Checkout compare mode. */
+  change?: "added" | "removed" | "modified";
 }
 
 /** Colocated source/test pairing for Spec nav. */
@@ -63,6 +65,8 @@ export interface TestFileNavNode {
   sourceRepoPath?: string | null;
   /** Repo path to the colocated test file when present. */
   testRepoPath?: string | null;
+  /** Present in Checkout compare mode for file (module) nodes. */
+  change?: "added" | "removed" | "modified";
 }
 
 export type TestScope =
@@ -82,6 +86,7 @@ export interface ExportLike {
     filePath: string;
     repoPath: string;
   }> | null;
+  change?: "added" | "removed" | "modified";
 }
 
 const TEST_SUFFIX_RE = /\.(test|spec)\.(tsx?|jsx?|mjs|cjs)$/i;
@@ -218,7 +223,7 @@ function addSuitesAndLeaf(fileNode: TestTreeNode, t: TestCaseLike): void {
     node = ensureChild(node, suite, "suite");
     attachSubjectToSuite(node, t, suite);
   }
-  ensureChild(node, leaf, "test");
+  ensureChild(node, leaf, "test", t.filePath);
 }
 
 function packageTests(

--- a/dev-tools/package.json
+++ b/dev-tools/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/dev-tools",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Tools for software development",
   "private": true,
   "type": "module",

--- a/drizzle/package.json
+++ b/drizzle/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/drizzle",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Tools, docs, and workflows for using drizzle + better-sqlite3",
   "type": "module",
   "exports": {

--- a/drizzle/workflows/templates/package.json
+++ b/drizzle/workflows/templates/package.json
@@ -1,5 +1,8 @@
 {
   "name": "template-package-db",
+  "saf": {
+    "kind": "db"
+  },
   "description": "Database package for __service-name__.",
   "private": true,
   "type": "module",

--- a/email/email/package.json
+++ b/email/email/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/email",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Centralized package for sending emails via SMTP. DEPRECATED: Use @saflib/email-service instead.",
   "private": true,
   "type": "module",

--- a/env/package.json
+++ b/env/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/env",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Specify, share, and enforce environment variables",
   "private": true,
   "type": "module",

--- a/express/package.json
+++ b/express/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/express",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Shared Express.js utilities for SAF services",
   "type": "module",
   "scripts": {

--- a/express/workflows/templates/package.json
+++ b/express/workflows/templates/package.json
@@ -1,5 +1,8 @@
 {
   "name": "template-package-http",
+  "saf": {
+    "kind": "http"
+  },
   "description": "HTTP server for the __service-name__ service",
   "type": "module",
   "exports": {

--- a/git/index.test.ts
+++ b/git/index.test.ts
@@ -13,6 +13,7 @@ import {
   GitCommandError,
   isAncestor,
   mergeBase,
+  listRenames,
   listRefs,
   listTree,
   log,
@@ -262,5 +263,44 @@ describe("mergeBase diverging branches", () => {
     const { result, error } = mergeBase(repoRoot, "feature", "main");
     expect(error).toBeUndefined();
     expect(result).toBe(fork);
+  });
+});
+
+describe("listRenames", () => {
+  let repoRoot: string;
+  let before: string;
+  let after: string;
+
+  beforeAll(() => {
+    repoRoot = mkdtempSync(join(tmpdir(), "saflib-git-renames-"));
+    git(repoRoot, ["init"]);
+    git(repoRoot, ["checkout", "-b", "main"]);
+    mkdirSync(join(repoRoot, "src"));
+    writeFileSync(join(repoRoot, "src/old.ts"), "export const n = 1;\n");
+    git(repoRoot, ["add", "src/old.ts"]);
+    git(repoRoot, ["commit", "-m", "add old.ts"]);
+    before = git(repoRoot, ["rev-parse", "HEAD"]);
+
+    git(repoRoot, ["mv", "src/old.ts", "src/new.ts"]);
+    git(repoRoot, ["commit", "-m", "rename old.ts to new.ts"]);
+    after = git(repoRoot, ["rev-parse", "HEAD"]);
+  });
+
+  afterAll(() => {
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it("returns git find-renames pairs", () => {
+    const { result, error } = listRenames(repoRoot, before, after);
+    expect(error).toBeUndefined();
+    expect(result).toEqual([
+      { fromPath: "src/old.ts", toPath: "src/new.ts", score: 100 },
+    ]);
+  });
+
+  it("returns an empty list when nothing was renamed", () => {
+    const { result, error } = listRenames(repoRoot, before, before);
+    expect(error).toBeUndefined();
+    expect(result).toEqual([]);
   });
 });

--- a/git/index.test.ts
+++ b/git/index.test.ts
@@ -12,6 +12,7 @@ import { execFileSync } from "node:child_process";
 import {
   GitCommandError,
   isAncestor,
+  mergeBase,
   listRefs,
   listTree,
   log,
@@ -143,6 +144,26 @@ describe("@saflib/git", () => {
     });
   });
 
+  describe("mergeBase", () => {
+    it("returns the earlier commit when the later one is a descendant", () => {
+      const { result, error } = mergeBase(repoRoot, commit1, commit3);
+      expect(error).toBeUndefined();
+      expect(result).toBe(commit1);
+    });
+
+    it("returns the commit itself when both sides are the same", () => {
+      const { result, error } = mergeBase(repoRoot, commit3, commit3);
+      expect(error).toBeUndefined();
+      expect(result).toBe(commit3);
+    });
+
+    it("returns GitCommandError for a missing ref", () => {
+      const { result, error } = mergeBase(repoRoot, "HEAD", "no-such-ref");
+      expect(result).toBeUndefined();
+      expect(error).toBeInstanceOf(GitCommandError);
+    });
+  });
+
   describe("readBlob", () => {
     it("returns exact file contents for a blob hash", () => {
       const tree = listTree(repoRoot, commit3);
@@ -206,5 +227,40 @@ describe("@saflib/git", () => {
       expect(result!.get(uni.blobHash)).toBe("café 日本語 🎉\n");
       expect(result!.get(a.blobHash)).toBe("alpha\nbeta\n");
     });
+  });
+});
+
+describe("mergeBase diverging branches", () => {
+  let repoRoot: string;
+  let fork: string;
+
+  beforeAll(() => {
+    repoRoot = mkdtempSync(join(tmpdir(), "saflib-git-merge-base-"));
+    git(repoRoot, ["init"]);
+    git(repoRoot, ["checkout", "-b", "main"]);
+    writeFileSync(join(repoRoot, "a.txt"), "a\n");
+    git(repoRoot, ["add", "a.txt"]);
+    git(repoRoot, ["commit", "-m", "root"]);
+    fork = git(repoRoot, ["rev-parse", "HEAD"]);
+
+    git(repoRoot, ["checkout", "-b", "feature"]);
+    writeFileSync(join(repoRoot, "feat.txt"), "f\n");
+    git(repoRoot, ["add", "feat.txt"]);
+    git(repoRoot, ["commit", "-m", "feature"]);
+
+    git(repoRoot, ["checkout", "main"]);
+    writeFileSync(join(repoRoot, "main.txt"), "m\n");
+    git(repoRoot, ["add", "main.txt"]);
+    git(repoRoot, ["commit", "-m", "main forward"]);
+  });
+
+  afterAll(() => {
+    rmSync(repoRoot, { recursive: true, force: true });
+  });
+
+  it("returns the fork point of feature vs main", () => {
+    const { result, error } = mergeBase(repoRoot, "feature", "main");
+    expect(error).toBeUndefined();
+    expect(result).toBe(fork);
   });
 });

--- a/git/index.ts
+++ b/git/index.ts
@@ -5,6 +5,7 @@ export { readBlob, readBlobs } from "./read-blob.ts";
 export { listRefs } from "./list-refs.ts";
 export { isAncestor } from "./is-ancestor.ts";
 export { mergeBase } from "./merge-base.ts";
+export { listRenames } from "./list-renames.ts";
 export { resolveRef } from "./resolve-ref.ts";
 export { currentBranch } from "./current-branch.ts";
 export type { GitRef } from "./list-refs.ts";

--- a/git/index.ts
+++ b/git/index.ts
@@ -4,6 +4,7 @@ export { listTree } from "./list-tree.ts";
 export { readBlob, readBlobs } from "./read-blob.ts";
 export { listRefs } from "./list-refs.ts";
 export { isAncestor } from "./is-ancestor.ts";
+export { mergeBase } from "./merge-base.ts";
 export { resolveRef } from "./resolve-ref.ts";
 export { currentBranch } from "./current-branch.ts";
 export type { GitRef } from "./list-refs.ts";

--- a/git/list-renames.ts
+++ b/git/list-renames.ts
@@ -1,0 +1,47 @@
+import type { ReturnsError } from "@saflib/monorepo";
+import type { GitCommandError } from "./errors.ts";
+import { execGit } from "./exec-git.ts";
+
+export interface GitRename {
+  fromPath: string;
+  toPath: string;
+  /** Similarity 0–100 from `git diff --find-renames` (`R090` → 90). */
+  score: number;
+}
+
+/**
+ * File rename pairs from `fromRef` to `toRef` (`git diff --find-renames -z --name-status --diff-filter=R`).
+ */
+export function listRenames(
+  repoRoot: string,
+  fromRef: string,
+  toRef: string,
+): ReturnsError<GitRename[], GitCommandError> {
+  const { result, error } = execGit(repoRoot, [
+    "diff",
+    "-z",
+    "--find-renames",
+    "--name-status",
+    "--diff-filter=R",
+    fromRef,
+    toRef,
+  ]);
+  if (error) return { error };
+  return { result: parseRenameNameStatus(result) };
+}
+
+export function parseRenameNameStatus(stdout: string): GitRename[] {
+  const parts = stdout.split("\0").filter((p) => p.length > 0);
+  const out: GitRename[] = [];
+  for (let i = 0; i + 2 < parts.length; i += 3) {
+    const status = parts[i]!;
+    const match = /^R(\d{3})$/.exec(status);
+    if (!match) continue;
+    out.push({
+      fromPath: parts[i + 1]!,
+      toPath: parts[i + 2]!,
+      score: Number(match[1]),
+    });
+  }
+  return out;
+}

--- a/git/merge-base.ts
+++ b/git/merge-base.ts
@@ -1,0 +1,16 @@
+import type { ReturnsError } from "@saflib/monorepo";
+import type { GitCommandError } from "./errors.ts";
+import { execGit } from "./exec-git.ts";
+
+/**
+ * Best common ancestor of two commits/refs (`git merge-base <a> <b>`).
+ */
+export function mergeBase(
+  repoRoot: string,
+  a: string,
+  b: string,
+): ReturnsError<string, GitCommandError> {
+  const { result, error } = execGit(repoRoot, ["merge-base", a, b]);
+  if (error) return { error };
+  return { result: result.trim() };
+}

--- a/git/package.json
+++ b/git/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/git",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Thin git plumbing wrappers (log / ls-tree / cat-file) — no checkout required",
   "private": true,
   "type": "module",

--- a/grpc/grpc/package.json
+++ b/grpc/grpc/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/grpc",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "gRPC servicer utilities",
   "private": true,
   "type": "module",

--- a/imports/package.json
+++ b/imports/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/imports",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "SAF import-graph measurement and enforcement tooling",
   "private": true,
   "type": "module",

--- a/integrations/package.json
+++ b/integrations/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/integrations",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Workflows and templates for initializing third-party integration packages",
   "private": true,
   "type": "module",

--- a/integrations/workflows/templates/package.json
+++ b/integrations/workflows/templates/package.json
@@ -1,5 +1,8 @@
 {
   "name": "template-integration",
+  "saf": {
+    "kind": "integration"
+  },
   "description": "TODO: Add package description",
   "private": true,
   "type": "module",

--- a/jobs/jobs/package.json
+++ b/jobs/jobs/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/jobs",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Async jobs runtime, HTTP surfaces, and enqueue client",
   "private": true,
   "type": "module",

--- a/links/package.json
+++ b/links/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/links",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Simple library for defining and working with links across subdomains, clients, and services",
   "private": true,
   "type": "module",

--- a/monorepo/index.ts
+++ b/monorepo/index.ts
@@ -81,6 +81,18 @@ export {
   type PackageLayoutIssueKind,
 } from "./src/package-layout.ts";
 
+export {
+  PACKAGE_KINDS,
+  PACKAGE_KIND_IDENTIFIERS,
+  classifySafPackage,
+  hasSdkRequestsExport,
+  isPackageKind,
+  parseSafPackageJson,
+  type PackageKind,
+  type PackageKindClassification,
+  type SafPackageJson,
+} from "./src/package-kind.ts";
+
 // Hack so TS doesn't complain about dirname and filename
 declare global {
   interface ImportMeta {

--- a/monorepo/package.json
+++ b/monorepo/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/monorepo",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Library and docs for projects which use the SAF monorepo structure and conventions",
   "type": "module",
   "exports": {
@@ -9,7 +12,8 @@
     "./eslint.config.js": "./eslint.config.js",
     "./dev": "./dev.ts",
     "./workspace": "./src/workspace.ts",
-    "./package-layout": "./src/package-layout.ts"
+    "./package-layout": "./src/package-layout.ts",
+    "./package-kind": "./src/package-kind.ts"
   },
   "scripts": {
     "test": "vitest run",

--- a/monorepo/src/package-kind.test.ts
+++ b/monorepo/src/package-kind.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from "vitest";
+import {
+  classifySafPackage,
+  hasSdkRequestsExport,
+  isPackageKind,
+  parseSafPackageJson,
+} from "./package-kind.ts";
+
+describe("isPackageKind", () => {
+  it("accepts known kinds", () => {
+    expect(isPackageKind("db")).toBe(true);
+    expect(isPackageKind("spec")).toBe(true);
+    expect(isPackageKind("nope")).toBe(false);
+  });
+});
+
+describe("parseSafPackageJson", () => {
+  it("parses objects and rejects junk", () => {
+    expect(parseSafPackageJson('{"name":"@scope/db"}')?.name).toBe("@scope/db");
+    expect(parseSafPackageJson("not-json")).toBeUndefined();
+    expect(parseSafPackageJson("[]")).toBeUndefined();
+  });
+});
+
+describe("hasSdkRequestsExport", () => {
+  it("detects ./requests subpaths", () => {
+    expect(hasSdkRequestsExport({ "./requests/*": "./requests/*.ts" })).toBe(
+      true,
+    );
+    expect(hasSdkRequestsExport({ ".": "./index.ts" })).toBe(false);
+    expect(hasSdkRequestsExport("./index.ts")).toBe(false);
+  });
+});
+
+describe("classifySafPackage", () => {
+  it("uses saf.kind when present", () => {
+    expect(
+      classifySafPackage({
+        name: "@scope/cron",
+        saf: { kind: "lib" },
+        dependencies: { "@saflib/drizzle": "*" },
+      }).kind,
+    ).toBe("lib");
+  });
+
+  it("infers from a unique identifier dependency", () => {
+    expect(
+      classifySafPackage({
+        name: "@scope/billing-db",
+        dependencies: { "@saflib/drizzle": "*" },
+      }).kind,
+    ).toBe("db");
+    expect(
+      classifySafPackage({
+        name: "@scope/billing-http",
+        dependencies: { "@saflib/express": "*" },
+      }).kind,
+    ).toBe("http");
+    expect(
+      classifySafPackage({
+        name: "@scope/billing-spec",
+        dependencies: { "@saflib/openapi": "*" },
+      }).kind,
+    ).toBe("spec");
+    expect(
+      classifySafPackage({
+        name: "@scope/account-spa",
+        dependencies: { "@saflib/vue": "*" },
+      }).kind,
+    ).toBe("spa");
+    expect(
+      classifySafPackage({
+        name: "@scope/billing-sdk",
+        dependencies: { "@saflib/sdk": "*" },
+      }).kind,
+    ).toBe("sdk");
+  });
+
+  it("treats identifier packages themselves as lib", () => {
+    expect(
+      classifySafPackage({
+        name: "@saflib/drizzle",
+        dependencies: {},
+      }).kind,
+    ).toBe("lib");
+    expect(
+      classifySafPackage({
+        name: "@saflib/express",
+        dependencies: { "@saflib/openapi": "*" },
+      }),
+    ).toEqual({ kind: "lib", mixedIdentifiers: [] });
+    expect(
+      classifySafPackage({
+        name: "@saflib/vue",
+        dependencies: { "@saflib/sdk": "*" },
+      }).kind,
+    ).toBe("lib");
+  });
+
+  it("flags mixed layer identifiers and does not infer a kind", () => {
+    expect(
+      classifySafPackage({
+        name: "@scope/http-and-db",
+        dependencies: {
+          "@saflib/drizzle": "*",
+          "@saflib/express": "*",
+        },
+      }),
+    ).toEqual({
+      kind: "other",
+      mixedIdentifiers: ["@saflib/drizzle", "@saflib/express"],
+    });
+  });
+
+  it("keeps saf.kind when layers are mixed", () => {
+    expect(
+      classifySafPackage({
+        name: "@scope/http-and-db",
+        saf: { kind: "http" },
+        dependencies: {
+          "@saflib/drizzle": "*",
+          "@saflib/express": "*",
+        },
+      }),
+    ).toEqual({
+      kind: "http",
+      mixedIdentifiers: ["@saflib/drizzle", "@saflib/express"],
+    });
+  });
+
+  it("splits sdk vs spa when both client identifiers are present", () => {
+    expect(
+      classifySafPackage({
+        name: "@scope/billing-sdk",
+        dependencies: { "@saflib/sdk": "*", "@saflib/vue": "*" },
+        exports: { "./requests/*": "./requests/*.ts" },
+      }).kind,
+    ).toBe("sdk");
+    expect(
+      classifySafPackage({
+        name: "@scope/app-spa",
+        dependencies: { "@saflib/sdk": "*", "@saflib/vue": "*" },
+        exports: { ".": "./main.ts" },
+      }).kind,
+    ).toBe("spa");
+  });
+
+  it("does not infer from missing identifier deps", () => {
+    expect(
+      classifySafPackage({
+        name: "@scope/lib",
+        dependencies: { "@saflib/git": "*" },
+      }).kind,
+    ).toBe("other");
+  });
+});

--- a/monorepo/src/package-kind.ts
+++ b/monorepo/src/package-kind.ts
@@ -1,0 +1,146 @@
+/**
+ * Product package kinds for inventory / layout.
+ *
+ * Prefer an explicit `package.json` `saf.kind`. Otherwise infer from a unique
+ * identifier dependency (`@saflib/drizzle` → db, and so on). Mixing drizzle /
+ * express / openapi in one package is a layout error — those layers should
+ * stay in separate packages.
+ */
+
+export const PACKAGE_KINDS = [
+  "db",
+  "http",
+  "spec",
+  "spa",
+  "sdk",
+  "lib",
+  "integration",
+  "other",
+] as const;
+
+export type PackageKind = (typeof PACKAGE_KINDS)[number];
+
+/** Identifier packages that imply a product layer. The packages themselves are `lib`. */
+export const PACKAGE_KIND_IDENTIFIERS = {
+  "@saflib/drizzle": "db",
+  "@saflib/express": "http",
+  "@saflib/openapi": "spec",
+  "@saflib/sdk": "sdk",
+  "@saflib/vue": "spa",
+} as const satisfies Record<string, PackageKind>;
+
+const LAYER_IDENTIFIERS = new Set<string>([
+  "@saflib/drizzle",
+  "@saflib/express",
+  "@saflib/openapi",
+]);
+
+export interface SafPackageJson {
+  name?: string;
+  saf?: { kind?: unknown };
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+  exports?: unknown;
+}
+
+export interface PackageKindClassification {
+  kind: PackageKind;
+  /**
+   * Layer identifier packages (`drizzle` / `express` / `openapi`) this package
+   * depends on when more than one is present.
+   */
+  mixedIdentifiers: string[];
+}
+
+export function isPackageKind(value: unknown): value is PackageKind {
+  return (
+    typeof value === "string" &&
+    (PACKAGE_KINDS as readonly string[]).includes(value)
+  );
+}
+
+export function parseSafPackageJson(text: string): SafPackageJson | undefined {
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      return undefined;
+    }
+    return parsed as SafPackageJson;
+  } catch {
+    return undefined;
+  }
+}
+
+function runtimeDeps(pkg: SafPackageJson): string[] {
+  return [
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.optionalDependencies ?? {}),
+  ];
+}
+
+function declaredKind(pkg: SafPackageJson): PackageKind | undefined {
+  return isPackageKind(pkg.saf?.kind) ? pkg.saf.kind : undefined;
+}
+
+/** True when `package.json` `exports` includes a `./requests` subpath. */
+export function hasSdkRequestsExport(exportsMap: unknown): boolean {
+  if (!exportsMap || typeof exportsMap !== "object" || Array.isArray(exportsMap)) {
+    return false;
+  }
+  return Object.keys(exportsMap).some(
+    (key) => key === "./requests" || key.startsWith("./requests/"),
+  );
+}
+
+/**
+ * Classify a package from `saf.kind` and/or identifier dependencies.
+ * Does not read the filesystem.
+ */
+export function classifySafPackage(
+  pkg: SafPackageJson,
+): PackageKindClassification {
+  const declared = declaredKind(pkg);
+  if (pkg.name && pkg.name in PACKAGE_KIND_IDENTIFIERS) {
+    return { kind: declared ?? "lib", mixedIdentifiers: [] };
+  }
+
+  const deps = runtimeDeps(pkg);
+  const layerHits = [
+    ...new Set(deps.filter((name) => LAYER_IDENTIFIERS.has(name))),
+  ].sort();
+  const clientHits = [
+    ...new Set(
+      deps.filter(
+        (name) => name === "@saflib/sdk" || name === "@saflib/vue",
+      ),
+    ),
+  ];
+  const mixedIdentifiers = layerHits.length > 1 ? layerHits : [];
+
+  if (declared) {
+    return { kind: declared, mixedIdentifiers };
+  }
+
+  if (layerHits.length === 1) {
+    const id = layerHits[0]!;
+    return {
+      kind: PACKAGE_KIND_IDENTIFIERS[id as keyof typeof PACKAGE_KIND_IDENTIFIERS],
+      mixedIdentifiers,
+    };
+  }
+  if (layerHits.length > 1) {
+    return { kind: "other", mixedIdentifiers };
+  }
+
+  const hasSdk = clientHits.includes("@saflib/sdk");
+  const hasVue = clientHits.includes("@saflib/vue");
+  if (hasSdk && hasVue) {
+    return {
+      kind: hasSdkRequestsExport(pkg.exports) ? "sdk" : "spa",
+      mixedIdentifiers,
+    };
+  }
+  if (hasSdk) return { kind: "sdk", mixedIdentifiers };
+  if (hasVue) return { kind: "spa", mixedIdentifiers };
+  return { kind: "other", mixedIdentifiers };
+}

--- a/monorepo/src/package-layout.test.ts
+++ b/monorepo/src/package-layout.test.ts
@@ -43,6 +43,31 @@ describe("isAllowedRootTsFile", () => {
 });
 
 describe("checkPackageLayoutFromInputs", () => {
+  it("flags mixed drizzle/express/openapi identifier deps", () => {
+    const issues = checkPackageLayoutFromInputs({
+      packageJson: {
+        name: "@scope/mixed",
+        dependencies: {
+          "@saflib/drizzle": "*",
+          "@saflib/express": "*",
+        },
+      },
+    });
+    expect(issues.map((i) => i.kindLabel)).toEqual(["kind"]);
+    expect(issues[0]?.name).toContain("@saflib/drizzle");
+    expect(issues[0]?.name).toContain("@saflib/express");
+  });
+
+  it("does not flag a unique identifier dep", () => {
+    const issues = checkPackageLayoutFromInputs({
+      packageJson: {
+        name: "@scope/db",
+        dependencies: { "@saflib/drizzle": "*" },
+      },
+    });
+    expect(issues.filter((i) => i.kindLabel === "kind")).toEqual([]);
+  });
+
   it("does not flag SPA root boot/config files", () => {
     const issues = checkPackageLayoutFromInputs({
       packageJson: {

--- a/monorepo/src/package-layout.ts
+++ b/monorepo/src/package-layout.ts
@@ -42,7 +42,7 @@ export interface CheckPackageLayoutFromInputsOptions {
   packageRepoPath?: string;
   /** Filenames of .ts/.tsx at package root (not nested). */
   rootTsFiles?: string[];
-  /** Prod source files with line counts (package-local paths). */
+  /** Prod source files with line counts (package-local paths; `.ts`/`.tsx`/`.yaml`/`.yml`). */
   sourceFiles?: Array<{ localPath: string; lineCount: number }>;
   maxSourceLines?: number;
 }
@@ -192,7 +192,10 @@ function walkSourceFiles(dir: string, out: string[]) {
       walkSourceFiles(full, out);
     } else if (
       e.isFile() &&
-      (e.name.endsWith(".ts") || e.name.endsWith(".tsx")) &&
+      (e.name.endsWith(".ts") ||
+        e.name.endsWith(".tsx") ||
+        e.name.endsWith(".yaml") ||
+        e.name.endsWith(".yml")) &&
       !e.name.endsWith(".d.ts") &&
       !isTestOrFixtureFileName(e.name)
     ) {

--- a/monorepo/src/package-layout.ts
+++ b/monorepo/src/package-layout.ts
@@ -3,6 +3,10 @@
  */
 import fs from "node:fs";
 import path from "node:path";
+import {
+  classifySafPackage,
+  type SafPackageJson,
+} from "./package-kind.ts";
 
 export const DEFAULT_MAX_SOURCE_LINES = 800;
 
@@ -27,7 +31,7 @@ export interface CheckPackageLayoutOptions {
 }
 
 /** In-memory package.json fields used by layout checks. */
-export interface PackageJsonLayoutFields {
+export interface PackageJsonLayoutFields extends SafPackageJson {
   bin?: Record<string, string> | string;
   scripts?: Record<string, string>;
   /** Subpath exports map (`"./foo": "./foo.ts"`). */
@@ -228,6 +232,18 @@ export function checkPackageLayoutFromInputs(
 
   const pj = options.packageJson;
   const basename = options.packageDirBasename ?? "package";
+
+  const mixed = classifySafPackage(pj).mixedIdentifiers;
+  if (mixed.length > 0) {
+    issues.push({
+      kind: "package-layout",
+      title: "Package layout",
+      name: `depends on multiple layer identifiers (${mixed.join(", ")}) — a package should be one of db, http, or spec`,
+      kindLabel: "kind",
+      filePath: "package.json",
+      repoPath: repoPathFor("package.json"),
+    });
+  }
 
   const bins: Record<string, string> =
     typeof pj.bin === "string" ? { [basename]: pj.bin } : (pj.bin ?? {});

--- a/monorepo/src/workspace-types.ts
+++ b/monorepo/src/workspace-types.ts
@@ -17,6 +17,8 @@ export interface PackageJson {
   overrides?: Record<string, string>;
   engines?: Record<string, string>;
   description?: string;
+  /** SAF package metadata (`kind` is db / http / spec / sdk / spa / lib / …). */
+  saf?: { kind?: string };
   scripts?: Record<string, string>;
   bin?: Record<string, string>;
   exports?: Record<string, string>;

--- a/monorepo/workflows/templates/package.json
+++ b/monorepo/workflows/templates/package.json
@@ -1,5 +1,8 @@
 {
   "name": "template-package",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "TODO: Add package description",
   "private": true,
   "type": "module",

--- a/node/package.json
+++ b/node/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/node",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Reusable Node.js utilities",
   "private": true,
   "type": "module",

--- a/notify/notify/package.json
+++ b/notify/notify/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/notify",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "In-process change-event pub/sub and SSE stream helpers",
   "private": true,
   "type": "module",

--- a/object-store/package.json
+++ b/object-store/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/object-store",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Object store library for file storage operations",
   "private": true,
   "type": "module",

--- a/openapi/package.json
+++ b/openapi/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/openapi",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Shared dependencies for generating OpenAPI specs in SAF projects",
   "type": "module",
   "main": "./index.ts",

--- a/openapi/workflows/templates/package.json
+++ b/openapi/workflows/templates/package.json
@@ -1,5 +1,8 @@
 {
   "name": "template-package-spec",
+  "saf": {
+    "kind": "spec"
+  },
   "description": "API specs for the __service-name__ service",
   "type": "module",
   "exports": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/saflib",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Full-featured web application framework using my preferred libraries and services.",
   "type": "module",
   "scripts": {

--- a/parser/package.json
+++ b/parser/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/parser",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Syntactic TypeScript helpers — extractExports / extractTestCases / extractDrizzleTables (no type-checker)",
   "private": true,
   "type": "module",

--- a/playwright/package.json
+++ b/playwright/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/playwright",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Playwright testing utilities for SAF applications",
   "private": true,
   "type": "module",

--- a/posthog-client/package.json
+++ b/posthog-client/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/posthog-client",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Posthog for web clients",
   "private": true,
   "type": "module",

--- a/processes/package.json
+++ b/processes/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/processes",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Templates and workflows for building and maintaining SAF projects",
   "type": "module",
   "exports": {

--- a/product/package.json
+++ b/product/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/product",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Package for product workflows",
   "private": true,
   "type": "module",

--- a/sdk/package.json
+++ b/sdk/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/sdk",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "For creating service-specific SDK packages",
   "type": "module",
   "exports": {

--- a/sdk/workflows/templates/package.json
+++ b/sdk/workflows/templates/package.json
@@ -1,5 +1,8 @@
 {
   "name": "template-package-sdk",
+  "saf": {
+    "kind": "sdk"
+  },
   "description": "Tanstack queries and shared components for __service-name__ service",
   "private": true,
   "type": "module",

--- a/secret-store/package.json
+++ b/secret-store/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/secret-store",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Secret store library for env-backed and Infisical-backed secret resolution",
   "private": true,
   "type": "module",

--- a/sentry/package.json
+++ b/sentry/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/sentry",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Sentry for Node.js services and Vite client builds",
   "private": true,
   "type": "module",

--- a/service/package.json
+++ b/service/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/service",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Workflows and utilities for bootstrapping and initializing services",
   "private": true,
   "type": "module",

--- a/utils/package.json
+++ b/utils/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/utils",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Utility functions for SAF monorepo",
   "private": true,
   "type": "module",

--- a/vitest/package.json
+++ b/vitest/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/vitest",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Library common testing dependencies and helpers",
   "type": "module",
   "exports": {

--- a/vue/package.json
+++ b/vue/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/vue",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "All-in-one set of helper methods and documents for creating Vue SPAs for SAF applications",
   "type": "module",
   "exports": {

--- a/vue/workflows/template/__subdomain-name__/package.json
+++ b/vue/workflows/template/__subdomain-name__/package.json
@@ -1,5 +1,8 @@
 {
   "name": "template-package-spa",
+  "saf": {
+    "kind": "spa"
+  },
   "private": true,
   "type": "module",
   "exports": {

--- a/workflows-cli/package.json
+++ b/workflows-cli/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/workflows-cli",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Project-specific workflows using @saflib/workflows",
   "private": true,
   "type": "module",

--- a/workflows/package.json
+++ b/workflows/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/workflows",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Workflow engine and utilities for SAF",
   "private": true,
   "type": "module",

--- a/xstate/package.json
+++ b/xstate/package.json
@@ -1,5 +1,8 @@
 {
   "name": "@saflib/xstate",
+  "saf": {
+    "kind": "lib"
+  },
   "description": "Shared logic and workflows for XState",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Moving forward on making this tool to keep my mental model of the codebase in tune, I added a way to compare the current checkout against where it forked from another branch. This way I can see what is effectively a pull request, but at the high level while being able to jump into details. This is my experiment in figuring out how to review changes that are agentic sized (thousands, tends of thousands, maybe hundreds of thousands of lines changed).